### PR TITLE
Cleanup setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,7 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 """Setup for pip package."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
-from setuptools import Extension
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import Extension, find_packages, setup
 from setuptools.dist import Distribution
-
-
-__version__ = '0.0.1'
-REQUIRED_PACKAGES = [
-    'tensorflow >= 1.12.0',
-]
-project_name = 'larq-compute-engine'
 
 
 class BinaryDistribution(Distribution):
@@ -38,34 +12,39 @@ class BinaryDistribution(Distribution):
 
 
 setup(
-    name=project_name,
-    version=__version__,
-    description=('An Open Source Collection of Highly Tuned Implementations of Primitives Operations for Binarized Neural Networks'),
+    name="larq-compute-engine",
+    version="0.0.1",
+    python_requires=">=3.6",
+    description="An Open Source Collection of Highly Tuned Implementations of Primitives Operations for Binarized Neural Networks",
     author="Plumerai",
     author_email="arash@plumerai.com",
-    # Contained modules and scripts.
     packages=find_packages(),
-    install_requires=REQUIRED_PACKAGES,
-    # Add in any packaged data.
+    install_requires=[],
+    extras_require={
+        "tensorflow": ["tensorflow>=1.13.1"],
+        "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],
+    },
     include_package_data=True,
-    ext_modules=[Extension('_foo', ['stub.cc'])],
+    ext_modules=[Extension("_foo", ["stub.cc"])],
     zip_safe=False,
     distclass=BinaryDistribution,
-    # PyPI package information.
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Software Development :: Libraries',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    license='Apache 2.0',
-    keywords='binarized neural networks',
+    license="Apache 2.0",
+    keywords="binarized neural networks",
 )


### PR DESCRIPTION
TensorFlow shouldn't be a direct dependency since we need the flexibility to install either `tensorflow-gpu` or `tensorflow`.