### PR TITLE
Add basic python benchmark of sign op

### DIFF
--- a/larq_compute_engine/python/benchmarks/benchmark.py
+++ b/larq_compute_engine/python/benchmarks/benchmark.py
@@ -7,10 +7,11 @@ import json
 import logging
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 
 class Benchmark:
-    """Benchmark configuration for a tensorflow operation.
+    """Benchmark for a tensorflow operation.
 
     Use `run_benchmark()` to run the benchmark on all datatypes and input sizes. This will internally store a list of results.
     Use `save_results(filename, append)` to store the results to a JSON file. If append is true, it will assume the file already contains other benchmark results and append the new results.
@@ -20,8 +21,10 @@ class Benchmark:
     # Arguments
     op: The operator to test, for example `tf.sign`.
     dtypes: List of data types that should be tested. By default it will test all datatypes and automatically ignore the types that are not supported by the operator.
-    max_inputsize: Maximum size of input tensor that should be given to the operator.
+    data_shape: When set to a tuple `(d1,...,dk)` then the inputs to the operator will be of shapes `(s,d1,...,dk)` where s varies from `0` to `max_inputsize`.  If set to `None` (default) then the input tensor will always be flat, of shape (s).
+    max_inputsize: Maximum size of input tensor. When input tensor has shape `(s,d1,...,dk)` then `s` will be limited such that `s * d1 * ... * dk <= max_inputsize`.
     inputsize_steps: The benchmark will try this many sizes from 0 up to max_inputsize.
+    repeat: The number of times to repeat each individual measurement for accuracy. The average will be stored.
 
     !!! example
         ```python
@@ -29,46 +32,62 @@ class Benchmark:
         sign_benchmark.run_benchmark()
         sign_benchmark.save_results("benchmark_results_sign.json", append = True)
         ```
+    !!! note
+        For every data type that is tested, the JSON file contains an entry of which `entry['timings']` gives an array of pairs `(size, time)` where `size` is the total number of elements in the input tensor and `time` is the time in seconds that the benchmark took.
     """
 
-    # TODO: Add option for different shapes
-    # because input shapes affect the results, even for simple
-    # operations like component-wise sign.
     def __init__(
         self,
         op,
-        dtypes=[np.int8, np.int32, np.int64, np.float32, np.float64, np.complex],
-        max_inputsize=1000000,
+        dtypes=[np.int8, np.int32, np.int64, np.float32, np.float64],
+        data_shape=None,
+        max_inputsize=4 * 1024 * 1024,
         inputsize_steps=10,
+        repeat=4,
     ):
         self.op = op
         self.dtypes = dtypes
         self.max_inputsize = max_inputsize
-        self.size_steps = inputsize_steps
+        self.repeat = repeat
         self.results = []
+        if data_shape is None:
+            self.shape_string = "(-1)"
+            max_s = max_inputsize
+            s_range = range(0, max_s + 1, int(max_s / inputsize_steps))
+            self.test_shapes = [(s,) for s in s_range]
+        else:
+            self.shape_string = str((-1,) + data_shape)
+            max_s = max_inputsize // np.prod(data_shape)
+            if max_s < 1:
+                raise ValueError(
+                    "max_inputsize {} is smaller than data_shape {}".format(
+                        max_inputsize, data_shape
+                    )
+                )
+            s_range = range(0, max_s + 1, int(np.ceil(max_s / inputsize_steps)))
+            self.test_shapes = [(s,) + data_shape for s in s_range]
 
     def run_benchmark(self):
-        test_sizes = range(
-            0, self.max_inputsize + 1, self.max_inputsize // self.size_steps
-        )
-
         self.results = []
         for dtype in self.dtypes:
             log.info("Benchmarking {} - {}".format(self.op.__name__, dtype.__name__))
             try:
                 timeresults = []
-                for s in test_sizes:
-                    shape = s
-                    result = self._single_run(shape, dtype)
-                    timeresults += [(s, result)]
-                self.results += [
+                for shape in self.test_shapes:
+                    result = 0
+                    for _ in range(self.repeat):
+                        result += self._single_run(shape, dtype)
+                    result /= self.repeat
+                    timeresults += [(int(np.prod(shape)), result)]
+                self.results.append(
                     {
                         "datetime": str(datetime.datetime.now()),
                         "operation": self.op.__name__,
                         "data_type": dtype.__name__,
+                        "data_shape": self.shape_string,
                         "timings": timeresults,
                     }
-                ]
+                )
             except TypeError:
                 log.info(
                     "Operator {} does not support {}.".format(
@@ -79,7 +98,6 @@ class Benchmark:
     def _single_run(self, inputshape, dtype):
         """Runs the op once and returns the elapsed time in seconds.
         """
-        # Construct a random input tensor
         x = np.random.random_integers(-10, 10, size=inputshape).astype(dtype)
         # Construct the tensorflow graph
         # TODO: It might make sense to put the operation inbetween some often-used layers
@@ -100,6 +118,6 @@ class Benchmark:
             with open(filename, "r") as filehandle:
                 results = json.load(filehandle)
 
-        results.append(self.results)
+        results.extend(self.results)
         with open(filename, "w") as filehandle:
             json.dump(results, filehandle)

--- a/larq_compute_engine/python/benchmarks/benchmarks_sign.py
+++ b/larq_compute_engine/python/benchmarks/benchmarks_sign.py
@@ -2,18 +2,24 @@ import tensorflow as tf
 import larq_compute_engine as lqce
 from benchmark import Benchmark
 
+bsign_bench_flat = Benchmark(lqce.bsign, data_shape=None)
+bsign_bench = Benchmark(lqce.bsign, data_shape=(128, 128, 32))
+tfsign_bench_flat = Benchmark(tf.sign, data_shape=None)
+tfsign_bench = Benchmark(tf.sign, data_shape=(128, 128, 32))
 
-bsign_bench = Benchmark(lqce.bsign)
-tfsign_bench = Benchmark(tf.sign)
-
+bsign_bench_flat.run_benchmark()
 bsign_bench.run_benchmark()
+tfsign_bench_flat.run_benchmark()
 tfsign_bench.run_benchmark()
+
 
 filename = "benchmark_results/benchmark_results_sign.json"
 
 print("Saving results to {}".format(filename))
 
-bsign_bench.save_results(filename, append=False)
+bsign_bench_flat.save_results(filename, append=False)
+bsign_bench.save_results(filename, append=True)
+tfsign_bench_flat.save_results(filename, append=True)
 tfsign_bench.save_results(filename, append=True)
 
 print("Use plot_benchmarks.ipynb to view the results.")

--- a/larq_compute_engine/python/benchmarks/plot_benchmarks.ipynb
+++ b/larq_compute_engine/python/benchmarks/plot_benchmarks.ipynb
@@ -27,7 +27,13 @@
    "outputs": [],
    "source": [
     "filehandle = open(\"../../../benchmark_results/benchmark_results_sign.json\", \"r\")\n",
-    "results = json.load(filehandle)"
+    "results = json.load(filehandle)\n",
+    "available_ops = set([x[\"operation\"] for x in results])\n",
+    "available_types = set([x[\"data_type\"] for x in results])\n",
+    "available_shapes = set([x[\"data_shape\"] for x in results])\n",
+    "print(\"Available operations in file: {}\".format(available_ops))\n",
+    "print(\"Available data types in file: {}\".format(available_types))\n",
+    "print(\"Available tensor shapes in file: {}\".format(available_shapes))"
    ]
   },
   {
@@ -36,8 +42,14 @@
    "source": [
     "# Choose what to plot\n",
     "\n",
-    "For example only plot certain datatypes.\n",
-    "For more detailed selection: the first index of the `results` object will indicate which operator it is and the second index indicates which datatype."
+    "Evaluate one of the cells below to choose a set of results to plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare data types"
    ]
   },
   {
@@ -46,8 +58,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot all datatypes\n",
-    "plot_datatypes = [\"int8\", \"int32\", \"int64\", \"float32\", \"float64\"]"
+    "plot_operations = [\"bsign\"]\n",
+    "plot_datatypes = available_types\n",
+    "plot_shapes = [\"(-1)\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare shapes"
    ]
   },
   {
@@ -56,8 +76,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot only int32 and float32\n",
-    "plot_datatypes = [\"int32\", \"float32\"]"
+    "plot_operations = [\"bsign\"]\n",
+    "plot_datatypes = [\"float32\"]\n",
+    "plot_shapes = available_shapes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_operations = available_ops\n",
+    "plot_datatypes = [\"float32\"]\n",
+    "plot_shapes = [\"(-1)\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare everything that is available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_operations = available_ops\n",
+    "plot_datatypes = available_types\n",
+    "plot_shapes = available_shapes"
    ]
   },
   {
@@ -80,14 +137,17 @@
     "def getY(xys):\n",
     "    return [xy[1] for xy in xys]\n",
     "\n",
-    "for op_result in results:\n",
-    "    for result in op_result:\n",
-    "        if not result[\"data_type\"] in plot_datatypes:\n",
-    "            continue\n",
-    "        ax.plot(getX(result[\"timings\"]), getY(result[\"timings\"]), label=result[\"operation\"] + \" - \" + result[\"data_type\"])\n",
+    "for result in results:\n",
+    "    if not result[\"operation\"] in plot_operations:\n",
+    "        continue\n",
+    "    if not result[\"data_type\"] in plot_datatypes:\n",
+    "        continue\n",
+    "    if not result[\"data_shape\"] in plot_shapes:\n",
+    "        continue\n",
+    "    ax.plot(getX(result[\"timings\"]), getY(result[\"timings\"]), \".-\", label=result[\"operation\"] + \" | \" + result[\"data_type\"] + \" | \" + result[\"data_shape\"])\n",
     "\n",
     "ax.legend()\n",
-    "ax.set(xlabel='input size (millions)', ylabel='time (seconds)',\n",
+    "ax.set(xlabel='input size (millions of elements)', ylabel='time (seconds)',\n",
     "       title='Tensorflow kernel speed')\n",
     "ax.grid()\n",
     "\n",


### PR DESCRIPTION
A simple benchmark that compares `lqce.bsign` with `tf.sign` on different datatypes.
Partially resolves #22 