### PR TITLE
fix the bazel python tests

### DIFF
--- a/larq_compute_engine/python/ops/compute_engine_ops.py
+++ b/larq_compute_engine/python/ops/compute_engine_ops.py
@@ -1,20 +1,11 @@
 """Use larq compute engine ops in python."""
 
-import tensorflow as tf
-import os
+from tensorflow.python.framework import load_library
+from tensorflow.python.platform import resource_loader
 
+_ops_lib = load_library.load_op_library(
+    resource_loader.get_path_to_datafile("_larq_compute_engine_ops.so")
+)
 
-def get_path_to_datafile(path):
-    """Get the path to the specified file in the data dependencies.
-    Args:
-    path: a string resource path relative to the current file
-    Returns:
-    The path to the specified data file
-    """
-    root_dir = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(root_dir, path)
-
-
-_ops_lib = tf.load_op_library(get_path_to_datafile("_larq_compute_engine_ops.so"))
 bgemm = _ops_lib.bgemm
 bsign = _ops_lib.bsign

--- a/larq_compute_engine/python/ops/compute_engine_ops_test.py
+++ b/larq_compute_engine/python/ops/compute_engine_ops_test.py
@@ -2,7 +2,11 @@
 import numpy as np
 import tensorflow as tf
 
-import larq_compute_engine as lqce
+
+try:
+    from larq_compute_engine.python.ops.compute_engine_ops import bgemm, bsign
+except ImportError:
+    from compute_engine_ops import bgemm, bsign
 
 
 class BGEMMTest(tf.test.TestCase):
@@ -12,7 +16,7 @@ class BGEMMTest(tf.test.TestCase):
             input_b = np.array([[1, 1], [1, 1]]).astype(np.int32)
             expected_output = np.array([[0, 0], [0, 0]])
 
-            self.assertAllClose(lqce.bgemm(input_a, input_b).eval(), expected_output)
+            self.assertAllClose(bgemm(input_a, input_b).eval(), expected_output)
 
 
 class SignTest(tf.test.TestCase):
@@ -20,7 +24,7 @@ class SignTest(tf.test.TestCase):
         with self.test_session():
             x = np.array([[2, -5], [-3, 0]]).astype(dtype)
             expected_output = np.array([[1, -1], [-1, 1]])
-            self.assertAllClose(lqce.bsign(x).eval(), expected_output)
+            self.assertAllClose(bsign(x).eval(), expected_output)
 
     # Test for +0 and -0 floating points.
     # We have sign(+0) = 1 and sign(-0) = -1
@@ -28,7 +32,7 @@ class SignTest(tf.test.TestCase):
         with self.test_session():
             x = np.array([[0.1, -5.8], [-3.0, 0.00], [0.0, -0.0]]).astype(dtype)
             expected_output = np.array([[1, -1], [-1, 1], [1, -1]])
-            self.assertAllClose(lqce.bsign(x).eval(), expected_output)
+            self.assertAllClose(bsign(x).eval(), expected_output)
 
     def test_sign_int8(self):
         self.run_test_for_integers(np.int8)
@@ -44,3 +48,7 @@ class SignTest(tf.test.TestCase):
 
     def test_sign_float64(self):
         self.run_test_for_floating(np.float64)
+
+
+if __name__ == "__main__":
+    tf.test.main()


### PR DESCRIPTION
the only way I could get the bazel run the tests was reverting the way the .so library is loaded to the way originally was implemented in "custom-op" repo. 