### PR TITLE
Simplify tflite build

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -54,27 +54,19 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Configure Bazel
+      - name: "TFLite: Download dependencies and build"
+        run: larq_compute_engine/tflite/build/build_lqce.sh --fullbuild
+      - name: "TFLite: Install Python wrapper"
+        run: pip3 install /tmp/tflite_pip/python3/dist/*.whl
+      - name: "TFLite test dependency: Configure Bazel"
         run: ./configure.sh <<< $'yes\nyes\n' #yes,yes for tf2
         shell: bash
-      - name: Build Bazel Package Creator Binary
+      - name: "TFLite test dependency: Build Bazel Package Creator Binary"
         run: bazel build :build_pip_pkg
-      - name: Build PIP Package
+      - name: "TFLite test dependency: Build PIP Package"
         run: bazel-bin/build_pip_pkg artifacts
-      - name: Install PIP Package
-        run: pip3 install artifacts/*.whl
-      - name: "TFLite: Download dependencies"
-        run: ext/tensorflow/tensorflow/lite/tools/make/download_dependencies.sh
-      - name: "TFLite: Build C++ library"
-        run: |
-          ext/tensorflow/tensorflow/lite/tools/make/build_lib.sh
-          larq_compute_engine/tflite/build/build_lqce.sh
-      - name: "TFLite: Install PIP dependencies"
-        run: pip3 install larq pytest
-      - name: "TFLite: Build and install Python wrapper"
-        run: |
-          ext/tensorflow/tensorflow/lite/tools/pip_package/build_pip_package.sh
-          pip3 install /tmp/tflite_pip/python3/dist/*.whl
+      - name: "TFLite test dependency: Install PIP Package"
+        run: pip3 install larq pytest artifacts/*.whl
       - name: "TFLite: Run Python Tests"
         run: |
           # Go to a different directory to force it to use the installed package

--- a/larq_compute_engine/tflite/build/build_lqce.sh
+++ b/larq_compute_engine/tflite/build/build_lqce.sh
@@ -15,12 +15,31 @@ elif [ "$UNAME" = "Darwin" ] ; then
 fi
 HOST_ARCH="$(if uname -m | grep -q i[345678]86; then echo x86_32; else uname -m; fi)"
 
-if [ -f "${TF_DIR}/tensorflow/lite/tools/make/gen/${HOST_OS}_${HOST_ARCH}/lib/libtensorflow-lite.a" ]; then
-    make -j 8 BUILD_WITH_NNAPI=false -C "${ROOT_DIR}" -f larq_compute_engine/tflite/build/Makefile
-    # Also re-make the tf-lite examples so that they use the modified library
+# Use --fullbuild to also download dependencies and build the package
+# It will not download dependencies if the downloads directory already exists
+# It will not rebuild the library if all files are already up to date
+# It will, however, always rebuild the pip package
+if [ "$1" == "--fullbuild" ]; then
+    # Check if dependencies need to be downloaded
+    if [ ! -d "${TF_DIR}/tensorflow/lite/tools/make/downloads" ]; then
+        ext/tensorflow/tensorflow/lite/tools/make/download_dependencies.sh
+    fi
+    # Build tflite (will automatically skip when up-to-date
     ${TF_DIR}/tensorflow/lite/tools/make/build_lib.sh
+    # Build our kernels
+    make -j 8 BUILD_WITH_NNAPI=false -C "${ROOT_DIR}" -f larq_compute_engine/tflite/build/Makefile
+    # Rebuild tflite binaries such as benchmarking libs to include our ops
+    ${TF_DIR}/tensorflow/lite/tools/make/build_lib.sh
+    # Build the pip package
+    ext/tensorflow/tensorflow/lite/tools/pip_package/build_pip_package.sh
 else
-    echo "${HOST_OS}_${HOST_ARCH} target not found. Please build tensorflow lite first using build_lib.sh"
+    if [ -f "${TF_DIR}/tensorflow/lite/tools/make/gen/${HOST_OS}_${HOST_ARCH}/lib/libtensorflow-lite.a" ]; then
+        make -j 8 BUILD_WITH_NNAPI=false -C "${ROOT_DIR}" -f larq_compute_engine/tflite/build/Makefile
+        # Also re-make the tf-lite examples so that they use the modified library
+        ${TF_DIR}/tensorflow/lite/tools/make/build_lib.sh
+    else
+        echo "${HOST_OS}_${HOST_ARCH} target not found. Please build tensorflow lite first using build_lib.sh"
+    fi
 fi
 
 # Check if we need to cross-compile to raspberry pi


### PR DESCRIPTION
Closes Issue #74.

Arash suggested (see #74) we make a bazel target that will build tflite so that we can do everything through bazel.

I tried to do this, and it turns out to work like this: we have the following bazel rule
```
sh_binary (
    name = "build_pip_pkg",
    srcs = "build_pip_pkg.sh",
    data = [ ... , larq_compute_engine_core_stuff ],
)
```
But if you now run `bazel build :build_pip_pkg` then it does *not* actually run that shell script. What it does is make sure the dependencies are ready, so in this case it builds the compute engine, and then it just copies the shell script into the `bazel-bin` directory.
That is why, after we call `bazel build :build_pip_pkg` we still have to run `bazel-bin/build_pip_pkg` separately.

So for tflite, if I make a similar entry, it would just copy the shell script but nothing else, so it would only add *more* commands.

Therefore I simplified it in another way. Now when you pass `--fullbuild` to the `build_lqce.sh` script, it will do everything: download dependencies, build tflite, build our kernels, build the pip package, etc.

So to summarize, previously we did
```bash
ext/tensorflow/tensorflow/lite/tools/make/download_dependencies.sh
ext/tensorflow/tensorflow/lite/tools/make/build_lib.sh
larq_compute_engine/tflite/build/build_lqce.sh
ext/tensorflow/tensorflow/lite/tools/pip_package/build_pip_package.sh
pip install  ..../tflite_runtime_xxx.whl
```
Now we do:
```bash
larq_compute_engine/tflite/build/build_lqce.sh --fullbuild
pip install  ..../tflite_runtime_xxx.whl
```
If we were to add this to bazel it would become something like
```bash
bazel build //larq_compute_engine/tflite:build_lqce   #this copies the script
bazel-bin/build_lqce --fullbuild
pip install ..../tflite_runtime_xxx.whl
```