### PR TITLE
Add dilation support to zero padding functor

### DIFF
--- a/larq_compute_engine/python/ops/bconv2d_ops_test.py
+++ b/larq_compute_engine/python/ops/bconv2d_ops_test.py
@@ -20,12 +20,13 @@ except ImportError:
 @pytest.mark.parametrize("bconv_op", [bconv2d8, bconv2d32, bconv2d64])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("data_format", ["NHWC"])
-@pytest.mark.parametrize("in_size", [[10, 10], [11, 11], [10, 11]])
-@pytest.mark.parametrize("filter_size", [[3, 3], [4, 5]])
-@pytest.mark.parametrize("in_channel", [1, 31, 32, 33, 64])
+@pytest.mark.parametrize("in_size", [[10, 10], [10, 11]])
+@pytest.mark.parametrize("filter_size", [[3, 3], [2, 3]])
+@pytest.mark.parametrize("in_channel", [31, 32, 33])
 @pytest.mark.parametrize("out_channel", [1, 16])
-@pytest.mark.parametrize("hw_stride", [[1, 1], [2, 2]])
+@pytest.mark.parametrize("strides", [[1, 1], [2, 3]])
 @pytest.mark.parametrize("padding", ["VALID", "SAME"])
+@pytest.mark.parametrize("dilations", [[1, 1]])  # Once we support dilations: [2, 3]
 def test_bconv(
     bconv_op,
     dtype,
@@ -34,15 +35,17 @@ def test_bconv(
     filter_size,
     in_channel,
     out_channel,
-    hw_stride,
+    strides,
     padding,
+    dilations,
 ):
     batch_size = out_channel
     h, w = in_size
     fh, fw = filter_size
     if data_format == "NHWC":
         ishape = [batch_size, h, w, in_channel]
-        strides = [1] + hw_stride + [1]
+        strides = [1] + strides + [1]
+        dilations = [1] + dilations + [1]
     else:
         raise ValueError("Unknown data_format: " + str(data_format))
     fshape = [fh, fw, in_channel, out_channel]
@@ -54,9 +57,15 @@ def test_bconv(
     filt = np.random.choice(sample_list, np.prod(fshape)).astype(dtype)
     filt = np.reshape(filt, fshape)
 
-    output = eval_op(bconv_op(inp, filt, strides, padding, data_format=data_format))
+    output = eval_op(
+        bconv_op(
+            inp, filt, strides, padding, dilations=dilations, data_format=data_format
+        )
+    )
     expected = eval_op(
-        tf.nn.conv2d(inp, filt, strides, padding, data_format=data_format)
+        tf.nn.conv2d(
+            inp, filt, strides, padding, dilations=dilations, data_format=data_format
+        )
     )
     np.testing.assert_allclose(output, expected)
 

--- a/larq_compute_engine/tflite/cc/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/cc/kernels/bconv2d.cc
@@ -268,8 +268,8 @@ void EvalRef(TfLiteContext* context, TfLiteNode* node,
     padding_functor(params->batch, params->input_height, params->input_width,
                     params->channels_in, filter->data.f, params->filter_height,
                     params->filter_width, params->channels_out, stride_height,
-                    stride_width, output->data.f, params->out_height,
-                    params->out_width);
+                    stride_width, params->dilations[1], params->dilations[2],
+                    output->data.f, params->out_height, params->out_width);
   }
 }
 

--- a/larq_compute_engine/tflite/cc/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/cc/kernels/bconv2d_impl.h
@@ -195,7 +195,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
       gemmlowp::ScopedProfilingLabel label3("ZeroPaddingCorrection");
       padding_functor(batches, input_height, input_width, input_depth,
                       filter_data, filter_height, filter_width, output_depth,
-                      stride_height, stride_width, output_data, output_height,
+                      stride_height, stride_width, dilation_height_factor,
+                      dilation_width_factor, output_data, output_height,
                       output_width);
     }
   }


### PR DESCRIPTION
Add dilation support to our zero-padding correction functor.
Closes #93 

The TF op doesn't support dilations because we use an im2col algorithm that doesn't support dilations. We got this im2col algorithm from a tensorflow source file [maybe this one or a similar one](https://github.com/rockchip-linux/tensorflow/blob/master/tensorflow/core/kernels/conv_ops_fused.cc) and this original also doesn't support dilations.
Since TF is not our main target right now, I simply throw an error when you try to use dilations in TF.

In TF lite the dilations work fine. However, in our TF lite unit test we now compare against `tf.nn.conv2d` (instead of `lqce.bconv2d`) because then we can test dilations.

Side note: since some unit tests became really slow, I made some parameter lists a bit smaller like the number of input channels.