### PR TITLE
add android build toolchains to LCE bazel configurations

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,5 +102,27 @@ http_archive(
 )  # https://github.com/bazelbuild/bazel-skylib/releases
 # END: Upstream TensorFlow dependencies
 
+# Apple and Swift rules.
+http_archive(
+    name = "build_bazel_rules_apple",
+    sha256 = "a045a436b642c70fb0c10ca84ff0fd2dcbd59cc89100d597a61e8374afafb366",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/0.18.0/rules_apple.0.18.0.tar.gz"],
+)  # https://github.com/bazelbuild/rules_apple/releases
+http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "18cd4df4e410b0439a4935f9ca035bd979993d42372ba79e7f2d4fafe9596ef0",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/0.12.1/rules_swift.0.12.1.tar.gz"],
+)  # https://github.com/bazelbuild/rules_swift/releases
+http_archive(
+    name = "build_bazel_apple_support",
+    sha256 = "122ebf7fe7d1c8e938af6aeaee0efe788a3a2449ece5a8d6a428cb18d6f88033",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/0.7.1/apple_support.0.7.1.tar.gz"],
+)  # https://github.com/bazelbuild/apple_support/releases
 load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")
 tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")
+
+# android bazel configurations
+load("@org_tensorflow//third_party/android:android_configure.bzl", "android_configure")
+android_configure(name="local_config_android")
+load("@local_config_android//:android.bzl", "android_workspace")
+android_workspace()

--- a/configure.sh
+++ b/configure.sh
@@ -193,4 +193,30 @@ test:v2 --action_env=TF2_BEHAVIOR=1
 build --config=v2
 test --config=v2
 
+# Android configs. Bazel needs to have --cpu and --fat_apk_cpu both set to the
+# target CPU to build transient dependencies correctly. See
+# https://docs.bazel.build/versions/master/user-manual.html#flag--fat_apk_cpu
+build:android --crosstool_top=//external:android/crosstool
+build:android --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:android_arm --config=android
+build:android_arm --cpu=armeabi-v7a
+build:android_arm --fat_apk_cpu=armeabi-v7a
+build:android_arm64 --config=android
+build:android_arm64 --cpu=arm64-v8a
+build:android_arm64 --fat_apk_cpu=arm64-v8a
+build:android_x86 --config=android
+build:android_x86 --cpu=x86
+build:android_x86 --fat_apk_cpu=x86
+build:android_x86_64 --config=android
+build:android_x86_64 --cpu=x86_64
+build:android_x86_64 --fat_apk_cpu=x86_64
+
+# TODO: The default android SDK/NDK paths are hardcoded here and the user needs
+# to change the paths according to the local configuration
+build --action_env ANDROID_NDK_HOME="/tmp/code/android/android-ndk-r19c"
+build --action_env ANDROID_NDK_API_LEVEL="21"
+build --action_env ANDROID_BUILD_TOOLS_VERSION="27.0.3"
+build --action_env ANDROID_SDK_API_LEVEL="28"
+build --action_env ANDROID_SDK_HOME="/tmp/code/android"
+
 EOM

--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -1,0 +1,29 @@
+load("@org_tensorflow//tensorflow/lite:build_def.bzl", "tflite_copts", "tflite_linkopts")
+
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+common_copts = ["-Wall"] + tflite_copts()
+
+cc_binary(
+    name = "lce_benchmark_model",
+    srcs = [
+        "lce_benchmark_main.cc",
+    ],
+    copts = common_copts,
+    linkopts = tflite_linkopts() + select({
+        "@org_tensorflow//tensorflow:android": [
+            "-pie",  # Android 5.0 and later supports only PIE
+            "-lm",  # some builtin ops, e.g., tanh, need -lm
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib",
+        "@org_tensorflow//tensorflow/lite/tools/benchmark:logging",
+    ],
+)

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -1,0 +1,38 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <iostream>
+
+#include "tensorflow/lite/tools/benchmark/benchmark_tflite_model.h"
+#include "tensorflow/lite/tools/benchmark/logging.h"
+
+namespace tflite {
+namespace benchmark {
+
+int Main(int argc, char** argv) {
+  TFLITE_LOG(INFO) << "STARTING!";
+  BenchmarkTfLiteModel benchmark;
+  BenchmarkLoggingListener listener;
+  benchmark.AddListener(&listener);
+  if (benchmark.Run(argc, argv) != kTfLiteOk) {
+    TFLITE_LOG(ERROR) << "Benchmarking failed.";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+}  // namespace benchmark
+}  // namespace tflite
+
+int main(int argc, char** argv) { return tflite::benchmark::Main(argc, argv); }


### PR DESCRIPTION
This PR adds support of bazel build configuration for android  and add a simple benchmarking binary (not including the custom ops yet) to build for android.  