### PR TITLE
add LCE benchmark binary with support of custom ops

### DIFF
--- a/larq_compute_engine/BUILD
+++ b/larq_compute_engine/BUILD
@@ -45,14 +45,20 @@ cc_test(
 # BUILDING PACKBITS
 cc_library(
     name = "packbits",
-    hdrs = select({
+    hdrs = ["cc/core/packbits.h"] + select({
         ":aarch64_build": [
             "cc/core/aarch64/packbits.h",
-            "cc/core/packbits.h",
         ],
-        "//conditions:default": [
-            "cc/core/packbits.h",
+        ":arm32_build": [
+            "cc/core/arm32/packbits.h",
         ],
+        "@org_tensorflow//tensorflow:android_arm": [
+            "cc/core/aarch64/packbits.h",
+        ],
+        "@org_tensorflow//tensorflow:android_arm64": [
+            "cc/core/aarch64/packbits.h",
+        ],
+        "//conditions:default": [],
     }),
     deps = [":utils"],
 )

--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -23,6 +23,7 @@ cc_binary(
         "//conditions:default": [],
     }),
     deps = [
+        "//larq_compute_engine/tflite/cc/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib",
         "@org_tensorflow//tensorflow/lite/tools/benchmark:logging",
     ],

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -15,8 +15,21 @@ limitations under the License.
 
 #include <iostream>
 
+#include "absl/base/attributes.h"
+#include "larq_compute_engine/tflite/cc/kernels/lce_ops_register.h"
 #include "tensorflow/lite/tools/benchmark/benchmark_tflite_model.h"
 #include "tensorflow/lite/tools/benchmark/logging.h"
+
+void ABSL_ATTRIBUTE_WEAK
+RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
+  resolver->AddCustom("LqceBsign", compute_engine::tflite::Register_BSIGN());
+  // resolver->// AddCustom("LqceBconv2d8",
+  // compute_engine::tflite::Register_BCONV_2D8());
+  resolver->AddCustom("LqceBconv2d32",
+                      compute_engine::tflite::Register_BCONV_2D32());
+  resolver->AddCustom("LqceBconv2d64",
+                      compute_engine::tflite::Register_BCONV_2D64());
+}
 
 namespace tflite {
 namespace benchmark {

--- a/larq_compute_engine/tflite/cc/kernels/BUILD
+++ b/larq_compute_engine/tflite/cc/kernels/BUILD
@@ -97,9 +97,9 @@ cc_library(
         "sign.cc",
         "bconv2d.cc",
     ],
-    hdrs = ["utils.h"],
+    hdrs = ["utils.h", "lce_ops_register.h"],
     copts = tflite_copts() + tf_opts_nortti_if_android(),
-    visibility = ["//visibility:private"],
+    # visibility = ["//visibility:private"],
     deps = [
         ":bconv2d_impl",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/larq_compute_engine/tflite/cc/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/cc/kernels/lce_ops_register.h
@@ -1,0 +1,20 @@
+#ifndef COMPUTE_EGNINE_TFLITE_KERNELS_LCE_REGISTER_H_
+#define COMPUTE_EGNINE_TFLITE_KERNELS_LCE_REGISTER_H_
+
+#include "tensorflow/lite/context.h"
+
+// This file contains forward declaration of all custom ops
+// implemented in LCE which can be used to link against LCE library.
+
+namespace compute_engine {
+namespace tflite {
+
+TfLiteRegistration* Register_BSIGN();
+// TfLiteRegistration* Register_BCONV_2D8();
+TfLiteRegistration* Register_BCONV_2D32();
+TfLiteRegistration* Register_BCONV_2D64();
+
+}  // namespace tflite
+}  // namespace compute_engine
+
+#endif  // TENSORFLOW_LITE_KERNELS_REGISTER_H_

--- a/larq_compute_engine/tflite/cc/kernels/lce_register.cc
+++ b/larq_compute_engine/tflite/cc/kernels/lce_register.cc
@@ -6,19 +6,9 @@
 // but this way we only have to add them once.
 //
 
+#include "larq_compute_engine/tflite/cc/kernels/lce_ops_register.h"
 #include "tensorflow/lite/kernels/builtin_op_kernels.h"
 #include "tensorflow/lite/kernels/register.h"
-
-namespace compute_engine {
-namespace tflite {
-
-TfLiteRegistration* Register_BSIGN();
-// TfLiteRegistration* Register_BCONV_2D8();
-TfLiteRegistration* Register_BCONV_2D32();
-TfLiteRegistration* Register_BCONV_2D64();
-
-}  // namespace tflite
-}  // namespace compute_engine
 
 namespace tflite {
 namespace ops {


### PR DESCRIPTION
In this PR, I create:
- a benchmark binary with a TF lite ```OpResolver``` **with registered LCE custom ops**. This is achieved by implementing ```RegisterSelectedOps()```function which will be weak-linked with TF lite library and therefore does not require to copy all the builtin ops registrations (in contrast to what we do with the make build). 
- The binary can be built for **android, x86, Raspberry Pi for both 32-bit and 64-bit**.