### PR TITLE
provide helper function to register LCE ops

### DIFF
--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -22,13 +22,7 @@ limitations under the License.
 
 void ABSL_ATTRIBUTE_WEAK
 RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
-  resolver->AddCustom("LqceBsign", compute_engine::tflite::Register_BSIGN());
-  // resolver->// AddCustom("LqceBconv2d8",
-  // compute_engine::tflite::Register_BCONV_2D8());
-  resolver->AddCustom("LqceBconv2d32",
-                      compute_engine::tflite::Register_BCONV_2D32());
-  resolver->AddCustom("LqceBconv2d64",
-                      compute_engine::tflite::Register_BCONV_2D64());
+  compute_engine::tflite::RegisterLCECustomOps(resolver);
 }
 
 namespace tflite {

--- a/larq_compute_engine/tflite/cc/kernels/BUILD
+++ b/larq_compute_engine/tflite/cc/kernels/BUILD
@@ -99,7 +99,6 @@ cc_library(
     ],
     hdrs = ["utils.h", "lce_ops_register.h"],
     copts = tflite_copts() + tf_opts_nortti_if_android(),
-    # visibility = ["//visibility:private"],
     deps = [
         ":bconv2d_impl",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/larq_compute_engine/tflite/cc/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/cc/kernels/lce_ops_register.h
@@ -2,6 +2,7 @@
 #define COMPUTE_EGNINE_TFLITE_KERNELS_LCE_REGISTER_H_
 
 #include "tensorflow/lite/context.h"
+#include "tensorflow/lite/op_resolver.h"
 
 // This file contains forward declaration of all custom ops
 // implemented in LCE which can be used to link against LCE library.
@@ -13,6 +14,16 @@ TfLiteRegistration* Register_BSIGN();
 // TfLiteRegistration* Register_BCONV_2D8();
 TfLiteRegistration* Register_BCONV_2D32();
 TfLiteRegistration* Register_BCONV_2D64();
+
+// By calling this function on TF lite mutable op resolver, all LCE custom ops
+// will be registerd to the op resolver.
+inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver) {
+  resolver->AddCustom("LqceBsign", compute_engine::tflite::Register_BSIGN());
+  resolver->AddCustom("LqceBconv2d32",
+                      compute_engine::tflite::Register_BCONV_2D32());
+  resolver->AddCustom("LqceBconv2d64",
+                      compute_engine::tflite::Register_BCONV_2D64());
+};
 
 }  // namespace tflite
 }  // namespace compute_engine


### PR DESCRIPTION
This PR, provides an helper function to register LCE ops into mutable op resolvers. An example of this process will follow in a separate PR.