### PR TITLE
add a C++ example to run forward pass of a model containing LCE ops

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,25 @@
+load("@org_tensorflow//tensorflow/lite:build_def.bzl", "tflite_linkopts")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_binary(
+    name = "lce_minimal",
+    srcs = [
+        "lce_minimal.cc",
+    ],
+    linkopts = tflite_linkopts() + select({
+        "@org_tensorflow//tensorflow:android": [
+            "-pie",  # Android 5.0 and later supports only PIE
+            "-lm",  # some builtin ops, e.g., tanh, need -lm
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//larq_compute_engine/tflite/cc/kernels:lce_op_kernels",
+        "@org_tensorflow//tensorflow/lite:framework",
+        "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
+    ],
+)

--- a/examples/lce_minimal.cc
+++ b/examples/lce_minimal.cc
@@ -1,0 +1,62 @@
+#include <cstdio>
+
+#include "larq_compute_engine/tflite/cc/kernels/lce_ops_register.h"
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model.h"
+#include "tensorflow/lite/optional_debug_tools.h"
+
+// This file is based on the TF lite minimal example where the
+// "BuiltinObResolver" is modified to include the "Larq Compute Engine" custom
+// ops. Here we read a binary model form disk and perform inference by using the
+// C++ interface. See the BUILD file in this directory to see an example of
+// linking "Larq Compute Engine" cutoms ops to your inference binary.
+
+using namespace tflite;
+
+#define TFLITE_MINIMAL_CHECK(x)                              \
+  if (!(x)) {                                                \
+    fprintf(stderr, "Error at %s:%d\n", __FILE__, __LINE__); \
+    exit(1);                                                 \
+  }
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "lce_minimal <tflite model>\n");
+    return 1;
+  }
+  const char* filename = argv[1];
+
+  // Load model
+  std::unique_ptr<tflite::FlatBufferModel> model =
+      tflite::FlatBufferModel::BuildFromFile(filename);
+  TFLITE_MINIMAL_CHECK(model != nullptr);
+
+  // Build the interpreter
+  tflite::ops::builtin::BuiltinOpResolver resolver;
+  compute_engine::tflite::RegisterLCECustomOps(&resolver);
+
+  InterpreterBuilder builder(*model, resolver);
+  std::unique_ptr<Interpreter> interpreter;
+  builder(&interpreter);
+  TFLITE_MINIMAL_CHECK(interpreter != nullptr);
+
+  // Allocate tensor buffers.
+  TFLITE_MINIMAL_CHECK(interpreter->AllocateTensors() == kTfLiteOk);
+  printf("=== Pre-invoke Interpreter State ===\n");
+  tflite::PrintInterpreterState(interpreter.get());
+
+  // Fill input buffers
+  // TODO(user): Insert code to fill input tensors
+
+  // Run inference
+  TFLITE_MINIMAL_CHECK(interpreter->Invoke() == kTfLiteOk);
+
+  printf("\n\n=== Post-invoke Interpreter State ===\n");
+  tflite::PrintInterpreterState(interpreter.get());
+
+  // Read output buffers
+  // TODO(user): Insert getting data out code.
+
+  return 0;
+}


### PR DESCRIPTION
a minimal C++ example of creating an OpResolver in C++, registering the LCE custom ops and invoke the forward pass. An example of bazel BUILD is also provided. 