### PR TITLE
Add fused activation support for valid padding

### DIFF
--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -55,6 +55,8 @@ struct BGemmImplUsingRuy {
     TSpec spec;
     spec.fused_multiply = params.fused_multiply;
     spec.fused_add = params.fused_add;
+    spec.clamp_min = params.clamp_min;
+    spec.clamp_max = params.clamp_max;
 
     // The allocator is used to allocate memory for pre-packed matrices
     ruy::Allocator allocator;

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -327,6 +327,25 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
       "fadd v20.4s, v20.4s, v15.4s\n"
       "fadd v22.4s, v22.4s, v15.4s\n"
 
+      // Perform the clamping (activation function)
+      // Load the clamp_min, clamp_max bounds
+      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
+      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"
+      "dup v14.4s, w2\n"  // clamp_min
+      "dup v15.4s, w3\n"  // clamp_max
+
+      // Apply the clamp_min bound
+      "fmax v16.4s, v16.4s, v14.4s\n"
+      "fmax v18.4s, v18.4s, v14.4s\n"
+      "fmax v20.4s, v20.4s, v14.4s\n"
+      "fmax v22.4s, v22.4s, v14.4s\n"
+
+      // Apply the clamp_max bound
+      "fmin v16.4s, v16.4s, v15.4s\n"
+      "fmin v18.4s, v18.4s, v15.4s\n"
+      "fmin v20.4s, v20.4s, v15.4s\n"
+      "fmin v22.4s, v22.4s, v15.4s\n"
+
       // Compute how much of the 4x4 block of destination values that
       // we have computed, fit in the destination matrix. Typically, all of
       // it fits, but when the destination matrix shape is not a multiple
@@ -744,6 +763,25 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
       "fadd v25.4s, v25.4s, v15.4s\n"
       "fadd v26.4s, v26.4s, v15.4s\n"
       "fadd v27.4s, v27.4s, v15.4s\n"
+
+      // Perform the clamping (activation function)
+      // Load the clamp_min, clamp_max bounds
+      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
+      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"
+      "dup v14.4s, w2\n"  // clamp_min
+      "dup v15.4s, w3\n"  // clamp_max
+
+      // Apply the clamp_min bound
+      "fmax v24.4s, v24.4s, v14.4s\n"
+      "fmax v25.4s, v25.4s, v14.4s\n"
+      "fmax v26.4s, v26.4s, v14.4s\n"
+      "fmax v27.4s, v27.4s, v14.4s\n"
+
+      // Apply the clamp_max bound
+      "fmin v24.4s, v24.4s, v15.4s\n"
+      "fmin v25.4s, v25.4s, v15.4s\n"
+      "fmin v26.4s, v26.4s, v15.4s\n"
+      "fmin v27.4s, v27.4s, v15.4s\n"
 
       // Compute how much of the 4x4 block of destination values that
       // we have computed, fit in the destination matrix. Typically, all of

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -14,7 +14,6 @@ using tflite::cpu_backend_gemm::QuantizationFlavor;
 // Original is in `lite/kernels/cpu_backend_gemm_params.h`
 // Modifications:
 // - bias changes to multiply + add
-// - clamp_min, clamp_max type changed from DstScalar to AccumScalar
 // - (later) 8-bit quantization related stuff
 template <typename AccumScalar, typename DstScalar,
           QuantizationFlavor quantization_flavor =
@@ -29,8 +28,8 @@ struct BGemmParams {
   // Later this might be changed to the int8 system of multipliers+shifts
   const float* fused_multiply = nullptr;
   const float* fused_add = nullptr;
-  AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
-  AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
+  DstScalar clamp_min = std::numeric_limits<DstScalar>::lowest();
+  DstScalar clamp_max = std::numeric_limits<DstScalar>::max();
 };
 
 //
@@ -38,7 +37,6 @@ struct BGemmParams {
 // Original is in `lite/experimental/ruy/spec.h`
 // Modifications:
 // - bias changes to multiply + add
-// - clamp_min, clamp_max types changed from DstScalar to AccumScalar
 // - (later) 8-bit quantization related stuff
 
 template <typename tAccumScalar, typename tDstScalar>
@@ -52,8 +50,8 @@ struct BinaryBasicSpec {
   // Later this might be changed to the int8 system of multipliers+shifts
   const float* fused_multiply = nullptr;
   const float* fused_add = nullptr;
-  AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
-  AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
+  DstScalar clamp_min = std::numeric_limits<DstScalar>::lowest();
+  DstScalar clamp_max = std::numeric_limits<DstScalar>::max();
 
   // This is identical to `ruy::BasicSpec`
   static constexpr LoopStructure kLoopStructure = LoopStructure::kAuto;
@@ -85,8 +83,8 @@ struct BinaryKernelParams {
   std::int32_t rhs_stride;
   std::int32_t dst_stride;
   std::int32_t depth;
-  std::uint32_t clamp_min;
-  std::uint32_t clamp_max;
+  float clamp_min;
+  float clamp_max;
   std::uint8_t flags;
   const T zero_data[LhsCols] = {0};
   T dst_tmp_buf[LhsCols * RhsCols];
@@ -124,8 +122,8 @@ inline void MakeBinaryKernelParams(
   params->rhs_stride = sizeof(T) * rhs.layout.stride;
   params->dst_stride = sizeof(float) * dst->layout.stride;
   params->depth = depth;
-  // params->clamp_min = spec.clamp_min;
-  // params->clamp_max = spec.clamp_max;
+  params->clamp_min = spec.clamp_min;
+  params->clamp_max = spec.clamp_max;
   params->dst_rows = dst->layout.rows;
   params->dst_cols = dst->layout.cols;
 

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -98,6 +98,8 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
         if (spec.fused_add) {
           dst_val += spec.fused_add[i];
         }
+        dst_val = std::min<DstScalar>(dst_val, spec.clamp_max);
+        dst_val = std::max<DstScalar>(dst_val, spec.clamp_min);
         *ElementPtr(dst, i, j) = dst_val;
       }
     }

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -170,6 +170,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
   BGemmParams<std::int32_t, T> gemm_params;
   gemm_params.fused_multiply = fused_multiply_data;
   gemm_params.fused_add = fused_add_data;
+  gemm_params.clamp_min = params.float_activation_min;
+  gemm_params.clamp_max = params.float_activation_max;
 
   // #if defined(TF_LITE_USE_CBLAS) && defined(__APPLE__)
 


### PR DESCRIPTION
This adds the `"activation"` attribute which can be set to `"RELU"`.