### PR TITLE
Strip symbols in generated wheels

### DIFF
--- a/.github/tools/release_linux.sh
+++ b/.github/tools/release_linux.sh
@@ -33,7 +33,7 @@ python -m pip install numpy six --no-cache-dir
 yes | ./configure.sh
 
 # Build
-bazelisk build :build_pip_pkg
+bazelisk build :build_pip_pkg --copt=-fvisibility=hidden
 
 # Package Whl
 bazel-bin/build_pip_pkg artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
           python --version
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
-          ./configure.sh <<< $'yes\n'
+          ./configure.sh
 
-          bazelisk build :build_pip_pkg
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden
           bazel-bin/build_pip_pkg artifacts
 
           for f in artifacts/*.whl; do

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -55,8 +55,12 @@ function main() {
   rsync -avm -L --exclude='*_test.py' ${PIP_FILE_PREFIX}larq_compute_engine "${TMPDIR}"
 
   pushd ${TMPDIR}
-  echo $(date) : "=== Building wheel"
 
+  echo "=== Stripping symbols"
+  chmod +w ${TMPDIR}/larq_compute_engine/mlir/*.so
+  strip -x ${TMPDIR}/larq_compute_engine/mlir/*.so
+
+  echo $(date) : "=== Building wheel"
   python setup.py bdist_wheel > /dev/null
 
   cp dist/*.whl "${DEST}"


### PR DESCRIPTION
This will make the generated wheels and linked `*.so` files significantly smaller.

Built wheels to try out can be found [here](https://github.com/larq/compute-engine/actions/runs/38795825)