### PR TITLE
Fix zero-padding when fused_multiplier is not -2

### DIFF
--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -471,7 +471,8 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
     padding_functor.cache_correction_values(
         GetTensorData<T>(filter), params->filter_height, params->filter_width,
         params->channels_out, params->channels_in, params->dilations[1],
-        params->dilations[2], GetTensorData<T>(padding_buffer));
+        params->dilations[2], GetTensorData<T>(fused_multiply),
+        GetTensorData<T>(padding_buffer));
     params->padding_cache_filled = true;
   }
 

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -208,7 +208,7 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                       filter_height, filter_width, output_depth, stride_height,
                       stride_width, dilation_height_factor,
                       dilation_width_factor, output_data, output_height,
-                      output_width, padding_buffer);
+                      output_width, fused_multiply_data, padding_buffer);
     }
   }
 }


### PR DESCRIPTION
This also adds more extensive unit testing for fused multipliers and biasses.