### PR TITLE
Skip CI if commit message contains 'ci-skip'

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   TFLite:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci-skip')"
     container:
       image: tensorflow/tensorflow:custom-op-ubuntu16
 
@@ -30,6 +31,7 @@ jobs:
 
   ARM:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v1
       - name: Install qemu-user
@@ -54,6 +56,7 @@ jobs:
 
   MLIR:
     runs-on: macos-latest
+    if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v1
       - name: Install Bazelisk


### PR DESCRIPTION
Since we are currently making a lot of docs changes it is nice to be able to ignore lengthy CI builds by adding `ci-ski` to the commit message.