### PR TITLE
Appease auditwheel for manylinux2010 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7']
+        python-version: ["3.6", "3.7"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7']
+        python-version: ["3.6", "3.7"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -57,23 +57,18 @@ jobs:
             tensorflow/tensorflow:custom-op-ubuntu16 \
             .github/tools/release_linux.sh
 
-          sudo apt-get -y -qq install patchelf rename --no-install-recommends
-          python -m pip install auditwheel==2.0.0
+          sudo apt-get -y -qq install patchelf --no-install-recommends
+          python -m pip install auditwheel --no-cache-dir
 
           for f in artifacts/*.whl; do
-            auditwheel show $f || true
-            # auditwheel repair fails likely due similar reasons as
-            # https://github.com/tensorflow/addons/pull/435
-            # auditwheel repair --plat manylinux2010_x86_64 $f
+            auditwheel repair --plat manylinux2010_x86_64 $f
           done
 
-          # Manually rename wheels since auditwheel fails
-          rename  's/linux_x86_64/manylinux2010_x86_64/' artifacts/*.whl
-          ls -al artifacts/
+          ls -al wheelhouse/
       - uses: actions/upload-artifact@v1
         with:
           name: ${{ runner.os }}-wheels
-          path: artifacts
+          path: wheelhouse
 
   upload-wheels:
     name: Publish wheels to PyPi

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -16,6 +16,12 @@
 set -e
 set -x
 
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
+function is_linux() {
+    [[ "${PLATFORM}" == "linux" ]]
+}
+
 PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/larq_compute_engine/"
 
 function abspath() {
@@ -53,6 +59,9 @@ function main() {
   cp ${PIP_FILE_PREFIX}MANIFEST.in "${TMPDIR}"
   cp ${PIP_FILE_PREFIX}README.md "${TMPDIR}"
   cp ${PIP_FILE_PREFIX}LICENSE "${TMPDIR}"
+  if is_linux; then
+    touch ${TMPDIR}/stub.cc
+  fi
   rsync -avm -L --exclude='*_test.py' ${PIP_FILE_PREFIX}larq_compute_engine "${TMPDIR}"
 
   pushd ${TMPDIR}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup for pip package."""
 
-from setuptools import dist, find_packages, setup
+from setuptools import dist, Extension, find_packages, setup
+from sys import platform
 
 
 def readme():
@@ -15,6 +16,8 @@ class BinaryDistribution(dist.Distribution):
         return True
 
 
+ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") else []
+
 setup(
     name="larq-compute-engine",
     version="0.1.0rc1",
@@ -25,6 +28,7 @@ setup(
     author="Plumerai",
     author_email="arash@plumerai.com",
     packages=find_packages(),
+    ext_modules=ext_modules,
     url="https://larq.dev/",
     install_requires=["packaging>=19"],
     extras_require={


### PR DESCRIPTION
Since we ship compiled *.so files without the source C++ code this hack is necessary to appease auditwheel.

This is dark magic copied from https://github.com/tensorflow/addons/pull/389 and https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/devtoolset/platlib.patch

Built wheels with this config can be found at https://github.com/larq/compute-engine/actions/runs/39581533