### PR TITLE
Fix all the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ advantage of multi-core modern desktop and mobile CPUs.
     is available in [Larq Zoo](https://docs.larq.dev/zoo/)
     and can be used out-of-the-box with LCE.
 
-  - LCE provides a custom [MLIR-based model converter](https://docs.larq.dev/compute-engine/converter.md) which
+  - LCE provides a custom [MLIR-based model converter](https://docs.larq.dev/compute-engine/converter) which
     is fully compatible with TensorFlow Lite and performs additional
     network level optimizations for Larq models.
 

--- a/README.md
+++ b/README.md
@@ -7,105 +7,108 @@ extremely quantized neural networks, such as
 Binarized Neural Networks (BNNs). It currently supports various mobile platforms
 and has been benchmarked on a Pixel 1 phone and a Raspberry Pi.
 LCE provides a collection of hand-optimized [TensorFlow Lite](https://www.tensorflow.org/lite)
-custom operators for supported instruction sets, developed in inline assembly or in C++ 
+custom operators for supported instruction sets, developed in inline assembly or in C++
 using compiler intrinsics. LCE leverages optimization techniques
-such as **tiling** to maximize the number of cache hits, **vectorization** to maximize 
+such as **tiling** to maximize the number of cache hits, **vectorization** to maximize
 the computational throughput, and **multi-threading parallelization** to take
 advantage of multi-core modern desktop and mobile CPUs.
 
 ## Key Features
+
 - **Effortless end-to-end integration** from training to deployment:
 
-    - Tight integration of LCE with [Larq](https://larq.dev) and
-      TensorFlow provides a smooth end-to-end training and deployment experience.
+  - Tight integration of LCE with [Larq](https://larq.dev) and
+    TensorFlow provides a smooth end-to-end training and deployment experience.
 
-    - A collection of Larq pre-trained BNN models for common machine learning tasks
-      is available in [Larq Zoo](https://larq.dev/models/)
-      and can be used out-of-the-box with LCE.
+  - A collection of Larq pre-trained BNN models for common machine learning tasks
+    is available in [Larq Zoo](https://docs.larq.dev/zoo/)
+    and can be used out-of-the-box with LCE.
 
-    - LCE provides a custom [MLIR-based model converter](./docs/mlir_converter.md) which
-      is fully compatible with TensorFlow Lite and performs additional
-      network level optimizations for Larq models.
+  - LCE provides a custom [MLIR-based model converter](https://docs.larq.dev/compute-engine/converter.md) which
+    is fully compatible with TensorFlow Lite and performs additional
+    network level optimizations for Larq models.
 
 - **Lightning fast deployment** on a variety of mobile platforms:
 
-    - LCE enables high performance, on-device machine learning inference by
-      providing hand-optimized kernels and network level optimizations for BNN models.
+  - LCE enables high performance, on-device machine learning inference by
+    providing hand-optimized kernels and network level optimizations for BNN models.
 
-    - LCE currently supports ARM64-based mobile platforms such as Android phones
-      and Raspberry Pi boards.
+  - LCE currently supports ARM64-based mobile platforms such as Android phones
+    and Raspberry Pi boards.
 
-    - Thread parallelism support in LCE is essential for modern mobile devices with
-      multi-core CPUs.
+  - Thread parallelism support in LCE is essential for modern mobile devices with
+    multi-core CPUs.
 
 ## Performance
+
 The table below presents **single-threaded** performance of Larq Compute Engine on
-different versions of a novel BNN model called Quicknet (trained on ImageNet dataset, soon to be released in [Larq Zoo](https://larq.dev/models/))
+different versions of a novel BNN model called Quicknet (trained on ImageNet dataset, soon to be released in [Larq Zoo](https://docs.larq.dev/zoo/))
 on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB)
 and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)) board:
 
 | Model                                                                                            | Top-1 Accuracy | RPi 4 B, ms (1 thread) | Pixel 1, ms (1 thread) |
-| --------------                                                                                   | :-------:      | :----------:           | :-----------:          |
-| Quicknet ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet.h5))             | 58.3 %         | 60.5                   | 27.9                   |
-| Quicknet-Large ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet_large.h5)) | 62.5 %         | 89.9                   | 41.8                   |
+| ------------------------------------------------------------------------------------------------ | :------------: | :--------------------: | :--------------------: |
+| Quicknet ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet.h5))             |     58.3 %     |          60.5          |          27.9          |
+| Quicknet-Large ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet_large.h5)) |     62.5 %     |          89.9          |          41.8          |
 
 For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](https://larq.dev/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
 while LCE achieves an inference time of 54.0 ms for Bi-RealNet on the same device.
 They furthermore present a modified version, BiRealNet-Stem, which achieves the same accuracy of 56.4% in 43.2 ms.
 
 The following table presents **multi-threaded** performance of Larq Compute Engine on
-a Pixel 1 phone and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)) 
+a Pixel 1 phone and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md))
 board:
 
 | Model                                                                                            | Top-1 Accuracy | RPi 4 B, ms (4 threads) | Pixel 1, ms (4 threads) |
-| --------------                                                                                   | :-------:      | :----------:            | :-----------:           |
-| Quicknet ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet.h5))             | 58.3 %         | 37.9                    | 19.1                    |
-| Quicknet-Large ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet_large.h5)) | 62.5 %         | 55.8                    | 28.0                    |
+| ------------------------------------------------------------------------------------------------ | :------------: | :---------------------: | :---------------------: |
+| Quicknet ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet.h5))             |     58.3 %     |          37.9           |          19.1           |
+| Quicknet-Large ([.h5](https://github.com/larq/zoo/releases/download/Quicknet/quicknet_large.h5)) |     62.5 %     |          55.8           |          28.0           |
 
 Benchmarked on February 14th, 2020 with LCE custom
 [TFLite Model Benchmark Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark)
-(see [here](./larq_compute_engine/tflite/benchmark))
+(see [here](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark))
 and BNN models with randomized weights and inputs.
 
 ## Getting started
+
 Follow these steps to deploy a BNN with LCE:
 
 1. **Pick a Larq model**
 
-    You can use [Larq](https://larq.dev) to build and train your own
-    model or pick a pre-trained model from [Larq Zoo](https://larq.dev/models/).
+   You can use [Larq](https://larq.dev) to build and train your own
+   model or pick a pre-trained model from [Larq Zoo](https://docs.larq.dev/zoo/).
 
 1. **Convert the Larq model**
 
-    LCE is built on top of TensorFlow Lite and uses the TensorFlow Lite
-    [FlatBuffer format](https://google.github.io/flatbuffers/)
-    to convert and serialize Larq models for inference.
-    We provide an [LCE Converter](./docs/converter.md) with additional
-    optimization passes to increase the speed of execution of Larq models
-    on supported target platforms.
+   LCE is built on top of TensorFlow Lite and uses the TensorFlow Lite
+   [FlatBuffer format](https://google.github.io/flatbuffers/)
+   to convert and serialize Larq models for inference.
+   We provide an [LCE Converter](https://docs.larq.dev/compute-engine/converter) with additional
+   optimization passes to increase the speed of execution of Larq models
+   on supported target platforms.
 
 1. **Build LCE**
 
-    The LCE documentation provides the build instructions for [Android](./docs/quickstart_android.md)
-    and [ARM64-based boards](./docs/build_arm.md) such as Raspberry Pi.
-    Please follow the provided instructions to create a native LCE build
-    or cross-compile for one of the supported targets.
+   The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android)
+   and [ARM64-based boards](https://docs.larq.dev/compute-engine/build_arm) such as Raspberry Pi.
+   Please follow the provided instructions to create a native LCE build
+   or cross-compile for one of the supported targets.
 
+1) **Run inference**
 
-1. **Run inference**
-
-    LCE uses the [TensorFlow Lite Interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/inference.md) 
-    to perform an inference. In addition to the already available built-in
-    TensorFlow Lite operators, optimized LCE operators are registered to the interpreter
-    to execute the Larq specific subgraphs of the model. An example to create
-    and build an LCE compatible TensorFlow Lite interpreter for your own
-    applications is provided [here](./docs/inference.md).
+   LCE uses the [TensorFlow Lite Interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/inference.md)
+   to perform an inference. In addition to the already available built-in
+   TensorFlow Lite operators, optimized LCE operators are registered to the interpreter
+   to execute the Larq specific subgraphs of the model. An example to create
+   and build an LCE compatible TensorFlow Lite interpreter for your own
+   applications is provided [here](https://docs.larq.dev/compute-engine/inference).
 
 ## Next steps
+
 - Explore [Larq pre-trained models](https://larq.dev/models/).
 - Learn how to [build](https://larq.dev/guides/bnn-architecture/) and
   [train](https://larq.dev/guides/bnn-optimization/) BNNs for your own
   application with Larq.
-- If you're a mobile developer, visit [Android quickstart](./docs/quickstart_android.md).
-- See our build instructions for Raspberry Pi and Arm64-based boards [here](./docs/build_arm.md).
-- Try our [example programs](./examples/).
+- If you're a mobile developer, visit [Android quickstart](https://docs.larq.dev/compute-engine/quickstart_android).
+- See our build instructions for Raspberry Pi and Arm64-based boards [here](https://docs.larq.dev/compute-engine/build_arm).
+- Try our [example programs](https://github.com/larq/compute-engine/tree/master/examples).

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Follow these steps to deploy a BNN with LCE:
 
 1) **Run inference**
 
-   LCE uses the [TensorFlow Lite Interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/inference.md)
+   LCE uses the [TensorFlow Lite Interpreter](https://www.tensorflow.org/lite/guide/inference)
    to perform an inference. In addition to the already available built-in
    TensorFlow Lite operators, optimized LCE operators are registered to the interpreter
    to execute the Larq specific subgraphs of the model. An example to create

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,4 +1,4 @@
-# Build Larq Compute Engine #
+# Build Larq Compute Engine
 
 The Larq Compute Engine (LCE) repository consists of two main components:
 
@@ -12,9 +12,9 @@ The Larq Compute Engine (LCE) repository consists of two main components:
 Before proceeding with building LCE components, you need to setup the LCE
 build enviroment first.
 
-## Setup the build environment ##
+## Setup the build environment
 
-### 1. Setup Docker container ###
+### 1. Setup Docker container
 
 We build the Larq Compute Engine (LCE) components inside a
 [docker](https://www.docker.com/) container. We also recommend to use
@@ -28,13 +28,13 @@ image.
 
 First, download the docker image:
 
-``` bash
+```bash
 docker pull tensorflow/tensorflow:custom-op-ubuntu16
 ```
 
 Clone the LCE repository in the host machine:
 
-``` bash
+```bash
 mkdir lce-volume
 git clone https://github.com/larq/compute-engine.git lce-volume
 ```
@@ -42,7 +42,7 @@ git clone https://github.com/larq/compute-engine.git lce-volume
 To start the container and map the `lce-volume` directory to the `/tmp/lce-volume`
 directory inside the container:
 
-``` bash
+```bash
 docker run -it -v $PWD/lce-volume:/tmp/lce-volume \
     -w /tmp/lce-volume tensorflow/tensorflow:custom-op-ubuntu16 /bin/bash
 ```
@@ -50,13 +50,13 @@ docker run -it -v $PWD/lce-volume:/tmp/lce-volume \
 Now, you will be able to build your targets inside the container
 and access the build artifacts directly from the host machine.
 
-### 2. Install Bazelisk ###
+### 2. Install Bazelisk
 
 [Bazel](https://bazel.build/) is the primary build system for LCE.
 However, to avoid Bazel compatibility issues,
 we recommend to use [Bazelisk](https://github.com/bazelbuild/bazelisk).
 To install Bazelisk on Linux, run the following two commands
-(replace ```v1.2.1``` with your preferred
+(replace `v1.2.1` with your preferred
 [bazelisk version](https://github.com/bazelbuild/bazelisk/releases)):
 
 ```shell
@@ -72,14 +72,14 @@ LCE converter's PIP package inside the `tensorflow:custom-op-ubuntu16`
 container. This script generates the Bazel configuration file `.bazelrc`
 in the LCE root directory.
 
-## Build LCE Runtime ##
+## Build LCE Runtime
 
 LCE runtime has a diverse platform support, covering
-[Android](./quickstart_android.md) and [ARM-based boards](./build_arm.md)
+[Android](/compute-engine/quickstart_android) and [ARM-based boards](/compute-engine/build_arm)
 such as Raspberry Pi. To build/install/run LCE runtime on
 each of these platforms, please refer to the corresponding guide.
 
-## Build LCE Converter ##
+## Build LCE Converter
 
 The LCE converter is available on [PyPI](https://pypi.org/project/larq-compute-engine/)
 and can be installed with Python's [pip](https://pip.pypa.io/en/stable/)
@@ -92,7 +92,7 @@ pip install larq-compute-engine
 You can also run the following commands,
 to build the LCE pip package yourself:
 
-``` bash
+```bash
 bazel build :build_pip_pkg
 bazel-bin/build_pip_pkg artifacts
 ```
@@ -100,6 +100,6 @@ bazel-bin/build_pip_pkg artifacts
 The script stores the wheel file in the `artifacts/` directory located in the
 LCE root directory. To install the PIP package:
 
-``` bash
+```bash
 pip install artifacts/*.whl
 ```

--- a/docs/build_arm.md
+++ b/docs/build_arm.md
@@ -1,4 +1,5 @@
 # Build Larq Compute Engine for ARM
+
 This page descibes how to build Larq Compute Engine (LCE) binaries
 for 32-bit, as well as 64-bit ARM-based systems.
 [Bazel](https://bazel.build/) is the primary build system for LCE and can
@@ -8,6 +9,7 @@ Makefile build system.
 
 This leaves us with three ways to build LCE binaries, which we recommend in
 the following order:
+
 1. To cross-compile LCE from a host machine, see
    [Cross-compiling LCE with Bazel](#cross-compiling-lce-with-bazel)
 2. To natively compile LCE, see
@@ -16,8 +18,8 @@ the following order:
    install Bazel, see
    [Cross-compiling LCE with Make](#cross-compiling-lce-with-make).
 
-This guide will show you how to build the [LCE example program](../examples/lce_minimal.cc).
-See [here](./inference.md) to find out how you can create your own LCE
+This guide will show you how to build the [LCE example program](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc).
+See [here](/compute-engine/inference) to find out how you can create your own LCE
 inference binary.
 
 NOTE: Although the Raspberry Pi 3 and Raspberry Pi 4 have 64-bit CPUs, the
@@ -27,18 +29,19 @@ as [Manjaro](https://manjaro.org/download/#raspberry-pi-4-xfce) should be used.
 
 ## Cross-compiling LCE with Bazel
 
-First configure Bazel using the instructions [here](build.md#configure-bazelrc).
+First configure Bazel using the instructions [here](/compute-engine/build#configure-bazelrc).
 
 To cross-compile the LCE example for ARM architectures, the bazel
 target needs to be built with the `--config=rpi3` (32-bit ARM) or
 `--config=aarch64` (64-bit ARM) flag. For example, to build the example
 for 64-bit ARM systems, run the following command from the LCE root
 directory:
+
 ```bash
 bazel build \
     --config=aarch64 \
     //examples:lce_minimal
- ```
+```
 
 To build the LCE benchmark tool, build the bazel target
 `//larq_compute_engine/tflite/benchmark:lce_benchmark_model`
@@ -49,11 +52,14 @@ The resulting binaries will be stored at
 copy these to your ARM machine and run them there.
 
 ## Building LCE with Make
+
 To build LCE with Make, first clone the Larq Compute Engine repo and make sure the tensorflow submodule is loaded
 (this only has to be done once):
-``` bash
+
+```bash
 git submodule update --init
 ```
+
 To simplify the build process for various supported targets, we provide the
 `build_lce.sh` script which accepts the build target platform as an input
 argument.
@@ -61,6 +67,7 @@ argument.
 To natively build the LCE library and C++ example programs, first you need to
 install the compiler toolchain on your target device. On Debian based systems like a
 Raspberry Pi board with Raspbian, run the following command:
+
 ```
 sudo apt-get install build-essential
 ```
@@ -73,6 +80,7 @@ sudo pacman -S base-devel
 
 You should then be able to natively compile LCE by running the following from
 the LCE root directory:
+
 ```bash
 larq_compute_engine/tflite/build_make/build_lce.sh --native
 ```
@@ -89,32 +97,36 @@ In the `lib` folder, you can find the TensorFlow Lite static library
 `libtensorflow-lite.a` which includes the LCE customs ops.
 
 ## Cross-compiling LCE with Make
+
 First clone the Larq Compute Engine repo and make sure the tensorflow submodule is loaded (this only has to be done
 once):
-``` bash
+
+```bash
 git submodule update --init
 ```
 
 To cross-compile LCE, you need to first install the compiler toolchain.
 For Debian based systems, run the following commands:
-``` bash
+
+```bash
 sudo apt-get update
 sudo apt-get install crossbuild-essential-armhf
 ```
 
 On an Arch based systems, the package is called `arm-linux-gnueabihf`:
 
-``` bash
+```bash
 sudo pacman -Syy
 sudo pacman -S arm-linux-gnueabihf
 ```
 
-
 To build for 32-bit ARM architectures, run the following command from the LCE
 root directory:
+
 ```bash
 larq_compute_engine/tflite/build_make/build_lce.sh --rpi
 ```
+
 When building for a 64-bit ARM architecture, replace `--rpi` with `--aarch64`.
 
 See [Building LCE with Make](#building-lce-with-make) for the location of

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,17 +1,19 @@
 # Larq Compute Engine Inference
+
 To perform an inference with Larq Compute Engine (LCE), we use the [TensorFlow Lite
-interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/inference.md).
+interpreter](https://www.tensorflow.org/lite/guide/inference).
 An LCE-compatible TensorFlow Lite interpreter drives the Larq model inference and
 uses LCE custom operators instead of built-in TensorFlow Lite operators for each applicable
 subgraph of the model.
 
 This guide describes how to create a TensorFlow Lite interpreter with registered
-LCE custom Ops and perform an inference with a [converted Larq model](./mlir_converter.md)
+LCE custom Ops and perform an inference with a [converted Larq model](/compute-engine/converter)
 using LCE C++ API.
 
 ## Load and run a model in C++
+
 Running an inference with TensorFlow Lite consists of multiple steps,
-which are comprehensively described in the [TensorFlow Lite inference guide](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/inference.md#load-and-run-a-model-in-c).
+which are comprehensively described in the [TensorFlow Lite inference guide](https://www.tensorflow.org/lite/guide/inference#load_and_run_a_model_in_c).
 Below we list these steps with one additional step to register LCE customs
 operators using the LCE C++ function `RegisterLCECustomOps()`:
 
@@ -65,4 +67,4 @@ float* output = interpreter->typed_output_tensor<float>(0);
 ```
 
 To build the inference binary with Bazel, it needs to be linked against `//larq_compute_engine/tflite/kernels:lce_op_kernels` target.
-See [LCE minimal](../examples/lce_minimal.cc) for an example code.
+See [LCE minimal](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc) for an example code.

--- a/docs/quickstart_android.md
+++ b/docs/quickstart_android.md
@@ -6,14 +6,15 @@ you must have the [Android NDK](https://developer.android.com/ndk) and
 Below we explain how to install the Android prerequisites in the LCE
 Docker container and how to configure the LCE Bazel build settings
 accordingly. Before proceeding with the next steps, please follow
-the instructions in the main [LCE build guide](./build.md) to setup the
+the instructions in the main [LCE build guide](/compute-engine/build) to setup the
 Docker container for LCE and the Bazel build system.
 
 NOTE: we recommend using the docker volume as described in the
-[LCE build guide](./build.md) to be able to easily transfer
+[LCE build guide](/compute-engine/build) to be able to easily transfer
 files in-between the container and host machine.
 
 #### Install prerequisites
+
 We provide a bash script which uses the `sdkmanager` tool
 to install the Android NDK and SDK inside the Docker container.
 Please run the script by executing the following command from the LCE
@@ -32,9 +33,9 @@ The script will download and unpack the android NDK and SKD under the directory
 The Android NDK and SDK versions used in LCE are currently hard-coded in the
 install script.
 To build LCE against a different NDK and SDK versions, you can manually
-modify ```ANDROID_VERSION``` and ```ANDROID_NDK_VERSION``` variables in the
-install script. Additionally, the following configurations in ```configure.sh```
-(or ```.bazelrc```) file need to be adjusted:
+modify `ANDROID_VERSION` and `ANDROID_NDK_VERSION` variables in the
+install script. Additionally, the following configurations in `configure.sh`
+(or `.bazelrc`) file need to be adjusted:
 
 ```shell
 build --action_env ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600"
@@ -45,18 +46,20 @@ build --action_env ANDROID_SDK_HOME="/usr/local/android/android-sdk-linux"
 ```
 
 #### Build an LCE inference binary
-To build an LCE inference binary for Android (see [here](./inference.md) for creating your
-own LCE binary) the Bazel target needs to build with ```--config=android_arm64``` flag.
 
-To build the [minimal example](../examples/lce_minimal.cc) for Android,
+To build an LCE inference binary for Android (see [here](/compute-engine/inference) for creating your
+own LCE binary) the Bazel target needs to build with `--config=android_arm64` flag.
+
+To build the [minimal example](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc) for Android,
 run the following command from the LCE root directory:
+
 ```bash
 bazel build -c opt \
     --config=android_arm64 \
     //examples:lce_minimal
 ```
 
-To build the [LCE benchmark tool](../larq_compute_engine/tflite/benchmark/)
+To build the [LCE benchmark tool](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark)
 for Android, simply build the bazel target
 `//larq_compute_engine/tflite/benchmark:lce_benchmark_model`.
 
@@ -66,26 +69,28 @@ The resulting binaries will be stored at
 See below on how to copy them to your android device.
 
 #### Run inference
-To run the inference with a [Larq converted model](./lce_converter.md) on an android phone,
+
+To run the inference with a [Larq converted model](/compute-engine/converter) on an android phone,
 please follow these steps on your host machine (replace the `lce_benchmark_model` with your
 desired inference binary):
 
 (1) Install the [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) on your host machine.
 
 (2) Follow the instructions [here](https://developer.android.com/studio/debug/dev-options#enable)
-   to enable `USB debugging` on your android phone.
+to enable `USB debugging` on your android phone.
 
 (3) Connect your phone and run the following command to confirm that your host
-    computer is connected to the phone:
+computer is connected to the phone:
 
 ```bash
 adb devices
 ```
 
 (4) Since Bazel stores the build artifacts outside the `lce-volume` directory,
-    You need to run the following command inside the container to copy the inference
-    binary from the bazel output direcotry to the `lce-volume` directory in order to be able to access it on the host
-    machine:
+You need to run the following command inside the container to copy the inference
+binary from the bazel output direcotry to the `lce-volume` directory in order to be able to access it on the host
+machine:
+
 ```bash
 cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model <volume-dir>
 ```
@@ -102,7 +107,7 @@ adb push lce_benchmark_model  /data/local/tmp
 adb shell chmod +x /data/local/tmp/lce_benchmark_model
 ```
 
-(7) Transfer the converted ```.tflite``` model file to your phone:
+(7) Transfer the converted `.tflite` model file to your phone:
 
 ```shell
 adb push binarynet.tflite /data/local/tmp


### PR DESCRIPTION
This should fix all the links on docs.larq.dev

Sorry about the big diff, my editor didn't like the markdown formatting.