### PR TITLE
Build wheels for macOS 10.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
           ./configure.sh
 
-          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden
-          bazel-bin/build_pip_pkg artifacts
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13
+          bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_13_x86_64
 
           for f in artifacts/*.whl; do
             delocate-wheel -w wheelhouse $f

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -32,15 +32,8 @@ function abspath() {
 }
 
 function main() {
-  while [[ ! -z "${1}" ]]; do
-    if [[ ${1} == "make" ]]; then
-      echo "Using Makefile to build pip package."
-      PIP_FILE_PREFIX=""
-    else
-      DEST=${1}
-    fi
-    shift
-  done
+  DEST=${1}
+  BUILD_FLAG=${@:2}
 
   if [[ -z ${DEST} ]]; then
     echo "No destination dir provided"
@@ -72,7 +65,7 @@ function main() {
   strip -x ${TMPDIR}/larq_compute_engine/mlir/*.so
 
   echo $(date) : "=== Building wheel"
-  python setup.py bdist_wheel > /dev/null
+  python setup.py bdist_wheel ${BUILD_FLAG} > /dev/null
 
   cp dist/*.whl "${DEST}"
   popd


### PR DESCRIPTION
This adds support for macOS 10.13, 10.14 and 10.15 when installing from PyPI.

See https://github.com/tensorflow/addons/issues/1108