### PR TITLE
Improve converter API docs

### DIFF
--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -37,7 +37,7 @@ def concrete_function_from_keras_model(model):
     return func.get_concrete_function()
 
 
-def convert_keras_model(model):
+def convert_keras_model(model: tf.keras.Model) -> bytes:
     """Converts a Keras model to TFLite flatbuffer.
 
     !!! example

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -40,8 +40,18 @@ def concrete_function_from_keras_model(model):
 def convert_keras_model(model):
     """Converts a Keras model to TFLite flatbuffer.
 
-    Returns:
-      The converted data in serialized format.
+    !!! example
+        ```python
+        tflite_model = convert_keras_model(model)
+        with open("/tmp/my_model.tflite", "wb") as f:
+            f.write(tflite_model)
+        ```
+
+    # Arguments
+    model: A [`tf.keras.Model`](https://www.tensorflow.org/api_docs/python/tf/keras/Model) to convert.
+
+    # Returns
+    The converted data in serialized format.
     """
     if not tf.executing_eagerly():
         raise RuntimeError(


### PR DESCRIPTION
This will allow us to properly render API docs on https://docs.larq.dev:
![Screenshot 2020-02-21 at 19 35 18](https://user-images.githubusercontent.com/13285808/75065810-7e350480-54e1-11ea-8e51-0fa482a802fc.png)
