### PR TITLE
Remove unused explicit padding argument

### DIFF
--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -42,7 +42,6 @@ TODO
 
     I64ArrayAttr:$strides,
     TF_AnyStrAttrOf<["SAME", "VALID", "EXPLICIT"]>:$padding,
-    DefaultValuedAttr<I64ArrayAttr, "{}">:$explicit_paddings,
     DefaultValuedAttr<TF_ConvnetDataFormatAttr, "NHWC">:$data_format,
     DefaultValuedAttr<I64ArrayAttr, "{1, 1, 1, 1}">:$dilations,
     DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI", "OHWI_PACKED"]>, "HWIO">:$filter_format

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -13,12 +13,11 @@ def HasOneUse : Constraint<CPred<"$0->hasOneUse()">>;
 multiclass FuseAddOrSubWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$output $input, $filter,
                           $fused_multiply, (ConstantOp F32ElementsAttr:$fused_add), $strides,
-                          $padding, $explicit_paddings, $data_format,
-                          $dilations, $filter_format),
+                          $padding, $data_format, $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), TFL_AF_None),
             (TF_LqceBconv2d64Op $input, $filter, $fused_multiply,
                           (binaryOp (ConstantOp $fused_add), (ConstantOp $value), TFL_AF_None),
-                          $strides, $padding, $explicit_paddings, $data_format,
+                          $strides, $padding, $data_format,
                           $dilations, $filter_format),
             [(HasOneUse $output)]>;
 }
@@ -30,7 +29,7 @@ multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$conv_output $input, $filter,
                         (ConstantOp F32ElementsAttr:$fused_multiply),
                         (ConstantOp F32ElementsAttr:$fused_add),
-                        $strides, $padding, $explicit_paddings, $data_format,
+                        $strides, $padding, $data_format,
                         $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), $TFL_AF_None),
             (TF_LqceBconv2d64Op $input, $filter,
@@ -38,7 +37,7 @@ multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
                                   (ConstantOp $value), TFL_AF_None),
                         (binaryOp (ConstantOp $fused_add),
                                   (ConstantOp $value), TFL_AF_None),
-                        $strides, $padding, $explicit_paddings, $data_format,
+                        $strides, $padding, $data_format,
                         $dilations, $filter_format),
          [(HasOneUse $conv_output)]>;
 }

--- a/larq_compute_engine/mlir/transforms/prepare_patterns.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns.td
@@ -33,6 +33,6 @@ def : Pat<(TF_Conv2DOp (TF_LqceBsignOp $input), $filter, $strides, $use_cudnn,
             (TF_TransposeOp $filter, (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
             (TF_ConstOp (GetMultiplier $filter)),
             (TF_ConstOp (GetBias $filter)),
-            $strides, $padding, $explicit_padding,
-            $data_format, $dilations, ConstantAttr<StrAttr, "OHWI">),
+            $strides, $padding, $data_format,
+            $dilations, ConstantAttr<StrAttr, "OHWI">),
           [(BinaryFilter $filter)], (addBenefit 90)>;


### PR DESCRIPTION
This was copied from the [TF ops](https://github.com/larq/compute-engine/blob/master/larq_compute_engine/tf/ops/compute_engine_ops.cc#L49), I don't think the TFLite version ever supported this argument anyway.