### PR TITLE
Simplify is binary check

### DIFF
--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -12,7 +12,8 @@ func @fuse_bsign(%arg0: tensor<8x16xf32>) -> tensor<8x16xf32> {
   // CHECK-NEXT: return %0
 }
 
-func @bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
+// CHECK-LABEL: @fuse_bconv2d
+func @fuse_bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
   %cst = "tf.Const"() { value = dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32> } : () -> tensor<1x2x2x2xf32>
   %0 = "tf.LqceBsign"(%arg0) : (tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32>
   %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>

--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -12,9 +12,8 @@ func @fuse_bsign(%arg0: tensor<8x16xf32>) -> tensor<8x16xf32> {
   // CHECK-NEXT: return %0
 }
 
-// CHECK-LABEL: @fuse_bconv2d
-func @fuse_bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
-  %cst = constant dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32>
+func @bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
+  %cst = "tf.Const"() { value = dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32> } : () -> tensor<1x2x2x2xf32>
   %0 = "tf.LqceBsign"(%arg0) : (tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32>
   %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>
   return %1 : tensor<1x112x112x2xf32>

--- a/larq_compute_engine/mlir/transforms/prepare_patterns.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns.td
@@ -23,14 +23,14 @@ class I32VectorElementsAttr<int len> : ElementsAttrBase<
     "RankedTensorType::get({" # len # "}, $_builder.getIntegerType(32)), $0)";
 }
 
-def GetBias : NativeCodeCall<"GetBias(*$0)">;
-def GetMultiplier : NativeCodeCall<"GetMultiplier(*$0)">;
+def GetBias : NativeCodeCall<"GetBias($0)">;
+def GetMultiplier : NativeCodeCall<"GetMultiplier($0)">;
 def BinaryFilter : Constraint<CPred<"IsBinaryFilter($0)">>;
 
-def : Pat<(TF_Conv2DOp (TF_LqceBsignOp $input), $filter, $strides, $use_cudnn,
+def : Pat<(TF_Conv2DOp (TF_LqceBsignOp $input), (ConstantOp $filter), $strides, $use_cudnn,
                        $padding, $explicit_padding, $data_format, $dilations),
           (TF_LqceBconv2d64Op $input,
-            (TF_TransposeOp $filter, (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
+            (TF_TransposeOp (ConstantOp $filter), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
             (TF_ConstOp (GetMultiplier $filter)),
             (TF_ConstOp (GetBias $filter)),
             $strides, $padding, $data_format,


### PR DESCRIPTION
## What do these changes do?
This PR will directly match a MLIR `ConstantOp` so we can simplify the binary check.

## How Has This Been Tested?
MLIR unit tests
