### PR TITLE
Support running lit tests on macOS without needing to install GNU find

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -61,10 +61,6 @@ jobs:
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
           chmod +x bazelisk
-      - name: Install GNU find
-        run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install findutils
-          ln -sf /usr/local/bin/gfind /usr/local/bin/find
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7


### PR DESCRIPTION
## What do these changes do?
This removes the need to install GNU find on macOS to run LIT tests which means less setup for local development.

## How Has This Been Tested?
CI
