### PR TITLE
Update BConv TableGen definition to match TFLite Op

### DIFF
--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -44,7 +44,7 @@ TODO
     TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,
     DefaultValuedAttr<TF_ConvnetDataFormatAttr, "NHWC">:$data_format,
     DefaultValuedAttr<I64ArrayAttr, "{1, 1, 1, 1}">:$dilations,
-    DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI", "OHWI_PACKED"]>, "OHWI">:$filter_format
+    DefaultValuedAttr<TF_AnyStrAttrOf<["OHWI", "OHWI_PACKED"]>, "OHWI">:$filter_format
   );
 
   let results = (outs

--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -44,7 +44,7 @@ TODO
     TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,
     DefaultValuedAttr<TF_ConvnetDataFormatAttr, "NHWC">:$data_format,
     DefaultValuedAttr<I64ArrayAttr, "{1, 1, 1, 1}">:$dilations,
-    DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI"]>, "OHWI">:$filter_format
+    DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI", "OHWI_PACKED"]>, "OHWI">:$filter_format
   );
 
   let results = (outs

--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -35,25 +35,21 @@ TODO
   }];
 
   let arguments = (ins
-    TensorOf<[BF16, F16, F32, F64, I32]>:$input,
-    TensorOf<[BF16, F16, F32, F64, I32]>:$filter,
+    TensorOf<[F32]>:$input,
+    TensorOf<[F32]>:$filter,
     TensorOf<[F32]>:$fused_multiply,
     TensorOf<[F32]>:$fused_add,
 
     I64ArrayAttr:$strides,
-    TF_AnyStrAttrOf<["SAME", "VALID", "EXPLICIT"]>:$padding,
+    TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,
     DefaultValuedAttr<TF_ConvnetDataFormatAttr, "NHWC">:$data_format,
     DefaultValuedAttr<I64ArrayAttr, "{1, 1, 1, 1}">:$dilations,
-    DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI", "OHWI_PACKED"]>, "HWIO">:$filter_format
+    DefaultValuedAttr<TF_AnyStrAttrOf<["HWIO", "OHWI"]>, "OHWI">:$filter_format
   );
 
   let results = (outs
-    TensorOf<[BF16, F16, F32, F64, I32]>:$output
+    TensorOf<[F32]>:$output
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  /* let verifier = [{
-    return Verify(*this);
-  }]; */
 }


### PR DESCRIPTION
This makes sure that the TableGen op definition matches the TFLite op implementation.