### PR TITLE
Split fused multiply into backtransform and post multiply

### DIFF
--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -54,8 +54,8 @@ struct BGemmImplUsingRuy {
 
     TSpec spec;
     spec.backtransform_add = params.backtransform_add;
-    spec.post_multiply = params.post_multiply;
-    spec.post_add = params.post_add;
+    spec.post_activation_multiplier = params.post_activation_multiplier;
+    spec.post_activation_bias = params.post_activation_bias;
 
     // The allocator is used to allocate memory for pre-packed matrices
     ruy::Allocator allocator;

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -53,8 +53,8 @@ struct BGemmImplUsingRuy {
     dst.data = dst_data;
 
     TSpec spec;
-    spec.fused_multiply = params.fused_multiply;
-    spec.fused_add = params.fused_add;
+    spec.post_multiply = params.post_multiply;
+    spec.post_add = params.post_add;
 
     // The allocator is used to allocate memory for pre-packed matrices
     ruy::Allocator allocator;

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -53,6 +53,7 @@ struct BGemmImplUsingRuy {
     dst.data = dst_data;
 
     TSpec spec;
+    spec.backtransform_add = params.backtransform_add;
     spec.post_multiply = params.post_multiply;
     spec.post_add = params.post_add;
 

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -77,8 +77,8 @@ using namespace ruy;
 #define RUY_OFFSET_LHS_BASE_PTR 0
 #define RUY_OFFSET_RHS_BASE_PTR 8
 #define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_POST_MULTIPLY 24
-#define RUY_OFFSET_POST_ADD 32
+#define RUY_OFFSET_POST_ACTIVATION_MULTIPLIER 24
+#define RUY_OFFSET_POST_ACTIVATION_BIAS 32
 #define RUY_OFFSET_START_ROW 40
 #define RUY_OFFSET_START_COL 44
 #define RUY_OFFSET_LAST_ROW 48
@@ -97,9 +97,12 @@ void CheckOffsetsInKernelParams32BP(const Params&) {
   static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
   static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
   static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, post_multiply) == RUY_OFFSET_POST_MULTIPLY,
+  static_assert(offsetof(Params, post_activation_multiplier) ==
+                    RUY_OFFSET_POST_ACTIVATION_MULTIPLIER,
                 "");
-  static_assert(offsetof(Params, post_add) == RUY_OFFSET_POST_ADD, "");
+  static_assert(
+      offsetof(Params, post_activation_bias) == RUY_OFFSET_POST_ACTIVATION_BIAS,
+      "");
   static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
   static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
   static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
@@ -289,7 +292,7 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
       "dup v13.4s, w1 \n"
 
       // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_MULTIPLY) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_MULTIPLIER) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -298,7 +301,7 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
       "ld1 {v14.4s}, [x1], #16\n"
 
       // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ADD) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_BIAS) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -468,8 +471,8 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
 }
 
 #undef RUY_OFFSET_BACKTRANSFORM_ADD
-#undef RUY_OFFSET_POST_MULTIPLY
-#undef RUY_OFFSET_POST_ADD
+#undef RUY_OFFSET_POST_ACTIVATION_MULTIPLIER
+#undef RUY_OFFSET_POST_ACTIVATION_BIAS
 #undef RUY_OFFSET_FLAGS
 #undef RUY_OFFSET_LHS_BASE_PTR
 #undef RUY_OFFSET_CLAMP_MIN
@@ -488,8 +491,8 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
 #define RUY_OFFSET_LHS_BASE_PTR 0
 #define RUY_OFFSET_RHS_BASE_PTR 8
 #define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_POST_MULTIPLY 24
-#define RUY_OFFSET_POST_ADD 32
+#define RUY_OFFSET_POST_ACTIVATION_MULTIPLIER 24
+#define RUY_OFFSET_POST_ACTIVATION_BIAS 32
 #define RUY_OFFSET_START_ROW 40
 #define RUY_OFFSET_START_COL 44
 #define RUY_OFFSET_LAST_ROW 48
@@ -508,9 +511,12 @@ void CheckOffsetsInKernelParams64BP(const Params&) {
   static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
   static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
   static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, post_multiply) == RUY_OFFSET_POST_MULTIPLY,
+  static_assert(offsetof(Params, post_activation_multiplier) ==
+                    RUY_OFFSET_POST_ACTIVATION_MULTIPLIER,
                 "");
-  static_assert(offsetof(Params, post_add) == RUY_OFFSET_POST_ADD, "");
+  static_assert(
+      offsetof(Params, post_activation_bias) == RUY_OFFSET_POST_ACTIVATION_BIAS,
+      "");
   static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
   static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
   static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
@@ -728,7 +734,7 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
       "dup v13.4s, w1 \n"
 
       // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_MULTIPLY) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_MULTIPLIER) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -737,7 +743,7 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
       "ld1 {v14.4s}, [x1], #16\n"
 
       // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ADD) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_BIAS) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -907,8 +913,8 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
 }
 
 #undef RUY_OFFSET_BACKTRANSFORM_ADD
-#undef RUY_OFFSET_POST_MULTIPLY
-#undef RUY_OFFSET_POST_ADD
+#undef RUY_OFFSET_POST_ACTIVATION_MULTIPLIER
+#undef RUY_OFFSET_POST_ACTIVATION_BIAS
 #undef RUY_OFFSET_FLAGS
 #undef RUY_OFFSET_LHS_BASE_PTR
 #undef RUY_OFFSET_CLAMP_MIN

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -77,8 +77,8 @@ using namespace ruy;
 #define RUY_OFFSET_LHS_BASE_PTR 0
 #define RUY_OFFSET_RHS_BASE_PTR 8
 #define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_FUSED_MULTIPLY 24
-#define RUY_OFFSET_FUSED_ADD 32
+#define RUY_OFFSET_POST_MULTIPLY 24
+#define RUY_OFFSET_POST_ADD 32
 #define RUY_OFFSET_START_ROW 40
 #define RUY_OFFSET_START_COL 44
 #define RUY_OFFSET_LAST_ROW 48
@@ -96,9 +96,9 @@ void CheckOffsetsInKernelParams32BP(const Params&) {
   static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
   static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
   static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, fused_multiply) == RUY_OFFSET_FUSED_MULTIPLY,
+  static_assert(offsetof(Params, post_multiply) == RUY_OFFSET_POST_MULTIPLY,
                 "");
-  static_assert(offsetof(Params, fused_add) == RUY_OFFSET_FUSED_ADD, "");
+  static_assert(offsetof(Params, post_add) == RUY_OFFSET_POST_ADD, "");
   static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
   static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
   static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
@@ -279,7 +279,7 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
       "ldrb w4, [%[params], #" RUY_STR(RUY_OFFSET_FLAGS) "]\n"
 
       // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_FUSED_MULTIPLY) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_MULTIPLY) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -288,7 +288,7 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
       "ld1 {v14.4s}, [x1], #16\n"
 
       // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_FUSED_ADD) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ADD) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -447,8 +447,8 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
         "v26", "v27", "v28", "v29", "v30", "v31");
 }
 
-#undef RUY_OFFSET_FUSED_MULTIPLY
-#undef RUY_OFFSET_FUSED_ADD
+#undef RUY_OFFSET_POST_MULTIPLY
+#undef RUY_OFFSET_POST_ADD
 #undef RUY_OFFSET_FLAGS
 #undef RUY_OFFSET_LHS_BASE_PTR
 #undef RUY_OFFSET_CLAMP_MIN
@@ -467,8 +467,8 @@ void BinaryKernelNeonOutOfOrder32BP4x4(
 #define RUY_OFFSET_LHS_BASE_PTR 0
 #define RUY_OFFSET_RHS_BASE_PTR 8
 #define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_FUSED_MULTIPLY 24
-#define RUY_OFFSET_FUSED_ADD 32
+#define RUY_OFFSET_POST_MULTIPLY 24
+#define RUY_OFFSET_POST_ADD 32
 #define RUY_OFFSET_START_ROW 40
 #define RUY_OFFSET_START_COL 44
 #define RUY_OFFSET_LAST_ROW 48
@@ -486,9 +486,9 @@ void CheckOffsetsInKernelParams64BP(const Params&) {
   static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
   static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
   static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, fused_multiply) == RUY_OFFSET_FUSED_MULTIPLY,
+  static_assert(offsetof(Params, post_multiply) == RUY_OFFSET_POST_MULTIPLY,
                 "");
-  static_assert(offsetof(Params, fused_add) == RUY_OFFSET_FUSED_ADD, "");
+  static_assert(offsetof(Params, post_add) == RUY_OFFSET_POST_ADD, "");
   static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
   static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
   static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
@@ -697,7 +697,7 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
       "ldrb w4, [%[params], #" RUY_STR(RUY_OFFSET_FLAGS) "]\n"
 
       // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_FUSED_MULTIPLY) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_MULTIPLY) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
@@ -706,7 +706,7 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
       "ld1 {v14.4s}, [x1], #16\n"
 
       // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_FUSED_ADD) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ADD) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x5, x1, %x[row], lsl #2\n"
       "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -24,11 +24,11 @@ template <typename AccumScalar, typename DstScalar,
 struct BGemmParams {
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
-  // fused_mutiply and fused_add are currently float
+  // post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* fused_multiply = nullptr;
-  const float* fused_add = nullptr;
+  const float* post_multiply = nullptr;
+  const float* post_add = nullptr;
   AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
   AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
 };
@@ -47,11 +47,11 @@ struct BinaryBasicSpec {
   using DstScalar = tDstScalar;
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
-  // fused_mutiply and fused_add are currently float
+  // post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* fused_multiply = nullptr;
-  const float* fused_add = nullptr;
+  const float* post_multiply = nullptr;
+  const float* post_add = nullptr;
   AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
   AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
 
@@ -70,11 +70,11 @@ struct BinaryKernelParams {
   const T* lhs_base_ptr;
   const T* rhs_base_ptr;
   float* dst_base_ptr;
-  // fused_mutiply and fused_add are currently float
+  // post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* fused_multiply;
-  const float* fused_add;
+  const float* post_multiply;
+  const float* post_add;
   std::int32_t start_row;
   std::int32_t start_col;
   std::int32_t last_row;
@@ -110,9 +110,9 @@ inline void MakeBinaryKernelParams(
       dst->data.get() + start_col * dst->layout.stride + start_row;
 
   std::uint8_t flags = 0;
-  params->fused_multiply = spec.fused_multiply;
-  params->fused_add = spec.fused_add;
-  if (spec.fused_multiply && spec.fused_add) {
+  params->post_multiply = spec.post_multiply;
+  params->post_add = spec.post_add;
+  if (spec.post_multiply && spec.post_add) {
     flags |= RUY_ASM_FLAG_HAS_BIAS;
   }
   params->flags = flags;

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -24,6 +24,7 @@ template <typename AccumScalar, typename DstScalar,
 struct BGemmParams {
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
+  int32_t backtransform_add = 0;
   // post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
@@ -47,6 +48,7 @@ struct BinaryBasicSpec {
   using DstScalar = tDstScalar;
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
+  int32_t backtransform_add = 0;
   // post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
@@ -87,6 +89,7 @@ struct BinaryKernelParams {
   std::int32_t depth;
   std::uint32_t clamp_min;
   std::uint32_t clamp_max;
+  std::int32_t backtransform_add;
   std::uint8_t flags;
   const T zero_data[LhsCols] = {0};
   T dst_tmp_buf[LhsCols * RhsCols];
@@ -115,6 +118,7 @@ inline void MakeBinaryKernelParams(
   if (spec.post_multiply && spec.post_add) {
     flags |= RUY_ASM_FLAG_HAS_BIAS;
   }
+  params->backtransform_add = spec.backtransform_add;
   params->flags = flags;
   params->start_row = start_row;
   params->start_col = start_col;

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -25,11 +25,11 @@ struct BGemmParams {
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
   int32_t backtransform_add = 0;
-  // post_mutiply and post_add are currently float
+  // post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* post_multiply = nullptr;
-  const float* post_add = nullptr;
+  const float* post_activation_multiplier = nullptr;
+  const float* post_activation_bias = nullptr;
   AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
   AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
 };
@@ -49,11 +49,11 @@ struct BinaryBasicSpec {
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
   int32_t backtransform_add = 0;
-  // post_mutiply and post_add are currently float
+  // post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* post_multiply = nullptr;
-  const float* post_add = nullptr;
+  const float* post_activation_multiplier = nullptr;
+  const float* post_activation_bias = nullptr;
   AccumScalar clamp_min = std::numeric_limits<AccumScalar>::lowest();
   AccumScalar clamp_max = std::numeric_limits<AccumScalar>::max();
 
@@ -72,11 +72,11 @@ struct BinaryKernelParams {
   const T* lhs_base_ptr;
   const T* rhs_base_ptr;
   float* dst_base_ptr;
-  // post_mutiply and post_add are currently float
+  // post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  const float* post_multiply;
-  const float* post_add;
+  const float* post_activation_multiplier;
+  const float* post_activation_bias;
   std::int32_t start_row;
   std::int32_t start_col;
   std::int32_t last_row;
@@ -113,9 +113,9 @@ inline void MakeBinaryKernelParams(
       dst->data.get() + start_col * dst->layout.stride + start_row;
 
   std::uint8_t flags = 0;
-  params->post_multiply = spec.post_multiply;
-  params->post_add = spec.post_add;
-  if (spec.post_multiply && spec.post_add) {
+  params->post_activation_multiplier = spec.post_activation_multiplier;
+  params->post_activation_bias = spec.post_activation_bias;
+  if (spec.post_activation_multiplier && spec.post_activation_bias) {
     flags |= RUY_ASM_FLAG_HAS_BIAS;
   }
   params->backtransform_add = spec.backtransform_add;

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -92,11 +92,11 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
           accum += xorpopcount<TBitpacked, AccumScalar>(lhs_val, rhs_val);
         }
         DstScalar dst_val = static_cast<DstScalar>(accum);
-        if (spec.fused_multiply) {
-          dst_val *= spec.fused_multiply[i];
+        if (spec.post_multiply) {
+          dst_val *= spec.post_multiply[i];
         }
-        if (spec.fused_add) {
-          dst_val += spec.fused_add[i];
+        if (spec.post_add) {
+          dst_val += spec.post_add[i];
         }
         *ElementPtr(dst, i, j) = dst_val;
       }

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -95,11 +95,11 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
         accum = spec.backtransform_add - 2 * accum;
         // Post multiply and add are done in float
         DstScalar dst_val = static_cast<DstScalar>(accum);
-        if (spec.post_multiply) {
-          dst_val *= spec.post_multiply[i];
+        if (spec.post_activation_multiplier) {
+          dst_val *= spec.post_activation_multiplier[i];
         }
-        if (spec.post_add) {
-          dst_val += spec.post_add[i];
+        if (spec.post_activation_bias) {
+          dst_val += spec.post_activation_bias[i];
         }
         *ElementPtr(dst, i, j) = dst_val;
       }

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -91,6 +91,9 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
           TBitpacked rhs_val = Element(rhs, k, j);
           accum += xorpopcount<TBitpacked, AccumScalar>(lhs_val, rhs_val);
         }
+        // Backtransform can still be done in int32
+        accum = spec.backtransform_add - 2 * accum;
+        // Post multiply and add are done in float
         DstScalar dst_val = static_cast<DstScalar>(accum);
         if (spec.post_multiply) {
           dst_val *= spec.post_multiply[i];

--- a/larq_compute_engine/core/padding_functor.h
+++ b/larq_compute_engine/core/padding_functor.h
@@ -31,7 +31,7 @@ class PaddingFunctor {
       const Tfilter* filter_data, const int filter_height,
       const int filter_width, const int filter_count, const int input_channels,
       const int dilation_rows, const int dilation_cols,
-      const Tfilter* fused_multiply_data, Tdata* output_cache) {
+      const Tfilter* post_multiply_data, Tdata* output_cache) {
     const int effective_filter_width = (filter_width - 1) * dilation_cols + 1;
     const int effective_filter_height = (filter_height - 1) * dilation_rows + 1;
 
@@ -165,7 +165,7 @@ class PaddingFunctor {
                              filter_count) +
                 y * (effective_filter_width * filter_count) + x * filter_count +
                 out_c;
-            const Tfilter mul = 0.5f * fused_multiply_data[out_c];
+            const Tfilter mul = 0.5f * post_multiply_data[out_c];
             output_cache[output_idx] = mul * corrections[direction];
           }
         }
@@ -182,7 +182,7 @@ class PaddingFunctor {
                   const int dilation_rows, const int dilation_cols,
                   Tdata* output_data, const int output_height,
                   const int output_width,
-                  const Tfilter* fused_multiply_data = nullptr,
+                  const Tfilter* post_multiply_data = nullptr,
                   const Tdata* padding_cache = nullptr) {
     const int effective_filter_width = (filter_width - 1) * dilation_cols + 1;
     const int effective_filter_height = (filter_height - 1) * dilation_rows + 1;
@@ -201,7 +201,7 @@ class PaddingFunctor {
                                        dilation_cols));
       cache_correction_values(filter_data, filter_height, filter_width,
                               filter_count, input_channels, dilation_rows,
-                              dilation_cols, fused_multiply_data,
+                              dilation_cols, post_multiply_data,
                               temp_cache.data());
       padding_cache = temp_cache.data();
     }

--- a/larq_compute_engine/core/padding_functor.h
+++ b/larq_compute_engine/core/padding_functor.h
@@ -31,7 +31,7 @@ class PaddingFunctor {
       const Tfilter* filter_data, const int filter_height,
       const int filter_width, const int filter_count, const int input_channels,
       const int dilation_rows, const int dilation_cols,
-      const Tfilter* post_multiply_data, Tdata* output_cache) {
+      const Tfilter* post_activation_multiplier_data, Tdata* output_cache) {
     const int effective_filter_width = (filter_width - 1) * dilation_cols + 1;
     const int effective_filter_height = (filter_height - 1) * dilation_rows + 1;
 
@@ -165,7 +165,7 @@ class PaddingFunctor {
                              filter_count) +
                 y * (effective_filter_width * filter_count) + x * filter_count +
                 out_c;
-            const Tfilter mul = -1.0f * post_multiply_data[out_c];
+            const Tfilter mul = -1.0f * post_activation_multiplier_data[out_c];
             output_cache[output_idx] = mul * corrections[direction];
           }
         }
@@ -182,7 +182,7 @@ class PaddingFunctor {
                   const int dilation_rows, const int dilation_cols,
                   Tdata* output_data, const int output_height,
                   const int output_width,
-                  const Tfilter* post_multiply_data = nullptr,
+                  const Tfilter* post_activation_multiplier_data = nullptr,
                   const Tdata* padding_cache = nullptr) {
     const int effective_filter_width = (filter_width - 1) * dilation_cols + 1;
     const int effective_filter_height = (filter_height - 1) * dilation_rows + 1;
@@ -201,7 +201,7 @@ class PaddingFunctor {
                                        dilation_cols));
       cache_correction_values(filter_data, filter_height, filter_width,
                               filter_count, input_channels, dilation_rows,
-                              dilation_cols, post_multiply_data,
+                              dilation_cols, post_activation_multiplier_data,
                               temp_cache.data());
       padding_cache = temp_cache.data();
     }

--- a/larq_compute_engine/core/padding_functor.h
+++ b/larq_compute_engine/core/padding_functor.h
@@ -165,7 +165,7 @@ class PaddingFunctor {
                              filter_count) +
                 y * (effective_filter_width * filter_count) + x * filter_count +
                 out_c;
-            const Tfilter mul = 0.5f * post_multiply_data[out_c];
+            const Tfilter mul = -1.0f * post_multiply_data[out_c];
             output_cache[output_idx] = mul * corrections[direction];
           }
         }

--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -37,8 +37,8 @@ TODO
   let arguments = (ins
     TensorOf<[F32]>:$input,
     TensorOf<[F32]>:$filter,
-    TensorOf<[F32]>:$fused_multiply,
-    TensorOf<[F32]>:$fused_add,
+    TensorOf<[F32]>:$post_multiply,
+    TensorOf<[F32]>:$post_add,
 
     I64ArrayAttr:$strides,
     TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,

--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -37,8 +37,8 @@ TODO
   let arguments = (ins
     TensorOf<[F32]>:$input,
     TensorOf<[F32]>:$filter,
-    TensorOf<[F32]>:$post_multiply,
-    TensorOf<[F32]>:$post_add,
+    TensorOf<[F32]>:$post_activation_multiplier,
+    TensorOf<[F32]>:$post_activation_bias,
 
     I64ArrayAttr:$strides,
     TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: @fuse_add_into_bconv2d
 func @fuse_add_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<1.5> : tensor<16xf32>
-  %fused_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %fused_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.add"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -17,8 +17,8 @@ func @fuse_add_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_sub_into_bconv2d
 func @fuse_sub_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<0.5> : tensor<16xf32>
-  %fused_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %fused_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.sub"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -30,9 +30,9 @@ func @fuse_sub_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_div_into_bconv2d
 func @fuse_div_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<0.5> : tensor<16xf32>
-  %fused_add = constant dense<1.5> : tensor<16xf32>
-  %fused_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %fused_multiply, %fused_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_add = constant dense<1.5> : tensor<16xf32>
+  %post_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_multiply, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.div"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -45,9 +45,9 @@ func @fuse_div_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_mul_into_bconv2d
 func @fuse_mul_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<2.0> : tensor<16xf32>
-  %fused_add = constant dense<1.5> : tensor<16xf32>
-  %fused_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %fused_multiply, %fused_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_add = constant dense<1.5> : tensor<16xf32>
+  %post_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_multiply, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.mul"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: @fuse_add_into_bconv2d
 func @fuse_add_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<1.5> : tensor<16xf32>
-  %post_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_activation_bias = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_activation_bias) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.add"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -17,8 +17,8 @@ func @fuse_add_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_sub_into_bconv2d
 func @fuse_sub_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<0.5> : tensor<16xf32>
-  %post_add = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_activation_bias = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %arg2, %post_activation_bias) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.sub"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -30,9 +30,9 @@ func @fuse_sub_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_div_into_bconv2d
 func @fuse_div_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<0.5> : tensor<16xf32>
-  %post_add = constant dense<1.5> : tensor<16xf32>
-  %post_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_multiply, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_activation_bias = constant dense<1.5> : tensor<16xf32>
+  %post_activation_multiplier = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_activation_multiplier, %post_activation_bias) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.div"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 
@@ -45,9 +45,9 @@ func @fuse_div_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3
 // CHECK-LABEL: @fuse_mul_into_bconv2d
 func @fuse_mul_into_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>) -> tensor<256x30x30x16xf32> {
   %cst = constant dense<2.0> : tensor<16xf32>
-  %post_add = constant dense<1.5> : tensor<16xf32>
-  %post_multiply = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_multiply, %post_add) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  %post_activation_bias = constant dense<1.5> : tensor<16xf32>
+  %post_activation_multiplier = constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %0 = "tf.LqceBconv2d64"(%arg0, %arg1, %post_activation_multiplier, %post_activation_bias) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   %1 = "tfl.mul"(%0, %cst) {fused_activation_function = "NONE"} : (tensor<256x30x30x16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %1 : tensor<256x30x30x16xf32>
 

--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -20,10 +20,10 @@ func @fuse_bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
   return %1 : tensor<1x112x112x2xf32>
 
   // CHECK: %cst = constant
-  // CHECK: %[[fused_multiply:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
-  // CHECK: %[[fused_add:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
+  // CHECK: %[[post_multiply:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
+  // CHECK: %[[post_add:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
   // CHECK-NEXT: %[[transpose:.*]] = "tf.Transpose"(%cst
-  // CHECK-NEXT: %[[conv:.*]] = "tf.LqceBconv2d64"(%arg0, %[[transpose]], %[[fused_multiply]], %[[fused_add]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 0 : i32, padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x112x112x2xf32>
+  // CHECK-NEXT: %[[conv:.*]] = "tf.LqceBconv2d64"(%arg0, %[[transpose]], %[[post_multiply]], %[[post_add]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 0 : i32, padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x112x112x2xf32>
   // CHECK-NEXT: return %[[conv]]
 }
 

--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -20,8 +20,8 @@ func @fuse_bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
   return %1 : tensor<1x112x112x2xf32>
 
   // CHECK: %cst = constant
-  // CHECK: %[[fused_multiply:.*]] = constant dense<-2.000000e+00> : tensor<2xf32>
-  // CHECK: %[[fused_add:.*]] = constant dense<4.000000e+00> : tensor<2xf32>
+  // CHECK: %[[fused_multiply:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
+  // CHECK: %[[fused_add:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
   // CHECK-NEXT: %[[transpose:.*]] = "tf.Transpose"(%cst
   // CHECK-NEXT: %[[conv:.*]] = "tf.LqceBconv2d64"(%arg0, %[[transpose]], %[[fused_multiply]], %[[fused_add]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 0 : i32, padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x112x112x2xf32>
   // CHECK-NEXT: return %[[conv]]
@@ -50,8 +50,8 @@ func @fuse_bconv2d_padding(%arg0: tensor<256x32x32x3xf32>) -> tensor<256x16x16x1
   %2 = "tf.Conv2D"(%1, %cst) {padding = "VALID", strides = [1, 2, 2, 1]} : (tensor<256x34x34x3xf32>, tensor<3x3x3x16xf32>) -> tensor<256x16x16x16xf32>
   return %2 : tensor<256x16x16x16xf32>
 
-  // CHECK:  %[[CST1:.*]] = constant dense<-2.000000e+00> : tensor<16xf32>
-  // CHECK:  %[[CST2:.*]] = constant dense<2.700000e+01> : tensor<16xf32>
+  // CHECK:  %[[CST1:.*]] = constant dense<1.000000e+00> : tensor<16xf32>
+  // CHECK:  %[[CST2:.*]] = constant dense<0.000000e+00> : tensor<16xf32>
   // CHECK:  %[[TRP:.*]] = "tf.Transpose"
   // CHECK:  %[[CONV:.*]] = "tf.LqceBconv2d64"(%arg0, %[[TRP]], %[[CST1]], %[[CST2]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 1 : i32, padding = "SAME", strides = [1, 2, 2, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x16x16x16xf32>
 }

--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -20,10 +20,10 @@ func @fuse_bconv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x112x112x2xf32> {
   return %1 : tensor<1x112x112x2xf32>
 
   // CHECK: %cst = constant
-  // CHECK: %[[post_multiply:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
-  // CHECK: %[[post_add:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
+  // CHECK: %[[post_activation_multiplier:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
+  // CHECK: %[[post_activation_bias:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
   // CHECK-NEXT: %[[transpose:.*]] = "tf.Transpose"(%cst
-  // CHECK-NEXT: %[[conv:.*]] = "tf.LqceBconv2d64"(%arg0, %[[transpose]], %[[post_multiply]], %[[post_add]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 0 : i32, padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x112x112x2xf32>
+  // CHECK-NEXT: %[[conv:.*]] = "tf.LqceBconv2d64"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]]) {data_format = "NHWC", dilations = [1, 1, 1, 1], filter_format = "OHWI", pad_values = 0 : i32, padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x112x112x2xf32>
   // CHECK-NEXT: return %[[conv]]
 }
 

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -12,11 +12,11 @@ def HasOneUse : Constraint<CPred<"$0->hasOneUse()">>;
 // TODO: Check shapes before fusing
 multiclass FuseAddOrSubWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$output $input, $filter,
-                          $post_multiply, (ConstantOp F32ElementsAttr:$post_add), $strides,
+                          $post_activation_multiplier, (ConstantOp F32ElementsAttr:$post_activation_bias), $strides,
                           $padding, $pad_values, $data_format, $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), TFL_AF_None),
-            (TF_LqceBconv2d64Op $input, $filter, $post_multiply,
-                          (binaryOp (ConstantOp $post_add), (ConstantOp $value), TFL_AF_None),
+            (TF_LqceBconv2d64Op $input, $filter, $post_activation_multiplier,
+                          (binaryOp (ConstantOp $post_activation_bias), (ConstantOp $value), TFL_AF_None),
                           $strides, $padding, $pad_values, $data_format,
                           $dilations, $filter_format),
             [(HasOneUse $output)]>;
@@ -27,15 +27,15 @@ foreach binaryOp = [TFL_AddOp, TFL_SubOp] in
 // TODO: Check shapes before fusing
 multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$conv_output $input, $filter,
-                        (ConstantOp F32ElementsAttr:$post_multiply),
-                        (ConstantOp F32ElementsAttr:$post_add),
+                        (ConstantOp F32ElementsAttr:$post_activation_multiplier),
+                        (ConstantOp F32ElementsAttr:$post_activation_bias),
                         $strides, $padding, $pad_values, $data_format,
                         $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), $TFL_AF_None),
             (TF_LqceBconv2d64Op $input, $filter,
-                        (binaryOp (ConstantOp $post_multiply),
+                        (binaryOp (ConstantOp $post_activation_multiplier),
                                   (ConstantOp $value), TFL_AF_None),
-                        (binaryOp (ConstantOp $post_add),
+                        (binaryOp (ConstantOp $post_activation_bias),
                                   (ConstantOp $value), TFL_AF_None),
                         $strides, $padding, $pad_values, $data_format,
                         $dilations, $filter_format),

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -12,11 +12,11 @@ def HasOneUse : Constraint<CPred<"$0->hasOneUse()">>;
 // TODO: Check shapes before fusing
 multiclass FuseAddOrSubWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$output $input, $filter,
-                          $fused_multiply, (ConstantOp F32ElementsAttr:$fused_add), $strides,
+                          $post_multiply, (ConstantOp F32ElementsAttr:$post_add), $strides,
                           $padding, $pad_values, $data_format, $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), TFL_AF_None),
-            (TF_LqceBconv2d64Op $input, $filter, $fused_multiply,
-                          (binaryOp (ConstantOp $fused_add), (ConstantOp $value), TFL_AF_None),
+            (TF_LqceBconv2d64Op $input, $filter, $post_multiply,
+                          (binaryOp (ConstantOp $post_add), (ConstantOp $value), TFL_AF_None),
                           $strides, $padding, $pad_values, $data_format,
                           $dilations, $filter_format),
             [(HasOneUse $output)]>;
@@ -27,15 +27,15 @@ foreach binaryOp = [TFL_AddOp, TFL_SubOp] in
 // TODO: Check shapes before fusing
 multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp (TF_LqceBconv2d64Op:$conv_output $input, $filter,
-                        (ConstantOp F32ElementsAttr:$fused_multiply),
-                        (ConstantOp F32ElementsAttr:$fused_add),
+                        (ConstantOp F32ElementsAttr:$post_multiply),
+                        (ConstantOp F32ElementsAttr:$post_add),
                         $strides, $padding, $pad_values, $data_format,
                         $dilations, $filter_format),
                       (ConstantOp F32ElementsAttr:$value), $TFL_AF_None),
             (TF_LqceBconv2d64Op $input, $filter,
-                        (binaryOp (ConstantOp $fused_multiply),
+                        (binaryOp (ConstantOp $post_multiply),
                                   (ConstantOp $value), TFL_AF_None),
-                        (binaryOp (ConstantOp $fused_add),
+                        (binaryOp (ConstantOp $post_add),
                                   (ConstantOp $value), TFL_AF_None),
                         $strides, $padding, $pad_values, $data_format,
                         $dilations, $filter_format),

--- a/larq_compute_engine/mlir/transforms/prepare_patterns.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns.td
@@ -23,16 +23,15 @@ class I32VectorElementsAttr<int len> : ElementsAttrBase<
     "RankedTensorType::get({" # len # "}, $_builder.getIntegerType(32)), $0)";
 }
 
-def GetBias : NativeCodeCall<"GetBias($0)">;
-def GetMultiplier : NativeCodeCall<"GetMultiplier($0)">;
+class GetConstantVector<string val> : NativeCodeCall<"GetConstantVector($0, " # val # ")">;
 def BinaryFilter : Constraint<CPred<"IsBinaryFilter($0)">>;
 
 def : Pat<(TF_Conv2DOp (TF_LqceBsignOp $input), (ConstantOp $filter), $strides, $use_cudnn,
                        $padding, $explicit_padding, IsDataFormatNHWC: $data_format, $dilations),
           (TF_LqceBconv2d64Op $input,
             (TF_TransposeOp (ConstantOp $filter), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
-            (ConstantOp (GetMultiplier $filter)),
-            (ConstantOp (GetBias $filter)),
+            (ConstantOp (GetConstantVector<"1.0f"> $filter)),
+            (ConstantOp (GetConstantVector<"0.0f"> $filter)),
             $strides, $padding, ConstantAttr<I32Attr, "0">, $data_format,
             $dilations, ConstantAttr<StrAttr, "OHWI">),
           [(BinaryFilter $filter)], (addBenefit 90)>;
@@ -52,8 +51,8 @@ def : Pat<(TF_Conv2DOp: $output
             $explicit_padding, IsDataFormatNHWC: $data_format, $dilations),
           (TF_LqceBconv2d64Op $input,
             (TF_TransposeOp (ConstantOp $filter), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
-            (ConstantOp (GetMultiplier $filter)),
-            (ConstantOp (GetBias $filter)),
+            (ConstantOp (GetConstantVector<"1.0f"> $filter)),
+            (ConstantOp (GetConstantVector<"0.0f"> $filter)),
             $strides,
             ConstantAttr<StrAttr, "SAME">,
             ConstantAttr<I32Attr, "1">,

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -160,21 +160,21 @@ TfLiteStatus Prepare(KernelType kernel_type, const int bitwidth,
 
   const auto* input = GetInput(context, node, 0);
   const auto* filter = GetInput(context, node, 1);
-  const auto* fused_multiply = GetInput(context, node, 2);
-  const auto* fused_add = GetInput(context, node, 3);
+  const auto* post_multiply = GetInput(context, node, 2);
+  const auto* post_add = GetInput(context, node, 3);
   auto* output = GetOutput(context, node, 0);
 
   TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
   TF_LITE_ENSURE_EQ(context, NumDimensions(filter), 4);
-  TF_LITE_ENSURE_EQ(context, NumDimensions(fused_multiply), 1);
-  TF_LITE_ENSURE_EQ(context, NumDimensions(fused_add), 1);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(post_multiply), 1);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(post_add), 1);
 
-  // The inputs fused_mutiply and fused_add are currently float
+  // The inputs post_mutiply and post_add are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
   TF_LITE_ENSURE_EQ(context, input->type, kTfLiteFloat32);
-  TF_LITE_ENSURE_EQ(context, fused_multiply->type, kTfLiteFloat32);
-  TF_LITE_ENSURE_EQ(context, fused_add->type, kTfLiteFloat32);
+  TF_LITE_ENSURE_EQ(context, post_multiply->type, kTfLiteFloat32);
+  TF_LITE_ENSURE_EQ(context, post_add->type, kTfLiteFloat32);
   TF_LITE_ENSURE_EQ(context, output->type, kTfLiteFloat32);
 
   // reading the input dimensions
@@ -194,9 +194,9 @@ TfLiteStatus Prepare(KernelType kernel_type, const int bitwidth,
   conv_params->filter_width = filter->dims->data[2];
   TF_LITE_ENSURE_EQ(context, conv_params->channels_in, filter->dims->data[3]);
 
-  TF_LITE_ENSURE_EQ(context, fused_multiply->dims->data[0],
+  TF_LITE_ENSURE_EQ(context, post_multiply->dims->data[0],
                     conv_params->channels_out);
-  TF_LITE_ENSURE_EQ(context, fused_add->dims->data[0],
+  TF_LITE_ENSURE_EQ(context, post_add->dims->data[0],
                     conv_params->channels_out);
 
   // computing the padding and output values (height, width)
@@ -384,8 +384,8 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
              TfLiteBConv2DParams* params) {
   const auto* input = GetInput(context, node, 0);
   const auto* filter = GetInput(context, node, 1);
-  const auto* fused_multiply = GetInput(context, node, 2);
-  const auto* fused_add = GetInput(context, node, 3);
+  const auto* post_multiply = GetInput(context, node, 2);
+  const auto* post_add = GetInput(context, node, 3);
   auto* output = GetOutput(context, node, 0);
 
   TfLiteTensor* im2col = params->need_im2col
@@ -409,7 +409,7 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
     padding_functor.cache_correction_values(
         GetTensorData<T>(filter), params->filter_height, params->filter_width,
         params->channels_out, params->channels_in, params->dilations[1],
-        params->dilations[2], GetTensorData<T>(fused_multiply),
+        params->dilations[2], GetTensorData<T>(post_multiply),
         params->padding_buffer.data());
     params->is_padding_correction_cached = true;
   }
@@ -465,7 +465,7 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
       op_params, GetTensorShape(input), GetTensorData<T>(input),
       GetTensorShape(filter),
       reinterpret_cast<TBitpacked*>(params->bitpacked_weights_buffer.data()),
-      GetTensorData<float>(fused_multiply), GetTensorData<float>(fused_add),
+      GetTensorData<float>(post_multiply), GetTensorData<float>(post_add),
       GetTensorShape(output), GetTensorData<T>(output), GetTensorShape(im2col),
       GetTensorData<T>(im2col), params->bitpack_before_im2col,
       params->padding_buffer.data(), params->pad_value,

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -58,15 +58,14 @@ inline void im2col(const ConvParams& params, const RuntimeShape& input_shape,
   result_shape.ReplaceWith(shape->DimensionsCount(), shape->DimsData());
 }
 
-// The inputs fused_mutiply and fused_add are currently float
+// The inputs post_mutiply and post_add are currently float
 // in order to accomodate for batchnorm scales
 // Later this might be changed to the int8 system of multipliers+shifts
 template <class T, class TBitpacked>
 inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                     const T* input_data, const RuntimeShape& filter_shape,
                     const TBitpacked* packed_filter_data,
-                    const float* fused_multiply_data,
-                    const float* fused_add_data,
+                    const float* post_multiply_data, const float* post_add_data,
                     const RuntimeShape& output_shape, T* output_data,
                     const RuntimeShape& im2col_shape, T* im2col_data,
                     bool bitpack_before_im2col, T* padding_buffer,
@@ -169,8 +168,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
 
   // Accumulation type, destination type
   BGemmParams<std::int32_t, T> gemm_params;
-  gemm_params.fused_multiply = fused_multiply_data;
-  gemm_params.fused_add = fused_add_data;
+  gemm_params.post_multiply = post_multiply_data;
+  gemm_params.post_add = post_add_data;
 
   // #if defined(TF_LITE_USE_CBLAS) && defined(__APPLE__)
 
@@ -209,7 +208,7 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                       filter_height, filter_width, output_depth, stride_height,
                       stride_width, dilation_height_factor,
                       dilation_width_factor, output_data, output_height,
-                      output_width, fused_multiply_data, padding_buffer);
+                      output_width, post_multiply_data, padding_buffer);
     }
   }
 }

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -58,14 +58,15 @@ inline void im2col(const ConvParams& params, const RuntimeShape& input_shape,
   result_shape.ReplaceWith(shape->DimensionsCount(), shape->DimsData());
 }
 
-// The inputs post_mutiply and post_add are currently float
+// The inputs post_mutiply and post_activation_bias are currently float
 // in order to accomodate for batchnorm scales
 // Later this might be changed to the int8 system of multipliers+shifts
 template <class T, class TBitpacked>
 inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                     const T* input_data, const RuntimeShape& filter_shape,
                     const TBitpacked* packed_filter_data,
-                    const float* post_multiply_data, const float* post_add_data,
+                    const float* post_activation_multiplier_data,
+                    const float* post_activation_bias_data,
                     const RuntimeShape& output_shape, T* output_data,
                     const RuntimeShape& im2col_shape, T* im2col_data,
                     bool bitpack_before_im2col, T* padding_buffer,
@@ -170,8 +171,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
   BGemmParams<std::int32_t, T> gemm_params;
   gemm_params.backtransform_add =
       filter_shape.Dims(1) * filter_shape.Dims(2) * filter_shape.Dims(3);
-  gemm_params.post_multiply = post_multiply_data;
-  gemm_params.post_add = post_add_data;
+  gemm_params.post_activation_multiplier = post_activation_multiplier_data;
+  gemm_params.post_activation_bias = post_activation_bias_data;
 
   // #if defined(TF_LITE_USE_CBLAS) && defined(__APPLE__)
 
@@ -210,7 +211,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                       filter_height, filter_width, output_depth, stride_height,
                       stride_width, dilation_height_factor,
                       dilation_width_factor, output_data, output_height,
-                      output_width, post_multiply_data, padding_buffer);
+                      output_width, post_activation_multiplier_data,
+                      padding_buffer);
     }
   }
 }

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -168,6 +168,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
 
   // Accumulation type, destination type
   BGemmParams<std::int32_t, T> gemm_params;
+  gemm_params.backtransform_add =
+      filter_shape.Dims(1) * filter_shape.Dims(2) * filter_shape.Dims(3);
   gemm_params.post_multiply = post_multiply_data;
   gemm_params.post_add = post_add_data;
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?

This PR is needed for a next PR where we support fused activation functions. We will then have the following computations applied at the end of the bgemm kernel:
- backtransformation `x = n - 2 * x` (can be done in `int32`)
- fused activation `x = relu(x)`  (can be done in `int32` or `float`)
- post-multiply and post-add `x = a + b * x`  (must be done in `float`. Comes from potential BatchNorm layers or other `Mul` and `Add` layers).

Currently there is no fused activation, so the backtransform and post-multiply&add are currently merged into one multiply&add.  This PR will split those two, so that its ready for fused activations.

The PR also renames `fused_{add,multiply}` to `post_{add,multiply}`, to make it extra clear that this transformation comes *after* the activation function (which is usually the final thing in an op).

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
The C++ unit tests have been updated to no longer include the backtransform into the post-multiply&add.

## Benchmark Results
<!-- Please provide new benchmark results on supported platforms if you believe these changes affect the LCE latency performance. -->
Since the backtransform and post-multiply&add are now separate, it slightly slows things down.

On the Amsterdam Pixel 1 phone, the inference time of quicknet goes up from `22.2 ms` to `22.5 ms` (1.4% slowdown).
However, once we actually fuse the batchnorm and activation, the time becomes `21.3 ms` (4% speedup). Since this speedup will apply to all networks in larq zoo, it is worth it.

As @AdamHillier mentioned, we could always provide a separate bgemm kernel for the case where there is no activation function, and there we can keep the backtransform fused.

