### PR TITLE
Cleanup LCE AAR build

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -116,8 +116,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-        with:
-          submodules: true
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 > bazelisk
@@ -128,4 +126,4 @@ jobs:
       - name: "Download and install Android NDK/SDK"
         run: ./third_party/install_android.sh
       - name: "Build LCE AAR"
-        run: ./larq_compute_engine/tflite/java/build_lce_aar.sh
+        run: BUILDER=./bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh

--- a/larq_compute_engine/tflite/java/build_lce_aar.sh
+++ b/larq_compute_engine/tflite/java/build_lce_aar.sh
@@ -13,7 +13,7 @@ trap "rm -rf $TMPDIR" EXIT
 
 VERSION=1.0
 
-BUILDER=bazel
+BUILDER="${BUILDER:-bazelisk}"
 BASEDIR=larq_compute_engine/tflite
 CROSSTOOL="//external:android/crosstool"
 HOST_CROSSTOOL="@bazel_tools//tools/cpp:toolchain"
@@ -26,7 +26,7 @@ test -d $BASEDIR || (echo "Aborting: not at top-level build directory"; exit 1)
 function build_lce_aar() {
   local OUTDIR=$1
   $BUILDER build $BUILD_OPTS $BASEDIR/java:tensorflow-lite-lce.aar
-  unzip -d $OUTDIR $BUILDER-bin/$BASEDIR/java/tensorflow-lite-lce.aar
+  unzip -d $OUTDIR bazel-bin/$BASEDIR/java/tensorflow-lite-lce.aar
   # targetSdkVersion is here to prevent the app from requesting spurious
   # permissions, such as permission to make phone calls. It worked for v1.0,
   # but minSdkVersion might be the preferred way to handle this.
@@ -34,7 +34,7 @@ function build_lce_aar() {
 
   $BUILDER build $BUILD_OPTS $BASEDIR/java:tensorflowlite_java
   # override the classes.jar with the Java sources from TF Lite Java API
-  cp $BUILDER-bin/$BASEDIR/java/libtensorflowlite_java.jar $OUTDIR/classes.jar
+  cp bazel-bin/$BASEDIR/java/libtensorflowlite_java.jar $OUTDIR/classes.jar
 }
 
 rm -rf $TMPDIR


### PR DESCRIPTION
## What do these changes do?
This switches to `bazelisk` for building LCE AAR which makes it consistent with our build instructions and will prevent version conflicts (required for #258).
~~This PR also adds some missing transient dependencies to the `tf_decode_constant_pass` (see https://github.com/tensorflow/tensorflow/commit/d8ee1d31d5618b1ca3313a18141937ec0e3d10e1).~~

## How Has This Been Tested?
No functional changes. CI will catch errors
