### PR TITLE
remove armv7 android ABI from LCE Lite AAR

### DIFF
--- a/larq_compute_engine/tflite/java/build_lce_aar.sh
+++ b/larq_compute_engine/tflite/java/build_lce_aar.sh
@@ -12,7 +12,7 @@ TMPDIR=`mktemp -d`
 trap "rm -rf $TMPDIR" EXIT
 
 AAR_NAME=lce-lite
-VERSION=0.1.2
+VERSION=$(git describe --tags)
 
 BUILDER=bazel
 BASEDIR=larq_compute_engine/tflite

--- a/larq_compute_engine/tflite/java/build_lce_aar.sh
+++ b/larq_compute_engine/tflite/java/build_lce_aar.sh
@@ -11,14 +11,15 @@ set -x
 TMPDIR=`mktemp -d`
 trap "rm -rf $TMPDIR" EXIT
 
-VERSION=1.0
+AAR_NAME=lce-lite
+VERSION=0.1.2
 
 BUILDER=bazel
 BASEDIR=larq_compute_engine/tflite
 CROSSTOOL="//external:android/crosstool"
 HOST_CROSSTOOL="@bazel_tools//tools/cpp:toolchain"
 
-BUILD_OPTS="-c opt --fat_apk_cpu=x86,x86_64,arm64-v8a,armeabi-v7a"
+BUILD_OPTS="-c opt --fat_apk_cpu=x86,x86_64,arm64-v8a"
 CROSSTOOL_OPTS="--crosstool_top=$CROSSTOOL --host_crosstool_top=$HOST_CROSSTOOL"
 
 test -d $BASEDIR || (echo "Aborting: not at top-level build directory"; exit 1)
@@ -43,11 +44,11 @@ mkdir -p $TMPDIR/jni
 build_lce_aar $TMPDIR
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    AAR_FILE=`realpath tflite-lce-${VERSION}.aar`
+    AAR_FILE=`realpath $AAR_NAME-${VERSION}.aar`
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # on macOS get 'grealpath' by installing 'coreutils' package:
     # "brew install coreutils"
-    AAR_FILE=`grealpath tflite-lce-${VERSION}.aar`
+    AAR_FILE=`grealpath $AAR_NAME-${VERSION}.aar`
 else
     # Unknown.
     echo "ERROR: could not detect the OS."


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
- remove creating armv7 android ABI from script so no one accidentally use the unoptimized ops ( we still build the x86 ABI since it is used by default for the android emulator in Android Studio) 
- add a new variable for version. @Tombana, @lgeiger how can we automatically sync this version number with release version? 

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
N/A
## Benchmark Results
<!-- Please provide new benchmark results on supported platforms if you believe these changes affect the LCE latency performance. -->
N/A
## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A