### PR TITLE
Switch converter tests to be Python only

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -96,36 +96,21 @@ jobs:
       - name: Run End2End tests
         run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false
 
-  MLIR_Python:
+  ConverterPython:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0]
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
-      - name: Install Bazelisk
-        run: |
-          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
-          chmod +x bazelisk
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: Configure Bazel
-        run: ./configure.sh
-      - name: Install pip dependencies
-        run: pip install tensorflow==2.1.0 larq_zoo==0.5.0 pytest tensorflow_datasets==1.3.2 --no-cache
-      - name: Run converter tests TF 2.1
-        run: ./bazelisk run larq_compute_engine/mlir:converter_test --distinct_host_configuration=false
-      - name: Install TF 2.0
-        run: pip install tensorflow==2.0.0 --no-cache
-      - name: Run converter tests TF 2.0
-        run: ./bazelisk run larq_compute_engine/mlir:converter_test --distinct_host_configuration=false
-      - name: Install TF 1.15
-        run: pip install tensorflow==1.15 --no-cache
-      - name: Run converter tests TF 1.15
-        run: ./bazelisk run larq_compute_engine/mlir:converter_test --distinct_host_configuration=false
-      - name: Install TF 1.14
-        run: pip install tensorflow==1.14 --no-cache
-      - name: Run converter tests TF 1.14
-        run: ./bazelisk run larq_compute_engine/mlir:converter_test --distinct_host_configuration=false
+      - name: Install dependencies
+        run: pip install tensorflow==${{matrix.tf-version}} larq_zoo==0.5.0 tensorflow_datasets==1.3.2 -e . --no-cache
+      - name: Run Converter test
+        run: python larq_compute_engine/mlir/python/converter_test.py
 
   Android_AAR:
     runs-on: ubuntu-latest

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -168,14 +168,6 @@ py_library(
     ],
 )
 
-py_test(
-    name = "converter_test",
-    srcs = ["python/converter_test.py"],
-    deps = [
-        ":converter",
-    ],
-)
-
 exports_files([
     "python/converter.py",
     "__init__.py",

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 import larq_zoo as lqz
+from tensorflow.python.eager import context
 
 sys.modules["larq_compute_engine.mlir._graphdef_tfl_flatbuffer"] = mock.MagicMock()
 
@@ -14,9 +15,9 @@ from larq_compute_engine.mlir._graphdef_tfl_flatbuffer import (
 
 class TestConverter(unittest.TestCase):
     def test_larq_zoo_models(self):
-        model = lqz.BinaryResNetE18(weights=None)
-
-        convert_keras_model(model)
+        with context.eager_mode():
+            model = lqz.BinaryResNetE18(weights=None)
+            convert_keras_model(model)
         mocked_converter.assert_called_once_with(
             mock.ANY, ["input_1"], ["DT_FLOAT"], [[1, 224, 224, 3]], ["Identity"],
         )


### PR DESCRIPTION
## What do these changes do?
This switches the converter tests to be Python only since the conversion process is now handled by the End2End tests from #269 and the MLIR LIT unittests. The only point of the converter test is now to ensure that our Python code is compatible with multiple TensorFlow version.
This allows us to easily parallelize the testing which should further speed up CI.

## How Has This Been Tested?
CI