### PR TITLE
(ci-skip) Simplify pip package publishing

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,6 +9,6 @@ jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: toolmantim/release-drafter@v5.6.1
+      - uses: toolmantim/release-drafter@v5.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: lce-release
 
 on:
-  push:
+  release:
+    types: [published]
     tags:
       - v*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,6 @@ We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html), [`black`]
 
 2. Wait until your PR is reviewed and merged.
 
-3. Create and push a new tag from the latest `master` branch (e.g. `v0.7.0`).
+3. Go to the [GitHub releases](https://github.com/larq/compute-engine/releases), edit the release notes of the draft release, change the tag to the desired version (e.g. `v0.7.0`) and hit "Publish release".
 
-   ```shell
-   git checkout master
-   git pull
-   git tag <version number>
-   git push --tags
-   ```
-
-4. A [GitHub action](https://github.com/larq/compute-engine/actions) will automatically build wheels publish a release to [PyPI](https://pypi.org/) based on the tag.
+4. A [GitHub action](https://github.com/larq/compute-engine/actions) will automatically publish a release to [PyPI](https://pypi.org/) based on the tag.


### PR DESCRIPTION
This allows us to publish a new release directly from the github UI. This process has been tested in `larq` and works well.
