### PR TITLE
Add +1 padding to the end2end test

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Configure Bazel
         run: ./configure.sh
       - name: Install pip dependencies
-        run: pip install tensorflow-cpu==2.1.0 larq_zoo==0.5.0 pytest tensorflow_datasets==1.3.2 --no-cache
+        run: pip install tensorflow==2.1.0 larq~=0.9.1 larq_zoo==1.0.b3 pytest tensorflow_datasets==1.3.2 --no-cache
       - name: Run End2End tests
         run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false
 
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow==${{matrix.tf-version}} larq_zoo==0.5.0 tensorflow_datasets==1.3.2 -e . --no-cache
+        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.9.1 larq_zoo==1.0.b3 tensorflow_datasets==1.3.2 -e . --no-cache
       - name: Run Converter test
         run: python larq_compute_engine/mlir/python/converter_test.py
 

--- a/examples/converter_examples.py
+++ b/examples/converter_examples.py
@@ -4,9 +4,9 @@ import larq_compute_engine as lce
 import larq_zoo as lqz
 
 # Example of converting a model from Larq Zoo to TF lite
-model = lqz.BinaryResNetE18(weights="imagenet")
+model = lqz.sota.QuickNet(weights="imagenet")
 converted = lce.convert_keras_model(model)
-with open("binaryresnete18.tflite", "wb") as f:
+with open("quicknet.tflite", "wb") as f:
     f.write(converted)
 
 # Example of converting an h5 file

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -16,7 +16,7 @@ from larq_compute_engine.mlir._graphdef_tfl_flatbuffer import (
 class TestConverter(unittest.TestCase):
     def test_larq_zoo_models(self):
         with context.eager_mode():
-            model = lqz.BinaryResNetE18(weights=None)
+            model = lqz.sota.QuickNet(weights=None)
             convert_keras_model(model)
         mocked_converter.assert_called_once_with(
             mock.ANY, ["input_1"], ["DT_FLOAT"], [[1, 224, 224, 3]], ["Identity"],

--- a/larq_compute_engine/tests/end2end_test.py
+++ b/larq_compute_engine/tests/end2end_test.py
@@ -18,7 +18,7 @@ def toy_model(**kwargs):
                 filters=32,
                 kernel_size=3,
                 padding=padding,
-                # pad_values=pad_values,
+                pad_values=pad_values,
                 input_quantizer="ste_sign",
                 kernel_quantizer="ste_sign",
                 use_bias=False,
@@ -52,7 +52,7 @@ def preprocess(data):
 
 
 @pytest.mark.parametrize(
-    "model_cls", [toy_model, lqz.BinaryResNetE18],
+    "model_cls", [toy_model, lqz.sota.QuickNet],
 )
 def test_simple_model(model_cls):
     model = model_cls(weights="imagenet")


### PR DESCRIPTION
## What do these changes do?
This upgrades larq to 0.9.1 in order to enable +1 padding in the end2end tests. This also switches the end2end test to use QuickNet which is now available in larq-zoo 1.0.0b3.

## How Has This Been Tested?
CI

## Related issue number
Closes #278 
