### PR TITLE
Implement SSE 4.2 and VNNI placeholder kernels.

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -61,6 +61,52 @@ struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar, Spec> {
   }
 };
 
+template <typename LhsScalar, typename RhsScalar, typename DstScalar,
+          typename Spec>
+struct BgemmKernel<ruy::Path::kAvxVnni, LhsScalar, RhsScalar, DstScalar, Spec> {
+  Tuning tuning = Tuning::kAuto;
+  using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
+  using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
+  explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
+  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
+           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
+           int start_row, int start_col, int end_row, int end_col,
+           ruy::Matrix<DstScalar>* dst) const {
+    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
+                  "Inputs to binary kernel should have the same type.");
+    static_assert(
+        // std::is_unsigned<LhsScalar>::value &&
+        std::is_integral<LhsScalar>::value,
+        "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
+    // TODO: not implemented -> fallback to standard cpp
+  }
+};
+
+template <typename LhsScalar, typename RhsScalar, typename DstScalar,
+          typename Spec>
+struct BgemmKernel<Path::kSse42, LhsScalar, RhsScalar, DstScalar, Spec> {
+  Tuning tuning = Tuning::kAuto;
+  using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
+  using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
+  explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
+  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
+           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
+           int start_row, int start_col, int end_row, int end_col,
+           ruy::Matrix<DstScalar>* dst) const {
+    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
+                  "Inputs to binary kernel should have the same type.");
+    static_assert(
+        // std::is_unsigned<LhsScalar>::value &&
+        std::is_integral<LhsScalar>::value,
+        "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
+    // TODO: not implemented -> fallback to standard cpp
+  }
+};
+
 #endif  // RUY_PLATFORM(X86)
 
 #endif  // COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_X86_H_

--- a/larq_compute_engine/core/bgemm_trmul_params.h
+++ b/larq_compute_engine/core/bgemm_trmul_params.h
@@ -173,7 +173,7 @@ void PopulateBinaryTrMulParamsAllCompiledPaths(ruy::Path the_path,
                              Spec>::Search(the_path, params);
 }
 
-template <Path CompiledPaths, typename LhsScalar, typename RhsScalar,
+template <ruy::Path CompiledPaths, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename Spec>
 void CreateBinaryTrMulParams(const Matrix<LhsScalar>& lhs,
                              const Matrix<RhsScalar>& rhs, const Spec& spec,


### PR DESCRIPTION
This resolves the build issues (at least locally).

https://github.com/tensorflow/tensorflow/commit/113a37348f295f4858df470f92e4ab49ac0fed23 introduced two new `ruy::Path`s, so we have to add two new x86 placeholder implementations.