### PR TITLE
Enable Bazel GCS remote cache

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -63,6 +63,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.gcs_bazel_cache }}
+          export_default_credentials: true
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
@@ -75,13 +79,17 @@ jobs:
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
       - name: Run FileCheck tests
-        run: ./bazelisk test larq_compute_engine/mlir/tests:all --test_output=all --distinct_host_configuration=false
+        run: ./bazelisk test larq_compute_engine/mlir/tests:all --test_output=all --distinct_host_configuration=false --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials
 
   EndToEnd:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.gcs_bazel_cache }}
+          export_default_credentials: true
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
@@ -94,7 +102,7 @@ jobs:
       - name: Install pip dependencies
         run: pip install tensorflow==2.1.0 larq~=0.9.1 larq_zoo==1.0.b3 pytest tensorflow_datasets==1.3.2 --no-cache
       - name: Run End2End tests
-        run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false
+        run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials
 
   ConverterPython:
     runs-on: macos-latest

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -63,7 +63,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.2
         with:
           service_account_key: ${{ secrets.gcs_bazel_cache }}
           export_default_credentials: true
@@ -86,7 +86,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.2
         with:
           service_account_key: ${{ secrets.gcs_bazel_cache }}
           export_default_credentials: true


### PR DESCRIPTION
## What do these changes do?

This enables Bazel remote caching in order to speed up CI for MLIR and End2End test.

It remains to be seen what the network egress cost of using this cache will be and if the network latency between GCS and GitHub actions is low enough to make a significant improvement. Since Ingress is free on GCS I didn't prevent writing to the cache from branches other than master. If cache integrity becomes a problem, we should investigate having a readonly cache for builds not from master (see https://docs.bazel.build/versions/master/remote-caching.html#read-from-and-write-to-the-remote-cache).

## CI Benchmarks

build job | master | first cache warmup | cached build
--- | --- | --- | ---
MLIR | 11:04 | DNF | 4:36
End2End | 21:52 | 30:12 |  6:16

The first uncached run takes quite a bit longer since it needs to upload ~3GB of cached objects, but subsequent build are super fast 🚀 .
We should monitor our network egress cost, since I don't know how much traffic the caching takes up. The cache is configured to delete objects after 14 days and is located in US East.

## Related issue number
#86