### PR TITLE
Use `fastbuild` instead of `dbg` for tests.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -50,13 +50,13 @@ jobs:
         run: ./configure.sh <<< $'yes\n' #yes for manylinux2010
         shell: bash
       - name: "TF Arm32: Cross-compile and run unit tests in qemu"
-        run: ./bazelisk run larq_compute_engine/core/tests:cc_tests_arm32_qemu --config=rpi3 --compilation_mode dbg
+        run: ./bazelisk run larq_compute_engine/core/tests:cc_tests_arm32_qemu --config=rpi3 --compilation_mode=fastbuild
       - name: "TF Lite Arm32: Cross-compile and run tflite tests in qemu"
-        run: ./bazelisk run larq_compute_engine/tflite/tests:cc_tests_arm32_qemu --config=rpi3 --compilation_mode dbg
+        run: ./bazelisk run larq_compute_engine/tflite/tests:cc_tests_arm32_qemu --config=rpi3 --compilation_mode=fastbuild
       - name: "TF Aarch64: Cross-compile and run unit tests in qemu"
-        run: ./bazelisk run larq_compute_engine/core/tests:cc_tests_aarch64_qemu --config=aarch64 --compilation_mode dbg
+        run: ./bazelisk run larq_compute_engine/core/tests:cc_tests_aarch64_qemu --config=aarch64 --compilation_mode=fastbuild
       - name: "TF Lite Aarch64: Cross-compile and run tflite tests in qemu"
-        run: ./bazelisk run larq_compute_engine/tflite/tests:cc_tests_aarch64_qemu --config=aarch64 --compilation_mode dbg
+        run: ./bazelisk run larq_compute_engine/tflite/tests:cc_tests_aarch64_qemu --config=aarch64 --compilation_mode=fastbuild
 
   MLIR:
     runs-on: macos-latest

--- a/configure.sh
+++ b/configure.sh
@@ -124,7 +124,7 @@ build:nohdfs --define=no_hdfs_support=true
 build:nonccl --define=no_nccl_support=true
 
 build --config=v2 --config=noaws --config=nogcp --config=nohdfs --config=nonccl
-test --config=v2 --compilation_mode dbg
+test --config=v2 --compilation_mode=fastbuild
 
 # Android configs. Bazel needs to have --cpu and --fat_apk_cpu both set to the
 # target CPU to build transient dependencies correctly. See


### PR DESCRIPTION
In #271 I set the compilation mode to `dbg` so that the compiler flag `-DNDEBUG` is not set, and debug assertions don't get stripped.

According to the [Bazel documentation](https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode), the compilation mode `fastbuild` also does not set `-DNDEBUG`, but (as the name suggests) should be faster.

I see a 15-25% speed-up when building the tests (specifically the TFLite CC tests, on MacOS) with `fastbuild` rather than `dbg`. I have also verified that adding the statement `RUY_DCHECK_EQ(true, false)` still causes the ARM and native tests to fail (which was the original issue addressed by #271).