### PR TITLE
Add preprocessor statement to fix warning

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -98,8 +98,10 @@ void RunBgemmKernelTyped(ruy::Tuning tuning,
                          ruy::Matrix<DstScalar>* dst) {
   using BKernel = BgemmKernel<ThePath, LhsScalar, RhsScalar, DstScalar, Spec>;
   BKernel kernel(tuning);
+#if !defined(NDEBUG) || !RUY_OPT_ENABLED(RUY_OPT_FAT_KERNEL)
   using LhsLayout = typename BKernel::LhsLayout;
   using RhsLayout = typename BKernel::RhsLayout;
+#endif
   // end_row and end_col may be larger than dst dimensions.
   // that is because kernels write directly to the destination matrix, whose
   // dimensions may not be a multiple of the kernel dimensions, and we try to


### PR DESCRIPTION
## What do these changes do?

This adds two lines to avoid a warning about unused `using` statements. See also [experimental/ruy/kernel_common.h L50](https://github.com/tensorflow/tensorflow/blob/3c1e8c03419266bb6ba379d303d3e03a380617a8/tensorflow/lite/experimental/ruy/kernel_common.h#L50)