### PR TITLE
Fix typo that caused 64-bit op on ARM32

### DIFF
--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -544,7 +544,6 @@ TfLiteRegistration* Register_BCONV_2D64_OPT() {
 // Use this registration wrapper to decide which impl. to use.
 TfLiteRegistration* Register_BCONV_2D() {
 #if defined TFLITE_WITH_RUY
-  return Register_BCONV_2D64_OPT();
 #if RUY_PLATFORM(ARM_32)
   return Register_BCONV_2D32_OPT();
 #else  // ARM 64 and x86


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This removes a line that was added by mistake by a3f3838944c62d21501029c34a430d249cfdf09b