### PR TITLE
Consolidate MLIR and End2End tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,30 +71,9 @@ jobs:
       - name: Configure Bazel
         run: ./configure.sh
       - name: Install pip dependencies
-        run: pip install numpy six --no-cache-dir
+        run: pip install tensorflow==2.1.0 larq~=0.9.1 larq_zoo==1.0.b3 pytest tensorflow_datasets==1.3.2 --no-cache-dir
       - name: Run FileCheck tests
         run: ./bazelisk test larq_compute_engine/mlir/tests:all --test_output=all --distinct_host_configuration=false --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials
-
-  EndToEnd:
-    runs-on: macos-latest
-    if: "!contains(github.event.head_commit.message, 'ci-skip')"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.2
-        with:
-          service_account_key: ${{ secrets.gcs_bazel_cache }}
-          export_default_credentials: true
-      - name: Install Bazelisk
-        run: |
-          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
-          chmod +x bazelisk
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Configure Bazel
-        run: ./configure.sh
-      - name: Install pip dependencies
-        run: pip install tensorflow==2.1.0 larq~=0.9.1 larq_zoo==1.0.b3 pytest tensorflow_datasets==1.3.2 --no-cache
       - name: Run End2End tests
         run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials
 


### PR DESCRIPTION
## What do these changes do?
This consolidates the MLIR and End2End tests. This should reduce the amount of network traffic and general overhead on CI since we now have proper caching, so splitting the tests doesn't improve speed anymore.  