### PR TITLE
Fix typos and standardise std:: namespace usage.

### DIFF
--- a/larq_compute_engine/core/benchmark/aarch64/packbits_bench.cc
+++ b/larq_compute_engine/core/benchmark/aarch64/packbits_bench.cc
@@ -12,25 +12,25 @@
 
 using namespace compute_engine::core;
 
-constexpr size_t min_size = 128;
-constexpr size_t max_size = 1 << 16;  // 64K
+constexpr std::size_t min_size = 128;
+constexpr std::size_t max_size = 1 << 16;  // 64K
 
 // Benchmark results seem to depend on memory alignment,
 // not only to cache-size (64 bytes) but also page size (4KB).
 // To get a fair comparison, we test all functions on the same memory.
-constexpr size_t alignment = 4 * 1024;
+constexpr std::size_t alignment = 4 * 1024;
 float* in_array = reinterpret_cast<float*>(
     aligned_alloc(alignment, max_size * sizeof(float)));
 uint64_t* out_array = reinterpret_cast<uint64_t*>(
     aligned_alloc(alignment, (max_size / 64) * sizeof(uint64_t)));
 
-template <void (*packing_func)(const float*, size_t, uint64_t*),
-          size_t blocksize>
+template <void (*packing_func)(const float*, std::size_t, std::uint64_t*),
+          std::size_t blocksize>
 static void packbits_bench(benchmark::State& state) {
-  const size_t in_size = state.range(0);
-  const size_t out_size = in_size / 64;
+  const std::size_t in_size = state.range(0);
+  const std::size_t out_size = in_size / 64;
 
-  const size_t num_blocks = in_size / blocksize;
+  const std::size_t num_blocks = in_size / blocksize;
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(out_array);
@@ -41,7 +41,7 @@ static void packbits_bench(benchmark::State& state) {
   state.counters["alignment"] = (reinterpret_cast<uint64_t>(in_array) % 4096);
 }
 
-BENCHMARK_TEMPLATE(packbits_bench, packbits_array<float, uint64_t>, 1)
+BENCHMARK_TEMPLATE(packbits_bench, packbits_array<float, std::uint64_t>, 1)
     ->Range(min_size, max_size);
 BENCHMARK_TEMPLATE(packbits_bench, packbits_aarch64_64, 64)
     ->Range(min_size, max_size);

--- a/larq_compute_engine/core/benchmark/bgemm_bench.cc
+++ b/larq_compute_engine/core/benchmark/bgemm_bench.cc
@@ -49,9 +49,9 @@ static void bgemm(benchmark::State& state) {
   }
 }
 
-BENCHMARK_TEMPLATE(bgemm, uint8_t, float)
+BENCHMARK_TEMPLATE(bgemm, std::uint8_t, float)
     ->Ranges({{16, 32}, {3, 5}, {8, 128}, {4, 16}});
-BENCHMARK_TEMPLATE(bgemm, uint32_t, float)
+BENCHMARK_TEMPLATE(bgemm, std::uint32_t, float)
     ->Ranges({{16, 32}, {3, 5}, {8, 128}, {4, 16}});
-BENCHMARK_TEMPLATE(bgemm, uint64_t, float)
+BENCHMARK_TEMPLATE(bgemm, std::uint64_t, float)
     ->Ranges({{16, 32}, {3, 5}, {8, 128}, {4, 16}});

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -101,7 +101,8 @@ struct BgemmKernel<ruy::Path::kNeonDotprod, LhsScalar, RhsScalar, DstScalar,
   ruy::Tuning tuning = Tuning::kAuto;
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
-  using Base = BgemmKernel<Path::kNeon, LhsLayout, RhsLayout, DstScalar, Spec>;
+  using Base =
+      BgemmKernel<ruy::Path::kNeon, LhsLayout, RhsLayout, DstScalar, Spec>;
   explicit BgemmKernel(ruy::Tuning tuning_) : tuning(tuning_) {}
   void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
            const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -24,7 +24,7 @@ template <typename AccumScalar, typename DstScalar,
 struct BGemmParams {
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
-  int32_t backtransform_add = 0;
+  std::int32_t backtransform_add = 0;
   // post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
@@ -48,7 +48,7 @@ struct BinaryBasicSpec {
   using DstScalar = tDstScalar;
   AccumScalar multiplier_fixedpoint = 0;
   int multiplier_exponent = 0;
-  int32_t backtransform_add = 0;
+  std::int32_t backtransform_add = 0;
   // post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts

--- a/larq_compute_engine/core/bgemm_trmul_params.h
+++ b/larq_compute_engine/core/bgemm_trmul_params.h
@@ -173,7 +173,7 @@ void PopulateBinaryTrMulParamsAllCompiledPaths(ruy::Path the_path,
                              Spec>::Search(the_path, params);
 }
 
-template <Path CompiledPaths, typename LhsScalar, typename RhsScalar,
+template <ruy::Path CompiledPaths, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename Spec>
 void CreateBinaryTrMulParams(const Matrix<LhsScalar>& lhs,
                              const Matrix<RhsScalar>& rhs, const Spec& spec,

--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -23,7 +23,7 @@ namespace core {
 
 template <class TIn, class TOut>
 inline void pack_canonical(const TIn* fptr, TOut* buf) {
-  const size_t bitwidth = std::numeric_limits<TOut>::digits;
+  const std::size_t bitwidth = std::numeric_limits<TOut>::digits;
   *buf = 0;
   for (size_t i = 0; i < bitwidth; ++i) {
     if (fptr[i] < 0) *buf |= (1ULL << i);
@@ -311,7 +311,7 @@ inline void pack_bitfield(const TIn* in, TOut* out) {
 template <BitpackOrder bitpack_order, class TIn, class TOut>
 inline void packbits_array(const TIn* input_array, const std::size_t n,
                            TOut* bitpacked_array) {
-  constexpr size_t bitwidth = std::numeric_limits<TOut>::digits;
+  constexpr std::size_t bitwidth = std::numeric_limits<TOut>::digits;
 
   int num_packed_elems = n / bitwidth;
   int elements_left = n - bitwidth * num_packed_elems;
@@ -340,16 +340,18 @@ inline void packbits_array(const TIn* input_array, const std::size_t n,
 // bitpacking operation compresses an MxN matrix to a Mx(N/bitwidth)
 // matrix.
 template <BitpackOrder bitpack_order, class TIn, class TOutContainer>
-inline void packbits_matrix(const TIn* input_data, const size_t input_num_rows,
-                            const size_t input_num_cols, TOutContainer& output,
-                            size_t& output_num_rows, size_t& output_num_cols,
-                            size_t& output_bitpadding,
+inline void packbits_matrix(const TIn* input_data,
+                            const std::size_t input_num_rows,
+                            const std::size_t input_num_cols,
+                            TOutContainer& output, std::size_t& output_num_rows,
+                            std::size_t& output_num_cols,
+                            std::size_t& output_bitpadding,
                             const Axis bitpacking_axis) {
   // Force the types to be unsigned so that the function can be called on signed
   // types as well
   using TOut =
       typename std::make_unsigned<typename TOutContainer::value_type>::type;
-  const size_t bitwidth = std::numeric_limits<TOut>::digits;
+  const std::size_t bitwidth = std::numeric_limits<TOut>::digits;
 
   if (bitpacking_axis == Axis::RowWise) {
     // calculate size of bitpacked matrix and allocate its memory
@@ -417,7 +419,7 @@ inline void packbits_matrix(const TIn* input_data, const size_t input_num_rows,
 
 template <typename TBitpacked, typename TUnpacked>
 void unpack_bitfield(const TBitpacked in, TUnpacked*& out,
-                     size_t num_elements) {
+                     std::size_t num_elements) {
   for (size_t i = 0; i < num_elements; ++i) {
     *out++ = (in & (1ULL << i)) ? TUnpacked(-1.0f) : TUnpacked(1.0f);
   }
@@ -428,9 +430,10 @@ void unpack_bitfield(const TBitpacked in, TUnpacked*& out,
 // The argument `num_cols` is the *unpacked* number of cols!
 // Enough output memory is assumed.
 template <typename TBitpacked, typename TUnpacked>
-inline void unpack_matrix(const TBitpacked* input_data, const size_t num_rows,
-                          const size_t num_cols, TUnpacked* output_data) {
-  constexpr size_t bitwidth = std::numeric_limits<TBitpacked>::digits;
+inline void unpack_matrix(const TBitpacked* input_data,
+                          const std::size_t num_rows,
+                          const std::size_t num_cols, TUnpacked* output_data) {
+  constexpr std::size_t bitwidth = std::numeric_limits<TBitpacked>::digits;
 
   const TBitpacked* in_ptr = input_data;
   TUnpacked* out_ptr = output_data;

--- a/larq_compute_engine/core/packbits_aarch64.h
+++ b/larq_compute_engine/core/packbits_aarch64.h
@@ -12,7 +12,7 @@ namespace core {
 
 // This will bitpack exactly 64 floats.
 // It will be packed in a weird order which is described in the comments
-void packbits_aarch64_64(const float* input, uint64_t* output) {
+void packbits_aarch64_64(const float* input, std::uint64_t* output) {
   asm volatile(
       "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%0], #64    \n"
       "sri    v0.4s, v2.4s, #1    \n"
@@ -70,8 +70,8 @@ void packbits_aarch64_64(const float* input, uint64_t* output) {
 }
 
 // For packing an entire array
-void packbits_aarch64_64(const float* input, size_t num_blocks,
-                         uint64_t* output) {
+void packbits_aarch64_64(const float* input, std::size_t num_blocks,
+                         std::uint64_t* output) {
   while (num_blocks--) {
     packbits_aarch64_64(input, output++);
     input += 64;

--- a/larq_compute_engine/core/packbits_arm32.h
+++ b/larq_compute_engine/core/packbits_arm32.h
@@ -9,7 +9,8 @@ namespace core {
 
 // Output should be allocated by caller
 // It should have size equal to (n+63)/64
-void packbits_arm32(const float* input, const size_t n, uint64_t* output) {
+void packbits_arm32(const float* input, const std::size_t n,
+                    std::uint64_t* output) {
   //
   // This is *not* yet valid bitpacking code.
   //
@@ -20,7 +21,7 @@ void packbits_arm32(const float* input, const size_t n, uint64_t* output) {
   // Interpreted as if output and input are both uint32_t
   //
 
-  size_t packed_elements = (n + 63) / 64;
+  std::size_t packed_elements = (n + 63) / 64;
   asm volatile(
       // Prefetch memory. %0 is input pointer
       "pld [%0] \n"

--- a/larq_compute_engine/core/padding_functor.h
+++ b/larq_compute_engine/core/padding_functor.h
@@ -72,7 +72,7 @@ class PaddingFunctor {
     // to obtain our correction value.
     //
     // So we could save this value for every tuple.
-    // However (T) and (B) can not be both true at the same time,
+    // However (T) and (B) cannot be both true at the same time,
     // and neither can (L) and (R) because we will assume that the (effective)
     // filter size is always smaller than the image.
     //
@@ -271,7 +271,7 @@ class PaddingFunctor {
             cache_X = (overflow_right >= 0 ? overflow_right : 0);
             cache_Y = overflow_bot;
           } else {
-            // This can not happen.
+            // This cannot happen.
             continue;
           }
 

--- a/larq_compute_engine/core/tests/bgemm_arm32_tests.cc
+++ b/larq_compute_engine/core/tests/bgemm_arm32_tests.cc
@@ -12,8 +12,8 @@ namespace ce = compute_engine;
 using ce::core::Layout;
 
 TEST(BGemmTests, BGemmArm32) {
-  ce::core::ReferenceBGemmFunctor<uint64_t, Layout::RowMajor, uint64_t,
-                                  Layout::ColMajor, int32_t>
+  ce::core::ReferenceBGemmFunctor<uint64_t, Layout::RowMajor, std::uint64_t,
+                                  Layout::ColMajor, std::int32_t>
       bgemm_functor;
 
   const int m = 10;

--- a/larq_compute_engine/core/tests/bgemm_tests.cc
+++ b/larq_compute_engine/core/tests/bgemm_tests.cc
@@ -51,26 +51,26 @@ void test_bgemm() {
 }
 
 TEST(BGemmTests, BinaryInnerProdUInt8) {
-  using TIn = uint8_t;
-  using TOut = int32_t;
+  using TIn = std::uint8_t;
+  using TOut = std::int32_t;
   test_binary_inner_prod<TIn, TOut>();
 }
 
 TEST(BGemmTests, BinaryInnerProdUInt32) {
-  using TIn = uint32_t;
-  using TOut = int32_t;
+  using TIn = std::uint32_t;
+  using TOut = std::int32_t;
   test_binary_inner_prod<TIn, TOut>();
 }
 
 TEST(BGemmTests, BinaryInnerProdUInt64) {
-  using TIn = uint64_t;
-  using TOut = int32_t;
+  using TIn = std::uint64_t;
+  using TOut = std::int32_t;
   test_binary_inner_prod<TIn, TOut>();
 }
 
 TEST(BGemmTests, BGemmTestUInt8) {
-  using TIn = uint8_t;
-  using TOut = int32_t;
+  using TIn = std::uint8_t;
+  using TOut = std::int32_t;
   using BGemmFunctor =
       ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
                                       Layout::RowMajor, TOut>;
@@ -81,8 +81,8 @@ TEST(BGemmTests, BGemmTestUInt8) {
 }
 
 TEST(BGemmTests, BGemmTestUInt32) {
-  using TIn = uint32_t;
-  using TOut = int32_t;
+  using TIn = std::uint32_t;
+  using TOut = std::int32_t;
   using BGemmFunctor =
       ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
                                       Layout::RowMajor, TOut>;
@@ -93,8 +93,8 @@ TEST(BGemmTests, BGemmTestUInt32) {
 }
 
 TEST(BGemmTests, BGemmTestUInt64) {
-  using TIn = uint64_t;
-  using TOut = int32_t;
+  using TIn = std::uint64_t;
+  using TOut = std::int32_t;
   using BGemmFunctor =
       ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
                                       Layout::RowMajor, TOut>;
@@ -105,8 +105,8 @@ TEST(BGemmTests, BGemmTestUInt64) {
 }
 
 TEST(BGemmTests, BGemmTestUInt64ColMajor) {
-  using TIn = uint64_t;
-  using TOut = int32_t;
+  using TIn = std::uint64_t;
+  using TOut = std::int32_t;
   using BGemmFunctor =
       ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
                                       Layout::ColMajor, TOut>;

--- a/larq_compute_engine/core/tests/packbits_aarch64_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_aarch64_tests.cc
@@ -12,14 +12,14 @@ namespace testing {
 
 using namespace compute_engine::core;
 
-template <void (*packing_func)(const float*, size_t, uint64_t*),
-          size_t blocksize>
+template <void (*packing_func)(const float*, std::size_t, std::uint64_t*),
+          std::size_t blocksize>
 void test_bitpacking() {
-  constexpr size_t n = 512;
+  constexpr std::size_t n = 512;
 
   // We will simply check if every input gets mapped uniquely to one bit
   float input[n];
-  uint64_t output[n / 64];
+  std::uint64_t output[n / 64];
   int mapping_in2out[n];
   int mapping_out2in[n];
   for (auto i = 0; i < n; ++i) {

--- a/larq_compute_engine/core/tests/packbits_arm32_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_arm32_tests.cc
@@ -13,8 +13,8 @@ namespace testing {
 namespace ce = compute_engine;
 
 TEST(BitpackingTests, BitpackingARM32) {
-  constexpr size_t n = 128;
-  constexpr size_t n_packed = (n + 63) / 64;
+  constexpr std::size_t n = 128;
+  constexpr std::size_t n_packed = (n + 63) / 64;
 
   std::array<float, n> input;
 
@@ -34,9 +34,9 @@ TEST(BitpackingTests, BitpackingARM32) {
 
   // The test assembly that I put in will compute input[0] ^ input[1]
   // So we check that here
-  uint32_t* ptr_in = reinterpret_cast<uint32_t*>(input.data());
-  uint32_t* ptr_out = reinterpret_cast<uint32_t*>(output.data());
-  uint32_t expected_output = ptr_in[0] ^ ptr_in[1];
+  std::uint32_t* ptr_in = reinterpret_cast<uint32_t*>(input.data());
+  std::uint32_t* ptr_out = reinterpret_cast<uint32_t*>(output.data());
+  std::uint32_t expected_output = ptr_in[0] ^ ptr_in[1];
   EXPECT_THAT(ptr_out[0], expected_output);
 }
 

--- a/larq_compute_engine/core/tests/packbits_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_tests.cc
@@ -20,12 +20,12 @@ void test_bitpacking_nonuniform_input_rowwise() {
   const auto bitpacking_axis = ce::core::Axis::RowWise;
 
   // input matrix (row-major memory laytout)
-  const size_t num_rows = 2, num_cols = 8;
+  const std::size_t num_rows = 2, num_cols = 8;
   std::array<TIn, 16> input{1, 1,  -1, 1,  -1, -1, -1, 1,
                             1, -1, 1,  -1, -1, -1, 1,  1};
 
   // expected output matrix after bitpacking
-  const size_t expected_num_rows = 2, expected_num_cols = 1;
+  const std::size_t expected_num_rows = 2, expected_num_cols = 1;
   std::vector<std::uint8_t> expected;
   if (CE_IS_BIG_ENDIAN)
     expected = {0b00101110, 0b01011100};
@@ -33,7 +33,7 @@ void test_bitpacking_nonuniform_input_rowwise() {
     expected = {0b01110100, 0b00111010};
 
   std::vector<std::uint8_t> output;
-  size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
       bitpadding, bitpacking_axis);
@@ -49,12 +49,12 @@ void test_bitpacking_nonuniform_input_colwise() {
   const auto bitpacking_axis = ce::core::Axis::ColWise;
 
   // input matrix (row-major memory laytout)
-  const size_t num_rows = 8, num_cols = 2;
+  const std::size_t num_rows = 8, num_cols = 2;
   std::array<TIn, 16> input{1,  1,  1,  -1, -1, 1, 1, -1,
                             -1, -1, -1, -1, -1, 1, 1, 1};
 
   // expected output matrix after bitpacking
-  const size_t expected_num_rows = 1, expected_num_cols = 2;
+  const std::size_t expected_num_rows = 1, expected_num_cols = 2;
   std::vector<std::uint8_t> expected;
   if (CE_IS_BIG_ENDIAN)
     expected = {0b00101110, 0b01011100};
@@ -62,7 +62,7 @@ void test_bitpacking_nonuniform_input_colwise() {
     expected = {0b01110100, 0b00111010};
 
   std::vector<std::uint8_t> output;
-  size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
       bitpadding, bitpacking_axis);
@@ -73,24 +73,24 @@ void test_bitpacking_nonuniform_input_colwise() {
   EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
 }
 
-template <class TIn, class TOut, size_t num_rows, size_t num_cols>
+template <class TIn, class TOut, std::size_t num_rows, std::size_t num_cols>
 void test_bitpacking(const ce::core::Axis bitpacking_axis,
-                     const size_t expected_num_rows,
-                     const size_t expected_num_cols) {
-  const size_t bitwidth = std::numeric_limits<TOut>::digits;
+                     const std::size_t expected_num_rows,
+                     const std::size_t expected_num_cols) {
+  const std::size_t bitwidth = std::numeric_limits<TOut>::digits;
 
-  const size_t num_elems = num_rows * num_cols;
+  const std::size_t num_elems = num_rows * num_cols;
   std::array<TIn, num_elems> input;
   input.fill(-1);
 
   std::vector<TOut> output;
-  size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
       bitpadding, bitpacking_axis);
 
   TOut expected_value = std::numeric_limits<TOut>::max();
-  const size_t num_elems_bp = num_elems / bitwidth;
+  const std::size_t num_elems_bp = num_elems / bitwidth;
   std::array<TOut, num_elems_bp> expected;
   expected.fill(expected_value);
 
@@ -142,8 +142,8 @@ TEST(BitpackingWithBitPaddingTests, RowMajorPadding) {
                            -1, 1,  -1, 1,  1, 1, -1, -1, 1};
 
   // expected output matrix after bitpacking
-  const size_t expected_num_rows = 2;
-  const size_t expected_num_cols = 2;
+  const std::size_t expected_num_rows = 2;
+  const std::size_t expected_num_cols = 2;
   std::vector<std::uint8_t> expected;
   if (CE_IS_BIG_ENDIAN)
     expected = {0b11010001, 0b10000000, 0b10100011, 0b00000000};
@@ -151,7 +151,7 @@ TEST(BitpackingWithBitPaddingTests, RowMajorPadding) {
     expected = {0b10001011, 0b00000001, 0b11000101, 0b00000000};
 
   std::vector<std::uint8_t> output;
-  size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
       bitpadding, bitpacking_axis);
@@ -172,8 +172,8 @@ TEST(BitpackingWithBitPaddingTests, ColMajorPadding) {
                            1,  1,  1,  1, -1, -1, -1, -1, 1};
 
   // expected output matrix after bitpacking
-  const size_t expected_num_rows = 2;
-  const size_t expected_num_cols = 2;
+  const std::size_t expected_num_rows = 2;
+  const std::size_t expected_num_cols = 2;
   std::vector<std::uint8_t> expected;
   if (CE_IS_BIG_ENDIAN)
     expected = {0b11010001, 0b10100011, 0b10000000, 0b00000000};
@@ -181,7 +181,7 @@ TEST(BitpackingWithBitPaddingTests, ColMajorPadding) {
     expected = {0b10001011, 0b11000101, 0b00000001, 0b00000000};
 
   std::vector<std::uint8_t> output;
-  size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
       bitpadding, bitpacking_axis);

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -34,7 +34,7 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
   const auto& dense_elements_iter =
       x.cast<DenseElementsAttr>().getValues<float>();
 
-  using PackedType = uint32_t;
+  using PackedType = std::uint32_t;
   constexpr int bitwidth = std::numeric_limits<PackedType>::digits;
 
   auto shape = x.getType().cast<ShapedType>().getShape();
@@ -45,7 +45,7 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
   std::vector<PackedType> new_values(num_rows * packed_channels);
 
   const float* in_ptr = &(*dense_elements_iter.begin());
-  size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
+  std::size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
   using namespace compute_engine::core;
   packbits_matrix<BitpackOrder::Canonical>(
       in_ptr, num_rows, unpacked_channels, new_values, filter_rows_bp,

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -181,7 +181,7 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     return conv_params;
   }
 
-  // We can not return an error code here, so we set this flag and return an
+  // We cannot return an error code here, so we set this flag and return an
   // error code in Prepare
   conv_params->conv_params_initialized = true;
   return conv_params;

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -37,21 +37,21 @@ const int kTensorNotAllocated = -1;
 
 typedef struct {
   // input tensor dimensions
-  int64_t batch{0};
-  int64_t input_width{0};
-  int64_t input_height{0};
+  std::int64_t batch{0};
+  std::int64_t input_width{0};
+  std::int64_t input_height{0};
 
   // filters tensor dimensions
-  int64_t filter_width{0};
-  int64_t filter_height{0};
-  int64_t channels_in{0};
-  int64_t channels_out{0};
+  std::int64_t filter_width{0};
+  std::int64_t filter_height{0};
+  std::int64_t channels_in{0};
+  std::int64_t channels_out{0};
 
   // strides
-  int64_t strides[4] = {};
+  std::int64_t strides[4] = {};
 
   // dilations
-  int64_t dilations[4] = {};
+  std::int64_t dilations[4] = {};
 
   // padding
   TfLitePadding padding_type{};
@@ -59,8 +59,8 @@ typedef struct {
   int pad_value = 0;  // Must be 0 or 1
 
   // output tensor dimensions
-  int64_t out_width{0};
-  int64_t out_height{0};
+  std::int64_t out_width{0};
+  std::int64_t out_height{0};
 
   ce::core::FilterFormat filter_format{ce::core::FilterFormat::Unknown};
 
@@ -78,7 +78,7 @@ typedef struct {
   // In node->temporaries there is a list of tensor id's that are part
   // of this node in particular. The indices below are offsets into this array.
   // So in pseudo-code: `node->temporaries[index] = id;`
-  int32_t im2col_index;
+  std::int32_t im2col_index;
 
   std::vector<float> padding_buffer;
   bool is_padding_correction_cached = false;
@@ -101,10 +101,10 @@ inline void decide_bitpack_before_im2col(TfLiteBConv2DParams* conv_params) {
   }
 }
 
-void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
   auto* conv_params = new TfLiteBConv2DParams{};
 
-  const uint8_t* buffer_t = reinterpret_cast<const uint8_t*>(buffer);
+  const std::uint8_t* buffer_t = reinterpret_cast<const std::uint8_t*>(buffer);
   const flexbuffers::Map& m = flexbuffers::GetRoot(buffer_t, length).AsMap();
 
   // Later we can change this so that we only allow "OHWI_PACKED" (prepacked)
@@ -417,7 +417,8 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
                              : nullptr;
 
   if (!params->is_filter_repacked || !params->is_padding_correction_cached) {
-    const uint32_t* filter_flatbuffer = GetTensorData<uint32_t>(filter);
+    const std::uint32_t* filter_flatbuffer =
+        GetTensorData<std::uint32_t>(filter);
     const T* filter_unpacked = nullptr;
 
     if (params->filter_format == ce::core::FilterFormat::OHWI_PACKED) {
@@ -479,12 +480,12 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
     }
 
     std::vector<TBitpacked> filter_data_bp;
-    size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
+    std::size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
     ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
         filter_unpacked, rows, cols, filter_data_bp, filter_rows_bp,
         filter_cols_bp, filter_bitpadding, ce::core::Axis::RowWise);
 
-    size_t num_bytes = filter_data_bp.size() * sizeof(TBitpacked);
+    std::size_t num_bytes = filter_data_bp.size() * sizeof(TBitpacked);
 
     params->filter_packed.resize(num_bytes);
     memcpy(params->filter_packed.data(), filter_data_bp.data(), num_bytes);

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -28,7 +28,7 @@ inline void im2col(const ConvParams& params, const RuntimeShape& input_shape,
   const int dilation_width_factor = params.dilation_width_factor;
   const int dilation_height_factor = params.dilation_height_factor;
 
-  const uint8 zero_byte = 0x00;
+  const std::uint8_t zero_byte = 0x00;
   const int filter_height = filter_shape.Dims(1);
   const int filter_width = filter_shape.Dims(2);
 

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -39,6 +39,7 @@ inline void im2col(const ConvParams& params, const RuntimeShape& input_shape,
 
   const RuntimeShape* shape = nullptr;
   if (need_dilated_im2col) {
+    TF_LITE_ASSERT(im2col_data);
     optimized_ops::DilatedIm2col<T>(params, zero_byte, input_shape, input_data,
                                     filter_shape, output_shape, im2col_data);
     *result_data = im2col_data;

--- a/larq_compute_engine/tflite/kernels/sign.cc
+++ b/larq_compute_engine/tflite/kernels/sign.cc
@@ -51,7 +51,7 @@ TfLiteStatus BsignEval(TfLiteContext* context, TfLiteNode* node) {
   float* input_data = input->data.f;
   float* output_data = output->data.f;
 
-  size_t count = 1;
+  std::size_t count = 1;
   int num_dims = NumDimensions(input);
   for (int i = 0; i < num_dims; ++i) {
     count *= input->dims->data[i];

--- a/larq_compute_engine/tflite/kernels/utils.h
+++ b/larq_compute_engine/tflite/kernels/utils.h
@@ -21,8 +21,8 @@ inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
   const int rows = FlatSizeSkipDim(in_shape, dims - 1);
   const int cols = in_shape.Dims(dims - 1);
 
-  size_t rows_bp = 0, cols_bp = 0;
-  size_t bitpadding = 0;
+  std::size_t rows_bp = 0, cols_bp = 0;
+  std::size_t bitpadding = 0;
   {
     gemmlowp::ScopedProfilingLabel label("Packbits");
     ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -40,8 +40,8 @@ namespace tflite {
 // Use the same bitwidth as the MLIR converter
 // Since tflite does not have an unsigned 32-bit int type
 // we have to use the signed type here or it will throw errors.
-using PackedFilterType = int32_t;
-constexpr size_t packed_bitwidth = 32;
+using PackedFilterType = std::int32_t;
+constexpr std::size_t packed_bitwidth = 32;
 
 constexpr int Padding_ONE = Padding_MAX + 1;
 
@@ -447,7 +447,7 @@ TEST_P(BConv2DOpTest, SimpleTest) {
                 std::end(post_activation_bias_data), float_generator);
 
   // Bitpack filters
-  size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
+  std::size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
   using namespace compute_engine::core;
   packbits_matrix<BitpackOrder::Canonical>(
       filters_data.data(), filter_count * filter_height * filter_width,

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -542,7 +542,7 @@ TEST_P(BConv2DOpTest, SimpleTest) {
   auto expected_array = m_builtin.GetOutput();
 
   // Apply the post multiply and add to the tflite model
-  // We can not fuse it into the tflite bias because it should happen *after*
+  // We cannot fuse it into the tflite bias because it should happen *after*
   // the activation function
   T* out_ptr = expected_array.data();
   for (int batch = 0; batch < input_batch_count; ++batch) {


### PR DESCRIPTION
This PR doesn't change any behaviour. It fixes a couple of typos in comments, and standardises the use of `std::` before integer types.

I don't feel strongly at all about using `std::uint8_t` versus just `uint8_t` (or `std::size_t` vs `size_t`, et cetera), but in the LCE codebase we're using both at the moment, and I think it's much cleaner to standardise the usage one way or the other.

I've gone with the `std::` prefixed versions because my very quick analysis indicates that that usage is about 50% more prevalent than the non-prefixed versions in the existing code. I'm equally happy to go the other way and use the non-prefixed versions everywhere.