### PR TITLE
Support reading and writing bitpacked activations in C++ kernels.

### DIFF
--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -30,7 +30,7 @@ namespace compute_engine {
 namespace ce = compute_engine;
 namespace ref {
 
-template <typename T, typename TBitpacked, typename AccumScalar,
+template <typename SrcScalar, typename TBitpacked, typename AccumScalar,
           typename DstScalar>
 inline void BConv2D(const ConvParams& params,
                     const RuntimeShape& packed_input_shape,
@@ -40,8 +40,8 @@ inline void BConv2D(const ConvParams& params,
                     const float* post_activation_multiplier_data,
                     const float* post_activation_bias_data,
                     const RuntimeShape& output_shape, DstScalar* output_data,
-                    const RuntimeShape& im2col_shape, T* im2col_data,
-                    bool bitpack_before_im2col, T* padding_buffer,
+                    const RuntimeShape& im2col_shape, SrcScalar* im2col_data,
+                    bool bitpack_before_im2col, SrcScalar* padding_buffer,
                     const int pad_value, void* cpu_backend_context,
                     const std::int32_t backtransform_add) {
   static_assert(std::is_same<DstScalar, float>::value ||

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -30,8 +30,6 @@ struct BGemmImplUsingRuy {
     static_assert(std::is_unsigned<LhsScalar>::value &&
                       std::is_integral<LhsScalar>::value,
                   "Input to BGEMM should be of type unsigned integral.");
-    static_assert(std::is_signed<DstScalar>::value,
-                  "Output of BGEMM should be of a signed type.");
 
     using TSpec = BinaryBasicSpec<AccumScalar, DstScalar>;
 

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -30,6 +30,8 @@ struct BGemmImplUsingRuy {
     static_assert(std::is_unsigned<LhsScalar>::value &&
                       std::is_integral<LhsScalar>::value,
                   "Input to BGEMM should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of BGEMM should be of a signed type.");
 
     using TSpec = BinaryBasicSpec<AccumScalar, DstScalar>;
 

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -82,11 +82,20 @@ struct BGemmImplUsingRuy {
     // 32-bit NEON optimized code is not available yet
     bgemm_runtime_path = ruy::Path::kStandardCpp;
 #endif
+    // Currently we only have 32-bit and 64-bit optimized kernels.
+    // For 8-bit, fall back to the standard cpp kernel.
+    if (std::is_same<LhsScalar, std::uint8_t>::value)
+      bgemm_runtime_path = ruy::Path::kStandardCpp;
 #elif RUY_PLATFORM(X86)
     if (bgemm_runtime_path == ruy::Path::kAvx2 ||
         bgemm_runtime_path == ruy::Path::kAvx512)
       bgemm_runtime_path = ruy::Path::kStandardCpp;
 #endif
+
+    // For writing bitpacked output, fallback to the standard C++ kernel.
+    if (std::is_same<DstScalar, std::int8_t>::value) {
+      bgemm_runtime_path = ruy::Path::kStandardCpp;
+    }
 
     ruy::Matrix<LhsScalar> transposed_lhs(lhs);
     Transpose(&transposed_lhs);

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -93,7 +93,7 @@ struct BGemmImplUsingRuy {
 #endif
 
     // For writing bitpacked output, fallback to the standard C++ kernel.
-    if (std::is_same<DstScalar, std::int8_t>::value) {
+    if (std::is_same<DstScalar, std::int32_t>::value) {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
     }
 

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -18,6 +18,27 @@ using namespace ruy;
 
 #if RUY_PLATFORM(NEON) && RUY_OPT_ENABLED(RUY_OPT_ASM)
 
+// Generic kNeon template when no types are specified
+template <typename LhsScalar, typename RhsScalar, typename DstScalar,
+          typename Spec>
+struct BgemmKernel<ruy::Path::kNeon, LhsScalar, RhsScalar, DstScalar, Spec> {
+  ruy::Tuning tuning = Tuning::kAuto;
+  using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
+  using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
+  explicit BgemmKernel(ruy::Tuning tuning_) : tuning(tuning_) {}
+  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
+           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
+           int start_row, int start_col, int end_row, int end_col,
+           ruy::Matrix<DstScalar>* dst) const {
+    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
+                  "Inputs to binary kernel should have the same type.");
+    static_assert(
+        /* std::is_unsigned<LhsScalar>::value && */
+        std::is_integral<LhsScalar>::value,
+        "Input to binary kernel should be of type unsigned integral.");
+  }
+};
+
 #if RUY_PLATFORM(NEON_64)
 // A BGEMM kernel for ARM64 Neon.
 #include "bgemm_kernels_arm64.h"

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -85,6 +85,8 @@ struct BgemmKernel<ruy::Path::kNeon, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented -> fallback to standard cpp
   }
 };
@@ -111,6 +113,8 @@ struct BgemmKernel<ruy::Path::kNeonDotprod, LhsScalar, RhsScalar, DstScalar,
         /* std::is_unsigned<LhsScalar>::value && */
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented
   }
 };

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -85,9 +85,6 @@ struct BgemmKernel<ruy::Path::kNeon, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
-    static_assert(std::is_signed<DstScalar>::value,
-                  "Output of binary kernel should be of a signed type.");
-
     // TODO: not implemented -> fallback to standard cpp
   }
 };
@@ -114,8 +111,6 @@ struct BgemmKernel<ruy::Path::kNeonDotprod, LhsScalar, RhsScalar, DstScalar,
         /* std::is_unsigned<LhsScalar>::value && */
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
-    static_assert(std::is_signed<DstScalar>::value,
-                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented
   }
 };

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -88,7 +88,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
   }
 };
 
-// A template specialisation for writing 8-bit bitpacked output.
+// A template specialisation for writing 32-bit bitpacked output.
 template <typename LhsScalar, typename RhsScalar, typename Spec>
 struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::int32_t,
                    Spec> {
@@ -112,9 +112,9 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::int32_t,
     // We are writing 32-bit bitpacked output (where we bitpack along the
     // channel axis) and so we need to operate on blocks of 32 channels at a
     // time. As the destination is column major, this means blocks of 32 rows at
-    // a time. The blocks Ruy uses are always a power of two and are almost
-    // always >> 8. However, when running with multiple threads and a very large
-    // input size, Ruy may use blocks of 4 rows.
+    // a time. The blocks Ruy uses are always a power of two and are usually
+    // greater than 32. However, when running with multiple threads and a very
+    // large input size, Ruy may use blocks of fewer rows.
     //     In this scenario, we round the start and end row down and up to the
     // nearest multiple of 32 respectively. This is a thread-safe way to ensure
     // that the result is correct, at the cost of some rare repeated

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -90,7 +90,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
 
 // A template specialisation for writing 8-bit bitpacked output.
 template <typename LhsScalar, typename RhsScalar, typename Spec>
-struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::uint8_t,
+struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::int8_t,
                    Spec> {
   using AccumScalar = typename Spec::AccumScalar;
   using LhsLayout = typename Spec::StandardCppKernelLhsLayout;
@@ -99,7 +99,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::uint8_t,
   void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
            const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
            int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<std::uint8_t>* dst) const {
+           ruy::Matrix<std::int8_t>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -88,6 +88,99 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
   }
 };
 
+// A template specialisation for writing 8-bit bitpacked output.
+template <typename LhsScalar, typename RhsScalar, typename Spec>
+struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::uint8_t,
+                   Spec> {
+  using AccumScalar = typename Spec::AccumScalar;
+  using LhsLayout = typename Spec::StandardCppKernelLhsLayout;
+  using RhsLayout = typename Spec::StandardCppKernelRhsLayout;
+  explicit BgemmKernel(ruy::Tuning) {}
+  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
+           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
+           int start_row, int start_col, int end_row, int end_col,
+           ruy::Matrix<std::uint8_t>* dst) const {
+    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
+                  "Inputs to binary kernel should have the same type.");
+    static_assert(
+        std::is_unsigned<LhsScalar>::value &&
+            std::is_integral<LhsScalar>::value,
+        "Input to binary kernel should be of type unsigned integral.");
+
+    using TBitpacked = LhsScalar;
+
+    // We are writing 8-bit bitpacked output (where we bitpack along the channel
+    // axis) and so we need to operate on blocks of 8 channels at a time. As the
+    // destination is column major, this means blocks of 8 rows at a time. The
+    // blocks Ruy uses are always a power of two and are almost always >> 8.
+    // However, when running with multiple threads and a very large input size,
+    // Ruy may use blocks of 4 rows.
+    //     In this scenario, we round the start and end row down and up to the
+    // nearest multiple of 8 respectively. This is a thread-safe way to ensure
+    // that the result is correct, at the cost of some rare repeated
+    // computation, which is acceptable for this non-optimised kernel.
+    start_row = 8 * (start_row / 8);
+    end_row = 8 * ((end_row + 7) / 8);
+
+    int clamped_end_row = std::min(end_row, dst->layout.rows);
+    int clamped_end_col = std::min(end_col, dst->layout.cols);
+    RUY_DCHECK_LE(0, start_row);
+    RUY_DCHECK_LE(start_row, clamped_end_row);
+    RUY_DCHECK_LE(clamped_end_row, dst->layout.rows);
+    RUY_DCHECK_LE(clamped_end_row, end_row);
+    RUY_DCHECK_LE(0, start_col);
+    RUY_DCHECK_LE(start_col, clamped_end_col);
+    RUY_DCHECK_LE(clamped_end_col, dst->layout.cols);
+    RUY_DCHECK_LE(clamped_end_col, end_col);
+    RUY_DCHECK_LE(end_col - clamped_end_col, RhsLayout::kCols);
+
+    RUY_DCHECK_EQ(dst->layout.order, Order::kColMajor);
+
+    gemmlowp::ScopedProfilingLabel label(
+        "Binary Kernel (Standard Cpp) Bitpacked Output.");
+
+    const int depth = lhs.layout.rows;
+    const int dst_stride_bitpacked = (dst->layout.stride + 7) / 8;
+
+    // The destination is column major and we need to bitpack along the row
+    // (channels) axis so we need to loop over column index then row index.
+    for (int j = start_col; j < clamped_end_col; j++) {
+      std::uint8_t bitpacked_column = 0;
+      for (int i = start_row; i < clamped_end_row; i++) {
+        using AccumScalar = typename Spec::AccumScalar;
+        AccumScalar accum = 0;
+        for (int k = 0; k < depth; k++) {
+          TBitpacked lhs_val = Element(lhs, k, i);
+          TBitpacked rhs_val = Element(rhs, k, j);
+          accum +=
+              ce::core::xor_popcount<TBitpacked, AccumScalar>(lhs_val, rhs_val);
+        }
+        // Backtransform can still be done in int32
+        accum = spec.backtransform_add - 2 * accum;
+        // Activation function can also be done in int32
+        accum = std::min<AccumScalar>(accum, spec.clamp_max);
+        accum = std::max<AccumScalar>(accum, spec.clamp_min);
+        // Post multiply and add are done in float
+        auto dst_val = static_cast<float>(accum);
+        if (spec.post_activation_multiplier) {
+          dst_val *= spec.post_activation_multiplier[i];
+        }
+        if (spec.post_activation_bias) {
+          dst_val += spec.post_activation_bias[i];
+        }
+        if (dst_val < 0) {
+          bitpacked_column += 1 << ((i - start_row) % 8);
+        }
+        if (((i - start_row + 1) % 8 == 0) || (i + 1 == clamped_end_row)) {
+          *(dst->data.get() + i / 8 + j * dst_stride_bitpacked) =
+              bitpacked_column;
+          bitpacked_column = 0;
+        }
+      }
+    }
+  }
+};
+
 template <ruy::Path ThePath, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename Spec>
 void RunBgemmKernelTyped(ruy::Tuning tuning,

--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -32,6 +32,8 @@ struct BgemmKernel<ruy::Path::kAvx2, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented -> fallback to standard cpp
   }
 };
@@ -53,6 +55,8 @@ struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
+    static_assert(std::is_signed<DstScalar>::value,
+                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented -> fallback to standard cpp
   }
 };

--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -34,7 +34,7 @@ struct BgemmKernel<ruy::Path::kAvx2, LhsScalar, RhsScalar, DstScalar, Spec> {
         "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
-    // TODO: not implemented -> fallback to standard cpp
+    TFLITE_DCHECK(false);
   }
 };
 
@@ -57,7 +57,7 @@ struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar, Spec> {
         "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
-    // TODO: not implemented -> fallback to standard cpp
+    TFLITE_DCHECK(false);
   }
 };
 

--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -32,8 +32,6 @@ struct BgemmKernel<ruy::Path::kAvx2, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
-    static_assert(std::is_signed<DstScalar>::value,
-                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented -> fallback to standard cpp
   }
 };
@@ -55,8 +53,6 @@ struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar, Spec> {
         // std::is_unsigned<LhsScalar>::value &&
         std::is_integral<LhsScalar>::value,
         "Input to binary kernel should be of type unsigned integral.");
-    static_assert(std::is_signed<DstScalar>::value,
-                  "Output of binary kernel should be of a signed type.");
     // TODO: not implemented -> fallback to standard cpp
   }
 };

--- a/larq_compute_engine/tflite/build_make/Makefile
+++ b/larq_compute_engine/tflite/build_make/Makefile
@@ -1,7 +1,7 @@
 #
 # This is based on
 # tensorflow/tensorflow/lite/tools/make/Makefile
-# 
+#
 # The makefile will always be run from the root of the compute engine repository
 
 # Make uses /bin/sh by default, which is incompatible with the bashisms seen

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -669,23 +669,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   if (kernel_type == KernelType::kRuyOptimized) {
     switch (conv_params->bitpacking_bitwidth) {
-// On Arm64, we don't yet support 8-bit bitpacked input or writing bitpacked
-// output.
-#if RUY_PLATFORM(ARM_64)
-      case 32:
-        if (conv_params->write_bitpacked_output)
-          return kTfLiteError;
-        else
-          EvalOpt<float, std::uint32_t, float>(context, node, conv_params);
-        return kTfLiteOk;
-      case 64:
-        if (conv_params->write_bitpacked_output)
-          return kTfLiteError;
-        else
-          EvalOpt<float, std::uint64_t, float>(context, node, conv_params);
-        return kTfLiteOk;
-// But we support both in our C++ kernels for Arm32 and x86.
-#else
       case 8:
         if (conv_params->write_bitpacked_output)
           EvalOpt<float, std::uint8_t, std::int8_t>(context, node, conv_params);
@@ -706,7 +689,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         else
           EvalOpt<float, std::uint64_t, float>(context, node, conv_params);
         return kTfLiteOk;
-#endif
     }
   } else if (kernel_type == KernelType::kGenericRef) {
     if (conv_params->bitpacking_bitwidth == 32) {

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -150,6 +150,7 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     conv_params->padding_type = kTfLitePaddingSame;
   } else {
     context->ReportError(context, "Invalid padding attribute.");
+    return conv_params;
   }
 
   // Read fused activation
@@ -199,6 +200,7 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     context->ReportError(context,
                          "Cannot read bitpacked input unless the `channels_in` "
                          "attribute is set in the converter.");
+    return conv_params;
   }
 
   if (conv_params->padding_type == TfLitePadding::kTfLitePaddingSame &&
@@ -419,7 +421,7 @@ TfLiteStatus Prepare(KernelType kernel_type,
   conv_params->is_filter_repacked = false;
 
   return kTfLiteOk;
-}  // namespace bconv2d
+}
 
 template <KernelType kernel_type, int default_bitpacking_bitwidth>
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -37,21 +37,21 @@ const int kTensorNotAllocated = -1;
 
 typedef struct {
   // input tensor dimensions
-  std::int32_t batch{0};
-  std::int32_t input_width{0};
-  std::int32_t input_height{0};
+  std::int64_t batch{0};
+  std::int64_t input_width{0};
+  std::int64_t input_height{0};
 
   // filters tensor dimensions
-  std::int32_t filter_width{0};
-  std::int32_t filter_height{0};
-  std::int32_t channels_in{0};
-  std::int32_t channels_out{0};
+  std::int64_t filter_width{0};
+  std::int64_t filter_height{0};
+  std::int64_t channels_in{0};
+  std::int64_t channels_out{0};
 
   // strides
-  std::int32_t strides[4] = {};
+  std::int64_t strides[4] = {};
 
   // dilations
-  std::int32_t dilations[4] = {};
+  std::int64_t dilations[4] = {};
 
   // padding
   TfLitePadding padding_type{};
@@ -59,8 +59,8 @@ typedef struct {
   int pad_value = 0;  // Must be 0 or 1
 
   // output tensor dimensions
-  std::int32_t out_width{0};
-  std::int32_t out_height{0};
+  std::int64_t out_width{0};
+  std::int64_t out_height{0};
 
   ce::core::FilterFormat filter_format{ce::core::FilterFormat::Unknown};
 

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -190,7 +190,7 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     conv_params->write_bitpacked_output = false;
   }
 
-  // If we are reading bitpacked input then the both input tensor and the
+  // If we are reading bitpacked input then both the input tensor and the
   // filters are bitpacked along the (input) channels axis. This means that we
   // cannot infer the 'true' input shape, and so we have to add an explicit
   // integer attribute to the op in the converter.

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -408,9 +408,6 @@ TfLiteStatus Prepare(KernelType kernel_type,
     // Determine the type
     if (conv_params->bitpack_before_im2col) {
       switch (conv_params->bitpacking_bitwidth) {
-        case 8:
-          im2col->type = kTfLiteInt8;
-          break;
         case 32:
           im2col->type = kTfLiteInt32;
           break;
@@ -656,13 +653,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   if (kernel_type == KernelType::kRuyOptimized) {
     switch (conv_params->bitpacking_bitwidth) {
-      case 8:
-        if (conv_params->write_bitpacked_output)
-          EvalOpt<float, std::uint8_t, std::int32_t>(context, node,
-                                                     conv_params);
-        else
-          EvalOpt<float, std::uint8_t, float>(context, node, conv_params);
-        return kTfLiteOk;
       case 32:
         if (conv_params->write_bitpacked_output)
           EvalOpt<float, std::uint32_t, std::int32_t>(context, node,

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -37,21 +37,21 @@ const int kTensorNotAllocated = -1;
 
 typedef struct {
   // input tensor dimensions
-  std::int64_t batch{0};
-  std::int64_t input_width{0};
-  std::int64_t input_height{0};
+  std::int32_t batch{0};
+  std::int32_t input_width{0};
+  std::int32_t input_height{0};
 
   // filters tensor dimensions
-  std::int64_t filter_width{0};
-  std::int64_t filter_height{0};
-  std::int64_t channels_in{0};
-  std::int64_t channels_out{0};
+  std::int32_t filter_width{0};
+  std::int32_t filter_height{0};
+  std::int32_t channels_in{0};
+  std::int32_t channels_out{0};
 
   // strides
-  std::int64_t strides[4] = {};
+  std::int32_t strides[4] = {};
 
   // dilations
-  std::int64_t dilations[4] = {};
+  std::int32_t dilations[4] = {};
 
   // padding
   TfLitePadding padding_type{};
@@ -59,8 +59,8 @@ typedef struct {
   int pad_value = 0;  // Must be 0 or 1
 
   // output tensor dimensions
-  std::int64_t out_width{0};
-  std::int64_t out_height{0};
+  std::int32_t out_width{0};
+  std::int32_t out_height{0};
 
   ce::core::FilterFormat filter_format{ce::core::FilterFormat::Unknown};
 
@@ -89,12 +89,15 @@ typedef struct {
   bool is_filter_repacked = false;
 
   int bitpacking_bitwidth;
+  bool read_bitpacked_input = false;
+  bool write_bitpacked_output = false;
 
   bool conv_params_initialized = false;
 } TfLiteBConv2DParams;
 
 inline void decide_bitpack_before_im2col(TfLiteBConv2DParams* conv_params) {
-  if (conv_params->channels_in >= conv_params->bitpacking_bitwidth / 4) {
+  if (conv_params->read_bitpacked_input ||
+      conv_params->channels_in >= conv_params->bitpacking_bitwidth / 4) {
     conv_params->bitpack_before_im2col = true;
   } else {
     conv_params->bitpack_before_im2col = false;
@@ -163,13 +166,39 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     context->ReportError(context, "Invalid value for activation.");
     return conv_params;
   }
-
   conv_params->pad_value =
       m["pad_values"].IsNull() ? 0 : m["pad_values"].AsInt64();
-
   if (conv_params->pad_value != 0 && conv_params->pad_value != 1) {
     context->ReportError(context, "Attribute pad_values must be 0 or 1.");
     return conv_params;
+  }
+
+  // Reading bitpacking flags
+  if (!m["read_bitpacked_input"].IsNull() &&
+      !m["write_bitpacked_output"].IsNull()) {
+    // We need to gatekeep with a null check in case the model was converted
+    // before these flags were added to the converter.
+    conv_params->read_bitpacked_input = m["read_bitpacked_input"].AsBool();
+    conv_params->write_bitpacked_output = m["write_bitpacked_output"].AsBool();
+  } else {
+    conv_params->read_bitpacked_input = false;
+    conv_params->write_bitpacked_output = false;
+  }
+
+  // If we are reading bitpacked input then the both input tensor and the
+  // filters are bitpacked along the (input) channels axis. This means that we
+  // cannot infer the 'true' input shape, and so we have to add an explicit
+  // integer attribute to the op in the converter.
+  if (!m["channels_in"].IsNull()) {
+    // Again, we need to gatekeep with a null check here.
+    conv_params->channels_in = m["channels_in"].AsInt32();
+  } else if (conv_params->read_bitpacked_input) {
+    // We don't expect this branch to ever be taken because the
+    // `read_bitpacked_input` and `channels_in` attributes will be added to the
+    // converter at the same time, but just in case we should throw here.
+    context->ReportError(context,
+                         "Cannot read bitpacked input unless the `channels_in` "
+                         "attribute is set in the converter.");
   }
 
   if (conv_params->padding_type == TfLitePadding::kTfLitePaddingSame &&
@@ -178,6 +207,14 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
     context->ReportError(
         context,
         "Fused activations are only supported with valid or one-padding.");
+    return conv_params;
+  }
+
+  if (conv_params->padding_type == TfLitePadding::kTfLitePaddingSame &&
+      conv_params->pad_value != 1 && conv_params->write_bitpacked_output) {
+    context->ReportError(context,
+                         "Writing bitpacked output is only supported with "
+                         "valid or one-padding.");
     return conv_params;
   }
 
@@ -215,22 +252,32 @@ TfLiteStatus Prepare(KernelType kernel_type,
   // The inputs post_mutiply and post_activation_bias are currently float
   // in order to accomodate for batchnorm scales
   // Later this might be changed to the int8 system of multipliers+shifts
-  TF_LITE_ENSURE_EQ(context, input->type, kTfLiteFloat32);
   TF_LITE_ENSURE_EQ(context, post_activation_multiplier->type, kTfLiteFloat32);
   TF_LITE_ENSURE_EQ(context, post_activation_bias->type, kTfLiteFloat32);
-  TF_LITE_ENSURE_EQ(context, output->type, kTfLiteFloat32);
-
-  // TODO: more intelligent selection of the parameters `bitpacking_bitwidth`
-  //       and `bitpack_before_im2col` based on benchmarking results
-  //       (as in https://github.com/larq/compute-engine/issues/290).
-  conv_params->bitpacking_bitwidth = default_bitpacking_bitwidth;
+  if (conv_params->read_bitpacked_input) {
+    TF_LITE_ENSURE_EQ(context, input->type, kTfLiteUInt8);
+    conv_params->bitpacking_bitwidth = 8;
+  } else {
+    TF_LITE_ENSURE_EQ(context, input->type, kTfLiteFloat32);
+    TF_LITE_ENSURE_EQ(context, conv_params->channels_in, input->dims->data[3]);
+    // TODO: more intelligent selection of the parameters `bitpacking_bitwidth`
+    //       and `bitpack_before_im2col` based on benchmarking results
+    //       (as in https://github.com/larq/compute-engine/issues/290).
+    conv_params->bitpacking_bitwidth = default_bitpacking_bitwidth;
+  }
+  if (conv_params->write_bitpacked_output) {
+    TF_LITE_ENSURE_EQ(context, output->type, kTfLiteUInt8);
+  } else {
+    TF_LITE_ENSURE_EQ(context, output->type, kTfLiteFloat32);
+  }
 
   // reading the input dimensions
   // TF and TF lite have the same input format [B, H, W, Ci]
   conv_params->batch = input->dims->data[0];
   conv_params->input_height = input->dims->data[1];
   conv_params->input_width = input->dims->data[2];
-  conv_params->channels_in = input->dims->data[3];
+  if (!conv_params->read_bitpacked_input)
+    conv_params->channels_in = input->dims->data[3];
 
   // reading the filter dimensions
   // only OHWI layout is supported for filters
@@ -278,7 +325,12 @@ TfLiteStatus Prepare(KernelType kernel_type,
   output_shape->data[0] = conv_params->batch;
   output_shape->data[1] = conv_params->out_height;
   output_shape->data[2] = conv_params->out_width;
-  output_shape->data[3] = conv_params->channels_out;
+  if (conv_params->write_bitpacked_output) {
+    // If we write bitpacked output, we use 8-bit bitpacking into bytes.
+    output_shape->data[3] = (conv_params->channels_out + 7) / 8;
+  } else {
+    output_shape->data[3] = conv_params->channels_out;
+  }
 
   // allocate the output buffer
   TF_LITE_ENSURE_OK(context,
@@ -339,6 +391,9 @@ TfLiteStatus Prepare(KernelType kernel_type,
     // Determine the type
     if (conv_params->bitpack_before_im2col) {
       switch (conv_params->bitpacking_bitwidth) {
+        case 8:
+          im2col->type = kTfLiteUInt8;
+          break;
         case 32:
           im2col->type = kTfLiteInt32;
           break;
@@ -364,7 +419,7 @@ TfLiteStatus Prepare(KernelType kernel_type,
   conv_params->is_filter_repacked = false;
 
   return kTfLiteOk;
-}
+}  // namespace bconv2d
 
 template <KernelType kernel_type, int default_bitpacking_bitwidth>
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
@@ -403,7 +458,7 @@ inline void GetConvParamsType(const TfLiteBConv2DParams& conv_params,
   op_params.quantized_activation_max = conv_params.output_activation_max;
 }
 
-template <class T, class TBitpacked>
+template <typename T, typename TBitpacked, typename DstScalar>
 void EvalOpt(TfLiteContext* context, TfLiteNode* node,
              TfLiteBConv2DParams* params) {
   const auto* input = GetInput(context, node, 0);
@@ -500,22 +555,27 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
   ConvParams op_params;
   GetConvParamsType(*params, op_params);
 
-  // `BConv2D` wants the *unpacked* filter shape
+  // `BConv2D` wants the *unpacked* filter and output shape.
   auto unpacked_filter_shape = GetTensorShape(filter);
-  unpacked_filter_shape.SetDim(3, GetTensorShape(input).Dims(3));
+  unpacked_filter_shape.SetDim(3, params->channels_in);
+  auto unpacked_output_shape = GetTensorShape(output);
+  unpacked_output_shape.SetDim(3, params->channels_out);
 
   // We pass the shape of the original unpacked filter, so that all the shape
   // information is correct (number of channels etc), but we pass the packed
-  // weights data
-  BConv2D<T, TBitpacked>(
+  // weights data.
+  //     Likewise, we pass the original output shape even if we are going to
+  // write bitpacked output directly.
+  BConv2D<T, TBitpacked, std::int32_t, DstScalar>(
       op_params, GetTensorShape(input), GetTensorData<T>(input),
       unpacked_filter_shape,
       reinterpret_cast<TBitpacked*>(params->filter_packed.data()),
       GetTensorData<float>(post_activation_multiplier),
-      GetTensorData<float>(post_activation_bias), GetTensorShape(output),
-      GetTensorData<T>(output), GetTensorShape(im2col),
+      GetTensorData<float>(post_activation_bias), unpacked_output_shape,
+      GetTensorData<DstScalar>(output), GetTensorShape(im2col),
       GetTensorData<T>(im2col), params->bitpack_before_im2col,
-      params->padding_buffer.data(), params->pad_value,
+      reinterpret_cast<DstScalar*>(params->padding_buffer.data()),
+      params->pad_value, params->read_bitpacked_input,
       CpuBackendContext::GetFromContext(context));
 }
 
@@ -525,12 +585,45 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   if (kernel_type == KernelType::kRuyOptimized) {
     switch (conv_params->bitpacking_bitwidth) {
+// On Arm64, we don't yet support 8-bit bitpacked input or writing bitpacked
+// output.
+#if RUY_PLATFORM(ARM_64)
       case 32:
-        EvalOpt<float, std::uint32_t>(context, node, conv_params);
+        if (conv_params->write_bitpacked_output)
+          return kTfLiteError;
+        else
+          EvalOpt<float, std::uint32_t, float>(context, node, conv_params);
         return kTfLiteOk;
       case 64:
-        EvalOpt<float, std::uint64_t>(context, node, conv_params);
+        if (conv_params->write_bitpacked_output)
+          return kTfLiteError;
+        else
+          EvalOpt<float, std::uint64_t, float>(context, node, conv_params);
         return kTfLiteOk;
+// But we support both in our C++ kernels for Arm32 and x86.
+#else
+      case 8:
+        if (conv_params->write_bitpacked_output)
+          EvalOpt<float, std::uint8_t, std::uint8_t>(context, node,
+                                                     conv_params);
+        else
+          EvalOpt<float, std::uint8_t, float>(context, node, conv_params);
+        return kTfLiteOk;
+      case 32:
+        if (conv_params->write_bitpacked_output)
+          EvalOpt<float, std::uint32_t, std::uint8_t>(context, node,
+                                                      conv_params);
+        else
+          EvalOpt<float, std::uint32_t, float>(context, node, conv_params);
+        return kTfLiteOk;
+      case 64:
+        if (conv_params->write_bitpacked_output)
+          EvalOpt<float, std::uint64_t, std::uint8_t>(context, node,
+                                                      conv_params);
+        else
+          EvalOpt<float, std::uint64_t, float>(context, node, conv_params);
+        return kTfLiteOk;
+#endif
     }
   }
   return kTfLiteError;

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -126,24 +126,31 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
     TBitpacked* packed_im2col_data = reinterpret_cast<TBitpacked*>(im2col_data);
 
     RuntimeShape result_shape;
-    // The input tensor has this shape which we bitpack along the channels
-    // dimension [batch, input height, input width, channels].
-    RuntimeShape packed_input_shape;
-    const TBitpacked* input_data_bp;
 
     if (read_bitpacked_input) {
-      packed_input_shape.ReplaceWith(4, input_shape.DimsData());
-      input_data_bp = reinterpret_cast<const TBitpacked*>(input_data);
+      RuntimeShape packed_input_shape = input_shape;
+
+      const TBitpacked* input_data_bp =
+          reinterpret_cast<const TBitpacked*>(input_data);
+
+      im2col<TBitpacked>(params, packed_input_shape, input_data_bp,
+                         packed_filter_shape, output_shape, im2col_shape,
+                         packed_im2col_data, result_shape, &rhs_data);
     } else {
       // Buffer for bitpacked input data.
       static std::vector<TBitpacked> input_data_bp;
+
+      // The input tensor has this shape which we bitpack along the channels
+      // dimension [batch, input height, input width, channels].
+      RuntimeShape packed_input_shape;
+
       ce::core::packbits_tensor(input_shape, input_data, packed_input_shape,
                                 input_data_bp);
-    }
 
-    im2col<TBitpacked>(params, packed_input_shape, input_data_bp,
-                       packed_filter_shape, output_shape, im2col_shape,
-                       packed_im2col_data, result_shape, &rhs_data);
+      im2col<TBitpacked>(params, packed_input_shape, input_data_bp.data(),
+                         packed_filter_shape, output_shape, im2col_shape,
+                         packed_im2col_data, result_shape, &rhs_data);
+    }
 
     k = result_shape.Dims(3);
     m = FlatSizeSkipDim(result_shape, 3);

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -126,31 +126,24 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
     TBitpacked* packed_im2col_data = reinterpret_cast<TBitpacked*>(im2col_data);
 
     RuntimeShape result_shape;
+    // The input tensor has this shape which we bitpack along the channels
+    // dimension [batch, input height, input width, channels].
+    RuntimeShape packed_input_shape;
+    const TBitpacked* input_data_bp;
 
     if (read_bitpacked_input) {
-      RuntimeShape packed_input_shape = input_shape;
-
-      const TBitpacked* input_data_bp =
-          reinterpret_cast<const TBitpacked*>(input_data);
-
-      im2col<TBitpacked>(params, packed_input_shape, input_data_bp,
-                         packed_filter_shape, output_shape, im2col_shape,
-                         packed_im2col_data, result_shape, &rhs_data);
+      packed_input_shape.ReplaceWith(4, input_shape.DimsData());
+      input_data_bp = reinterpret_cast<const TBitpacked*>(input_data);
     } else {
       // Buffer for bitpacked input data.
       static std::vector<TBitpacked> input_data_bp;
-
-      // The input tensor has this shape which we bitpack along the channels
-      // dimension [batch, input height, input width, channels].
-      RuntimeShape packed_input_shape;
-
       ce::core::packbits_tensor(input_shape, input_data, packed_input_shape,
                                 input_data_bp);
-
-      im2col<TBitpacked>(params, packed_input_shape, input_data_bp.data(),
-                         packed_filter_shape, output_shape, im2col_shape,
-                         packed_im2col_data, result_shape, &rhs_data);
     }
+
+    im2col<TBitpacked>(params, packed_input_shape, input_data_bp,
+                       packed_filter_shape, output_shape, im2col_shape,
+                       packed_im2col_data, result_shape, &rhs_data);
 
     k = result_shape.Dims(3);
     m = FlatSizeSkipDim(result_shape, 3);

--- a/larq_compute_engine/tflite/tests/BUILD
+++ b/larq_compute_engine/tflite/tests/BUILD
@@ -5,7 +5,7 @@ package(
 
 cc_test(
     name = "bconv2d_test",
-    size = "small",
+    size = "medium",
     srcs = ["bconv2d_test.cc"],
     deps = [
         "//larq_compute_engine/tflite/kernels:lce_ops",

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -694,33 +694,15 @@ TEST_P(BConv2DOpTest, ReadFPWriteFP) {
 }
 
 TEST_P(BConv2DOpTest, ReadBPWriteBP) {
-  if (TestParam(GetParam()).registration ==
-      compute_engine::tflite::Register_BCONV_2D32_REF) {
-    // Reference op uses 32-bit bitpacking
-    runTest<std::int32_t, std::int32_t>(TestParam(GetParam()));
-  } else {
-    runTest<std::int8_t, std::int8_t>(TestParam(GetParam()));
-  }
+  runTest<std::int32_t, std::int32_t>(TestParam(GetParam()));
 }
 
 TEST_P(BConv2DOpTest, ReadFPWriteBP) {
-  if (TestParam(GetParam()).registration ==
-      compute_engine::tflite::Register_BCONV_2D32_REF) {
-    // Reference op uses 32-bit bitpacking
-    runTest<float, std::int32_t>(TestParam(GetParam()));
-  } else {
-    runTest<float, std::int8_t>(TestParam(GetParam()));
-  }
+  runTest<float, std::int32_t>(TestParam(GetParam()));
 }
 
 TEST_P(BConv2DOpTest, ReadBPWriteFP) {
-  if (TestParam(GetParam()).registration ==
-      compute_engine::tflite::Register_BCONV_2D32_REF) {
-    // Reference op uses 32-bit bitpacking
-    runTest<std::int32_t, float>(TestParam(GetParam()));
-  } else {
-    runTest<std::int8_t, float>(TestParam(GetParam()));
-  }
+  runTest<std::int32_t, float>(TestParam(GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -451,11 +451,11 @@ void runTest(const TestParam& param) {
   static_assert(std::is_same<TInput, float>::value ||
                     std::is_same<TInput, std::int8_t>::value ||
                     std::is_same<TInput, std::int32_t>::value,
-                "The LCE op input type must be float or uint8 or uint32.");
+                "The LCE op input type must be float or int8 or int32.");
   static_assert(std::is_same<TOutput, float>::value ||
                     std::is_same<TOutput, std::int8_t>::value ||
                     std::is_same<TOutput, std::int32_t>::value,
-                "The LCE op output type must be float or uint8 or uint32.");
+                "The LCE op output type must be float or int8 or int32.");
 
   const register_function registration = param.registration;
   const int input_batch_count = param.input_batch_count;

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -817,15 +817,9 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(Padding_VALID, Padding_SAME, Padding_ONE),  // padding
         ::testing::Values(ActivationFunctionType_NONE,
                           ActivationFunctionType_RELU),  // activation function
-#if RUY_PLATFORM(ARM_64)
-        // There's not yet Arm64 kernel support for bitpacked activations.
-        ::testing::Values(false),  // read bitpacked input
-        ::testing::Values(false),  // write bitpcked output
-#else
-        ::testing::Values(false, true),  // read bitpacked input
+        ::testing::Values(false, true),                  // read bitpacked input
         ::testing::Values(false, true),  // write bitpacked output
-#endif
-        ::testing::Values(1, 2),  // number of threads
+        ::testing::Values(1, 2),         // number of threads
         ::testing::ValuesIn(BConv2DOpTest::GetKernelsTuples(*kKernelMap))),
     TestParam::TestNameSuffix);
 


### PR DESCRIPTION
## What do these changes do?

This feature is disabled by default and so does not change any behaviour for new or existing converted models; enabling this feature will require changes to the converter to set the correct op flags.

Currently, binary convolutions expect full precision input, bitpack that input, perform the computation, and then write full-precision output. This feature allows a binary convolutions to instead perform bitpacking inside the kernel and write (8-bit or 32-bit) bitpacked output, and for the subsequent binary convolution to skip the usual initial bitpacking step and read the already-bitpacked input directly. Doing this significantly reduces the number of reads and writes to memory and the the overall memory footprint of the model inference.

Support is added only for the C++ kernels (x86 and Arm32), including the reference kernel. Support for the optimised assembly kernels (Arm64) requires additional future work.

## How have these changes been tested?

The existing `bconv2d_test.cc` tests have been extended to support testing bitpacked input/output tensors with the Ruy c++ kernel (8-bit bitpacking) and the reference kernel (32-bit bitpacking).