### PR TITLE
remove obsolete bazel build targets

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -43,30 +43,8 @@ cc_library(
 )
 
 cc_library(
-    name = "fused_bgemm_functor",
-    hdrs = [
-        "fused_bgemm_functor.h",
-    ],
-    deps = [
-        ":bgemm_functor",
-        ":packbits",
-    ],
-)
-
-cc_library(
     name = "padding_functor",
     hdrs = ["padding_functor.h"],
-)
-
-cc_library(
-    name = "bconv2d_functor",
-    hdrs = [
-        "bconv2d_functor.h",
-    ],
-    deps = [
-        ":fused_bgemm_functor",
-        ":padding_functor",
-    ],
 )
 
 cc_library(


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
removing the leftover build targets from already deleted legacy code
