### PR TITLE
(skip-ci) Add missing copyright notice.

### DIFF
--- a/larq_compute_engine/tflite/kernels/lce_register.cc
+++ b/larq_compute_engine/tflite/kernels/lce_register.cc
@@ -1,3 +1,19 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright (C) 2020 Larq Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 //
 // This file is a copy of `tensorflow/tensorflow/lite/kernels/register.cc`.
 // But with our custom ops added to it.


### PR DESCRIPTION
I noticed that in TensorFlow this file has a copyright notice at the top, so I've added it to our modified version too.