### PR TITLE
Add MLIR status handler to log converter errors

### DIFF
--- a/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
@@ -12,6 +12,7 @@
 #include "tensorflow/compiler/mlir/lite/flatbuffer_translate.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/import_model.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/mlir_roundtrip_flags.h"
+#include "tensorflow/compiler/mlir/tensorflow/utils/error_util.h"
 #include "tensorflow/compiler/mlir/tensorflow/utils/import_utils.h"
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/protobuf/graph_debug_info.pb.h"
@@ -47,6 +48,8 @@ pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
 
   mlir::MLIRContext context;
   GraphDebugInfo debug_info;
+  mlir::StatusScopedDiagnosticHandler statusHandler(&context,
+                                                    /*propagate=*/true);
   auto module = ConvertGraphdefToMlir(graphdef, debug_info, specs, &context);
 
   if (!module.ok()) {


### PR DESCRIPTION
## What do these changes do?
This adds a MLIR status handler that will log errors to the TensorFlow Cpp logger.
I tried to correctly forward the location info to Python, but this resulted in some very unreadable error messages with duplication and weird `unknown` logs all over the place. With `propagate=true` this will just reuse the TensorFlow Cpp logger which logs errors nicely to stderr.

## How Has This Been Tested?
I manually set `emit_custom_ops=False` in the flatbuffer export which will throw a `RuntimeError` in Python and the MLIR location info is correctly forwarded.