### PR TITLE
Add reference implementation of binary convolution.

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -135,3 +135,13 @@ cc_library(
         ":bgemm_ruy",
     ],
 )
+
+cc_library(
+    name = "bconv2d_impl_ref",
+    hdrs = [
+        "bconv2d_impl_ref.h",
+    ],
+    deps = [
+        ":bgemm_functor",
+    ],
+)

--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -1,3 +1,18 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright (C) 2020 Larq Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 #ifndef COMPUTE_EGNINE_CORE_BCONV2d_IMPL_H_
 #define COMPUTE_EGNINE_CORE_BCONV2d_IMPL_H_
 

--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -98,7 +98,7 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                 const int in_x = in_x_origin + dilation_width_factor * filter_x;
                 const int in_y =
                     in_y_origin + dilation_height_factor * filter_y;
-                // pad_value is 0
+                // `pad_value=1`, which means the bitpacked value is 0, so we set `input_value=0`
                 TBitpacked input_value = 0;
                 if ((in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
                     (in_y < input_height)) {

--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -98,7 +98,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
                 const int in_x = in_x_origin + dilation_width_factor * filter_x;
                 const int in_y =
                     in_y_origin + dilation_height_factor * filter_y;
-                // `pad_value=1`, which means the bitpacked value is 0, so we set `input_value=0`
+                // `pad_value=1`, which means the bitpacked value is 0, so we
+                // set `input_value=0`
                 TBitpacked input_value = 0;
                 if ((in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
                     (in_y < input_height)) {

--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -1,0 +1,126 @@
+#ifndef COMPUTE_EGNINE_CORE_BCONV2d_IMPL_H_
+#define COMPUTE_EGNINE_CORE_BCONV2d_IMPL_H_
+
+#include "larq_compute_engine/core/bgemm_functor.h"
+#include "larq_compute_engine/core/packbits_utils.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+// This file is originally copied from
+// "tensorflow/lite/kernels/internal/reference/conv.h".
+// However, it's modified to perform binary convolution instead
+using namespace tflite;
+
+namespace compute_engine {
+namespace ce = compute_engine;
+namespace ref {
+
+template <class T, class TBitpacked>
+inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
+                    const T* input_data,
+                    const RuntimeShape& packed_filter_shape,
+                    const TBitpacked* packed_filter_data,
+                    const float* post_activation_multiplier_data,
+                    const float* post_activation_bias_data,
+                    const RuntimeShape& output_shape, T* output_data,
+                    const RuntimeShape& im2col_shape, T* im2col_data,
+                    bool bitpack_before_im2col, T* padding_buffer,
+                    const int pad_value, void* cpu_backend_context) {
+  // TODO: generalize this
+  using AccumScalar = std::int32_t;
+  using DstScalar = T;
+
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = params.padding_values.width;
+  const int pad_height = params.padding_values.height;
+  // TODO: should the type be AccumScalar?
+  // packed_filter_shape.Dims(3) is bitpacked
+  // therefore we need to use the input_shape.Dims(3)
+  const std::int32_t backtransform_add = packed_filter_shape.Dims(1) *
+                                         packed_filter_shape.Dims(2) *
+                                         input_shape.Dims(3);
+  const auto* post_activation_multiplier = post_activation_multiplier_data;
+  const auto* post_activation_bias = post_activation_bias_data;
+  AccumScalar clamp_min = params.quantized_activation_min;
+  AccumScalar clamp_max = params.quantized_activation_max;
+
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(packed_filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+  // Buffer for bitpacked input data
+  static std::vector<TBitpacked> packed_input_data;
+  RuntimeShape packed_input_shape;
+  ce::core::packbits_tensor(input_shape, input_data, packed_input_shape,
+                            packed_input_data);
+
+  (void)im2col_data;   // only used in optimized code.
+  (void)im2col_shape;  // only used in optimized code.
+  const int batches = MatchingDim(packed_input_shape, 0, output_shape, 0);
+  const int input_depth =
+      MatchingDim(packed_input_shape, 3, packed_filter_shape, 3);
+  const int output_depth = MatchingDim(packed_filter_shape, 0, output_shape, 3);
+  const int input_height = packed_input_shape.Dims(1);
+  const int input_width = packed_input_shape.Dims(2);
+  const int filter_height = packed_filter_shape.Dims(1);
+  const int filter_width = packed_filter_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    for (int out_y = 0; out_y < output_height; ++out_y) {
+      for (int out_x = 0; out_x < output_width; ++out_x) {
+        for (int out_channel = 0; out_channel < output_depth; ++out_channel) {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          AccumScalar accum = AccumScalar(0);
+          for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
+            for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
+              for (int in_channel = 0; in_channel < input_depth; ++in_channel) {
+                const int in_x = in_x_origin + dilation_width_factor * filter_x;
+                const int in_y =
+                    in_y_origin + dilation_height_factor * filter_y;
+                // If the location is outside the bounds of the input image,
+                // use pad_value as default value.
+                float input_value = pad_value;
+                if ((in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
+                    (in_y < input_height)) {
+                  input_value = input_data[Offset(input_shape, batch, in_y,
+                                                  in_x, in_channel)];
+                }
+                float filter_value =
+                    packed_filter_data[Offset(packed_filter_shape, out_channel,
+                                              filter_y, filter_x, in_channel)];
+                accum += ce::core::xor_popcount<TBitpacked, AccumScalar>(
+                    input_value, filter_value);
+              }
+            }
+          }
+          // Backtransformation to {-1,1} space
+          accum = backtransform_add - 2 * accum;
+          // Activation
+          accum = std::min<AccumScalar>(accum, clamp_max);
+          accum = std::max<AccumScalar>(accum, clamp_min);
+          // Post multiply and add are done in float
+          DstScalar dst_val = static_cast<DstScalar>(accum);
+          if (post_activation_multiplier) {
+            dst_val *= post_activation_multiplier[out_channel];
+          }
+          if (post_activation_bias) {
+            dst_val += post_activation_bias[out_channel];
+          }
+          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
+              dst_val;
+        }
+      }
+    }
+  }
+}
+
+}  // namespace ref
+}  // namespace compute_engine
+
+#endif  // COMPUTE_EGNINE_CORE_BCONV2d_IMPL_H_

--- a/larq_compute_engine/core/packbits_utils.h
+++ b/larq_compute_engine/core/packbits_utils.h
@@ -8,10 +8,8 @@
 using namespace tflite;
 
 namespace compute_engine {
-
 namespace ce = compute_engine;
-
-namespace tflite {
+namespace core {
 
 // Convenience function for bitpacking a tensor along its last dimension
 // and updating the tensor shape
@@ -48,7 +46,7 @@ RuntimeShape packed_shape(const RuntimeShape& in_shape) {
   return out_shape;
 }
 
-}  // namespace tflite
+}  // namespace core
 }  // namespace compute_engine
 
 #endif  // COMPUTE_ENGINE_CORE_PACKBITS_UTILS_H_

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -36,6 +36,7 @@ cc_library(
     copts = tflite_copts() + tf_opts_nortti_if_android(),
     deps = [
         ":bconv2d_impl",
+        "//larq_compute_engine/core:bconv2d_impl_ref",
         "@flatbuffers",
         "@gemmlowp//:profiler",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -293,8 +293,9 @@ TfLiteStatus Prepare(KernelType kernel_type,
 
   if (kernel_type == KernelType::kGenericRef) {
     // We require 32-bit bitpacking in the reference implementation
-    TFLITE_ENSURE_EQ(conv_params->bitpacking_bitwidth, 32);
-    // We only support one-padding or valid-padding in the reference implementation
+    TF_LITE_ENSURE_EQ(conv_params->bitpacking_bitwidth, 32);
+    // We only support one-padding or valid-padding in the reference
+    // implementation
     TF_LITE_ENSURE(context, !(conv_params->pad_value == 0 &&
                               conv_params->padding_type ==
                                   TfLitePadding::kTfLitePaddingSame));
@@ -620,15 +621,11 @@ TfLiteRegistration* Register_BCONV_2D() {
 
 #else  // disabled TFLITE_WITH_RUY
 
-#if RUY_PLATFORM(ARM_32)
+  // When the RUY is disabled, we run the 32-bit reference implementation
+  // on both 32-bit and 64-bit architectures.
   return Register_BCONV_2D32_REF();
-#else  // ARM 64 and x86
-  static_assert(false,
-                "LCE does not support 64-bit binary convolution kernel "
-                "implementation without TFLite RUY activated.");
-#endif
 
-#endif
+#endif  // defined TFLITE_WITH_RUY
 }
 
 }  // namespace tflite

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -572,13 +572,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         return kTfLiteOk;
     }
   } else if (kernel_type == KernelType::kGenericRef) {
-    switch (conv_params->bitpacking_bitwidth) {
-      case 32:
-        EvalRef<float, std::uint32_t>(context, node, conv_params);
-        return kTfLiteOk;
-      case 64:
-        EvalRef<float, std::uint64_t>(context, node, conv_params);
-        return kTfLiteOk;
+    if (conv_params->bitpacking_bitwidth == 32) {
+      EvalRef<float, std::uint32_t>(context, node, conv_params);
+      return kTfLiteOk;
     }
   }
 

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -293,7 +293,7 @@ TfLiteStatus Prepare(KernelType kernel_type,
 
   if (kernel_type == KernelType::kGenericRef) {
     // We require 32-bit bitpacking in the reference implementation
-    TF_LITE_ENSURE_EQ(conv_params->bitpacking_bitwidth, 32);
+    TF_LITE_ENSURE_EQ(context, conv_params->bitpacking_bitwidth, 32);
     // We only support one-padding or valid-padding in the reference
     // implementation
     TF_LITE_ENSURE(context, !(conv_params->pad_value == 0 &&

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -292,7 +292,9 @@ TfLiteStatus Prepare(KernelType kernel_type,
   decide_bitpack_before_im2col(conv_params);
 
   if (kernel_type == KernelType::kGenericRef) {
-    // we only support one-padding in reference implementation
+    // We require 32-bit bitpacking in the reference implementation
+    TFLITE_ENSURE_EQ(conv_params->bitpacking_bitwidth, 32);
+    // We only support one-padding or valid-padding in the reference implementation
     TF_LITE_ENSURE(context, !(conv_params->pad_value == 0 &&
                               conv_params->padding_type ==
                                   TfLitePadding::kTfLitePaddingSame));
@@ -622,7 +624,7 @@ TfLiteRegistration* Register_BCONV_2D() {
   return Register_BCONV_2D32_REF();
 #else  // ARM 64 and x86
   static_assert(false,
-                "LCE do not support 64-bit binary convolution kernel "
+                "LCE does not support 64-bit binary convolution kernel "
                 "implementation without TFLite RUY activated.");
 #endif
 

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -120,10 +120,12 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
     // Input tensor has this shape which we bitpack along the channels dimension
     //  [batch, input height, input width, channels]
     RuntimeShape packed_input_shape;
-    packbits_tensor(input_shape, input_data, packed_input_shape, input_data_bp);
+    ce::core::packbits_tensor(input_shape, input_data, packed_input_shape,
+                              input_data_bp);
 
     // Filter tensor was already bitpacked. Only get the new shape
-    RuntimeShape packed_filter_shape = packed_shape<TBitpacked>(filter_shape);
+    RuntimeShape packed_filter_shape =
+        ce::core::packed_shape<TBitpacked>(filter_shape);
 
     // Get the im2col data buffer
     TBitpacked* packed_im2col_data = reinterpret_cast<TBitpacked*>(im2col_data);
@@ -145,8 +147,8 @@ inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
     // The RHS tensor has this shape which we bitpack along the last dimension
     //  [batch, output_height, output_width, k * bitwidth]
     RuntimeShape packed_input_shape;
-    packbits_tensor(result_shape, result_data, packed_input_shape,
-                    input_data_bp);
+    ce::core::packbits_tensor(result_shape, result_data, packed_input_shape,
+                              input_data_bp);
     rhs_data = input_data_bp.data();
 
     k = packed_input_shape.Dims(3);

--- a/larq_compute_engine/tflite/tests/BUILD
+++ b/larq_compute_engine/tflite/tests/BUILD
@@ -5,7 +5,7 @@ package(
 
 cc_test(
     name = "bconv2d_test",
-    size = "small",
+    size = "medium",
     srcs = ["bconv2d_test.cc"],
     deps = [
         "//larq_compute_engine/tflite/kernels:lce_ops",

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -166,6 +166,8 @@ using namespace tflite;
 namespace compute_engine {
 namespace tflite {
 
+TfLiteRegistration* Register_BCONV_2D32_REF();
+TfLiteRegistration* Register_BCONV_2D64_REF();
 TfLiteRegistration* Register_BCONV_2D32_OPT();
 TfLiteRegistration* Register_BCONV_2D64_OPT();
 
@@ -333,8 +335,10 @@ class BConv2DOpModel : public BaseBConv2DOpModel {
 };
 
 const auto kKernelMap = new std::map<string, register_function>({
-    {"BConv2D32", compute_engine::tflite::Register_BCONV_2D32_OPT},
-    {"BConv2D64", compute_engine::tflite::Register_BCONV_2D64_OPT},
+    // {"BConv2D32REF", compute_engine::tflite::Register_BCONV_2D32_REF},
+    // {"BConv2D64REF", compute_engine::tflite::Register_BCONV_2D64_REF},
+    {"BConv2D32OPT", compute_engine::tflite::Register_BCONV_2D32_OPT},
+    {"BConv2D64OPT", compute_engine::tflite::Register_BCONV_2D64_OPT},
 });
 
 class BConv2DOpTest : public ::testing::TestWithParam<TestParamTuple> {

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -167,7 +167,6 @@ namespace compute_engine {
 namespace tflite {
 
 TfLiteRegistration* Register_BCONV_2D32_REF();
-TfLiteRegistration* Register_BCONV_2D64_REF();
 TfLiteRegistration* Register_BCONV_2D32_OPT();
 TfLiteRegistration* Register_BCONV_2D64_OPT();
 
@@ -335,8 +334,7 @@ class BConv2DOpModel : public BaseBConv2DOpModel {
 };
 
 const auto kKernelMap = new std::map<string, register_function>({
-    // {"BConv2D32REF", compute_engine::tflite::Register_BCONV_2D32_REF},
-    // {"BConv2D64REF", compute_engine::tflite::Register_BCONV_2D64_REF},
+    {"BConv2D32REF", compute_engine::tflite::Register_BCONV_2D32_REF},
     {"BConv2D32OPT", compute_engine::tflite::Register_BCONV_2D32_OPT},
     {"BConv2D64OPT", compute_engine::tflite::Register_BCONV_2D64_OPT},
 });
@@ -421,6 +419,16 @@ TEST_P(BConv2DOpTest, SimpleTest) {
   const int packed_num_elem =
       filter_count * filter_height * filter_width * packed_channels;
 
+  // the reference implementation only support one-padding
+  const auto is_reference_registration =
+      (registration == compute_engine::tflite::Register_BCONV_2D32_REF);
+
+  if ((padding == Padding_SAME && pad_values == 0) &&
+      is_reference_registration) {
+    GTEST_SKIP();
+    return;
+  }
+
   using T = float;
   std::vector<T> input_data, padded_input_data, filters_data;
   std::vector<T> post_activation_multiplier_data, post_activation_bias_data,
@@ -430,7 +438,7 @@ TEST_P(BConv2DOpTest, SimpleTest) {
   filters_data.resize(filters_num_elem);
   packed_filters_data.resize(packed_num_elem);
   bias_data.resize(filter_count, 0);
-  post_activation_multiplier_data.resize(filter_count, 0);
+  post_activation_multiplier_data.resize(filter_count, 1);
   post_activation_bias_data.resize(filter_count, 0);
 
   std::random_device rd;


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
Add the reference implementation of binary convolution op (without using the `im2col` algorithm) for 32-bit bitpacking (64-bit bitpacking requires repacking of flatbuffer weights but it is not relevant for our needs at this point).

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
we use the same test matrix as the optimized binary convolution op, we just don't support same-padding with pad values other than one. (for devices with restricted memory available extra padding correction increases the binary size).

## Benchmark Results
<!-- Please provide new benchmark results on supported platforms if you believe these changes affect the LCE latency performance. -->
Benchmark results on our current benchmarking target devices is not relevant since we never use this implementation on them. It will be benchmarked on other target devices tough in future.

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A