### PR TITLE
set bazel as default builder for android AAR

### DIFF
--- a/larq_compute_engine/tflite/java/build_lce_aar.sh
+++ b/larq_compute_engine/tflite/java/build_lce_aar.sh
@@ -14,7 +14,7 @@ trap "rm -rf $TMPDIR" EXIT
 AAR_NAME=lce-lite
 VERSION=$(git describe --tags)
 
-BUILDER="${BUILDER:-bazelisk}"
+BUILDER="${BUILDER:-bazel}"
 BASEDIR=larq_compute_engine/tflite
 CROSSTOOL="//external:android/crosstool"
 HOST_CROSSTOOL="@bazel_tools//tools/cpp:toolchain"


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
in this PR we set the bazel as default builder in android AAR script. The reasoning behind using 
the bazel command instead of directly using bazelisk  is that in our documentation [here](https://docs.larq.dev/compute-engine/build/#2-install-bazelisk) we instruct the user to alias `bazelisk` command with `bazel` but in this script we are forcing the user to have an explicit `bazelisk` command installed on the system which is not consistent with our documentation. In addition, the script now also works for the people who do not intent to use bazelisk. 
 
## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Benchmark Results
<!-- Please provide new benchmark results on supported platforms if you believe these changes affect the LCE latency performance. -->

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
