### PR TITLE
fix dependency for ref. bconv

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -143,5 +143,6 @@ cc_library(
     ],
     deps = [
         ":bgemm_functor",
+        ":packbits_utils",
     ],
 )


### PR DESCRIPTION
this extra dependency was missed without being noticed bc the target using it has already the dependency defined.