### PR TITLE
Switch CI testing from mac to linux

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.9.1 larq_zoo==1.0.b3 tensorflow_datasets==1.3.2 --no-cache
+        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.9.1 larq_zoo==1.0.b3 tensorflow_datasets==1.3.2 packaging --no-cache
       - name: Run Converter test
         run: PYTHONPATH=./ python larq_compute_engine/mlir/python/converter_test.py
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -90,9 +90,9 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.9.1 larq_zoo==1.0.b3 tensorflow_datasets==1.3.2 -e . --no-cache
+        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.9.1 larq_zoo==1.0.b3 tensorflow_datasets==1.3.2 --no-cache
       - name: Run Converter test
-        run: python larq_compute_engine/mlir/python/converter_test.py
+        run: PYTHONPATH=./ python larq_compute_engine/mlir/python/converter_test.py
 
   Android_AAR:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,7 +53,7 @@ jobs:
         run: ./bazelisk run larq_compute_engine/tests:cc_tests_aarch64_qemu --config=aarch64 --compilation_mode=fastbuild
 
   MLIR:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
@@ -63,22 +63,23 @@ jobs:
           export_default_credentials: true
       - name: Install Bazelisk
         run: |
-          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-darwin-amd64 > bazelisk
+          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 > bazelisk
           chmod +x bazelisk
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7
       - name: Configure Bazel
-        run: ./configure.sh
+        run: ./configure.sh <<< $'n\n'
+        shell: bash
       - name: Install pip dependencies
         run: pip install tensorflow==2.1.0 larq~=0.9.1 larq_zoo==1.0.b3 pytest tensorflow_datasets==1.3.2 --no-cache-dir
       - name: Run FileCheck tests
-        run: ./bazelisk test larq_compute_engine/mlir/tests:all --test_output=all --distinct_host_configuration=false $([ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] || echo "--remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials")
+        run: ./bazelisk test larq_compute_engine/mlir/tests:all --test_output=all --distinct_host_configuration=false $([ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] || echo "--remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-ubuntu --google_default_credentials")
       - name: Run End2End tests
-        run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false $([ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] || echo "--remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-macos --google_default_credentials")
+        run: ./bazelisk run larq_compute_engine/tests:end2end_test --distinct_host_configuration=false $([ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] || echo "--remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-ubuntu --google_default_credentials")
 
   ConverterPython:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0]


### PR DESCRIPTION
## What do these changes do?
This unifies our CI testing to run on Ubuntu. We originally opted to run the MLIR tests on Mac to speedup the builds. Since we now have caching we don't need to do this anymore.

## How Has This Been Tested?
CI