### PR TITLE
Update dead download link in README

### DIFF
--- a/larq_compute_engine/tflite/tools/accuracy/ilsvrc/README.md
+++ b/larq_compute_engine/tflite/tools/accuracy/ilsvrc/README.md
@@ -78,13 +78,13 @@ The following optional parameters can be used to modify the inference runtime:
 (2) Download the ground truth labels `.txt` file:
 
 ```bash
-wget https://raw.githubusercontent.com/tensorflow/datasets/master/tensorflow_datasets/image/imagenet2012_validation_labels.txt -O ground_truth_labels.txt
+wget https://raw.githubusercontent.com/tensorflow/datasets/v2.1.0/tensorflow_datasets/image/imagenet2012_validation_labels.txt -O ground_truth_labels.txt
 ```
 
 (3) Download the model output labels `.txt` file:
 
 ```bash
-wget https://raw.githubusercontent.com/tensorflow/datasets/master/tensorflow_datasets/image/imagenet2012_labels.txt -O model_output_labels.txt
+wget https://raw.githubusercontent.com/tensorflow/datasets/v2.1.0/tensorflow_datasets/image/imagenet2012_labels.txt -O model_output_labels.txt
 ```
 
 ### On Android


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?

This fixes a download link in the accuracy-tool README. The tensorflow datasets repo recently moved these files to a different location so we pin it to the `v2.1.0` tag now.