### PR TITLE
Upgrade actions/checkout@v2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@ jobs:
       image: tensorflow/tensorflow:custom-op-ubuntu16
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Install Bazelisk
@@ -103,7 +103,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 > bazelisk


### PR DESCRIPTION
## What do these changes do?
`actions/checkout@v2.1.0` added support for submodules, so we can upgrade to speedup checkout of the submodules.

## How Has This Been Tested?
CI

## Benchmark Results
-
