### PR TITLE
Support weight scaling in converter

### DIFF
--- a/larq_compute_engine/mlir/transforms/prepare_patterns.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns.td
@@ -25,12 +25,13 @@ class I32VectorElementsAttr<int len> : ElementsAttrBase<
 
 class GetConstantVector<string val> : NativeCodeCall<"GetConstantVector($0, " # val # ")">;
 def BinaryFilter : Constraint<CPred<"IsBinaryFilter($0)">>;
+def GetScaleVector : NativeCodeCall<"GetScaleVector($0)">;
 
 def : Pat<(TF_Conv2DOp (TF_LceBsignOp $input), (ConstantOp $filter), $strides, $use_cudnn,
                        $padding, $explicit_padding, IsDataFormatNHWC: $data_format, $dilations),
           (TF_LceBconv2dOp $input,
-            (TF_TransposeOp (ConstantOp $filter), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
-            (ConstantOp (GetConstantVector<"1.0f"> $filter)),
+            (TF_TransposeOp (TF_DivOp (ConstantOp $filter), (ConstantOp (GetScaleVector $filter))), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
+            (ConstantOp (GetScaleVector $filter)),
             (ConstantOp (GetConstantVector<"0.0f"> $filter)),
             $strides, $padding, ConstantAttr<I32Attr, "0">, $data_format,
             $dilations, ConstantAttr<StrAttr, "OHWI">, TFL_AF_None),
@@ -48,8 +49,8 @@ def : Pat<(TF_Conv2DOp: $output
             (ConstantOp $filter), $strides, $use_cudnn, ConstantAttr<StrAttr, "VALID">,
             $explicit_padding, IsDataFormatNHWC: $data_format, $dilations),
           (TF_LceBconv2dOp $input,
-            (TF_TransposeOp (ConstantOp $filter), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
-            (ConstantOp (GetConstantVector<"1.0f"> $filter)),
+            (TF_TransposeOp (TF_DivOp (ConstantOp $filter), (ConstantOp (GetScaleVector $filter))), (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
+            (ConstantOp (GetScaleVector $filter)),
             (ConstantOp (GetConstantVector<"0.0f"> $filter)),
             $strides,
             ConstantAttr<StrAttr, "SAME">,

--- a/larq_compute_engine/mlir/transforms/prepare_tf.cc
+++ b/larq_compute_engine/mlir/transforms/prepare_tf.cc
@@ -53,7 +53,8 @@ bool IsBinaryFilter(Attribute filter_attr) {
       for (std::size_t i = 0; i < shape[2]; ++i) {
         for (std::size_t o = 0; o < shape[3]; ++o) {
           auto scale = filter.getValue<float>({0, 0, 0, o});
-          if (scale == 0.0f) return false;
+          if (std::abs(scale) <= std::numeric_limits<float>::epsilon())
+            return false;
           auto value = filter.getValue<float>({h, w, i, o});
           if (std::abs(std::abs(value / scale) - 1.0f) > 0.005f) return false;
         }

--- a/larq_compute_engine/mlir/transforms/prepare_tf.cc
+++ b/larq_compute_engine/mlir/transforms/prepare_tf.cc
@@ -48,11 +48,10 @@ bool IsBinaryFilter(Attribute filter_attr) {
   auto shape = filter_attr.getType().cast<ShapedType>().getShape();
   if (shape.size() != 4) return false;
 
-  std::size_t h, w, i, o;
-  for (h = 0; h < shape[0]; ++h) {
-    for (w = 0; w < shape[1]; ++w) {
-      for (i = 0; i < shape[2]; ++i) {
-        for (o = 0; o < shape[3]; ++o) {
+  for (std::size_t h = 0; h < shape[0]; ++h) {
+    for (std::size_t w = 0; w < shape[1]; ++w) {
+      for (std::size_t i = 0; i < shape[2]; ++i) {
+        for (std::size_t o = 0; o < shape[3]; ++o) {
           auto scale = filter.getValue<float>({0, 0, 0, o});
           if (scale == 0.0f) return false;
           auto value = filter.getValue<float>({h, w, i, o});

--- a/larq_compute_engine/mlir/transforms/prepare_tf.cc
+++ b/larq_compute_engine/mlir/transforms/prepare_tf.cc
@@ -25,11 +25,41 @@ DenseElementsAttr GetConstantVector(Attribute filter, float val) {
   return DenseElementsAttr::get(type, val);
 }
 
-bool IsBinaryFilter(Attribute filter) {
-  if (!filter.isa<DenseElementsAttr>()) return false;
+DenseElementsAttr GetScaleVector(Attribute filter_attr) {
+  auto filter = filter_attr.cast<DenseElementsAttr>();
+  auto filter_type = filter_attr.getType().cast<ShapedType>();
+  auto channels = filter_type.getShape()[3];
+  auto element_type = filter_type.getElementType();
 
-  for (auto value : filter.cast<DenseElementsAttr>().getValues<float>()) {
-    if (std::abs((std::abs(value) - 1.0f)) > 0.005f) return false;
+  std::vector<Attribute> scales(channels);
+  for (std::size_t i = 0; i < channels; ++i) {
+    auto scale = std::abs(filter.getValue<float>({0, 0, 0, i}));
+    scales[i] = FloatAttr::get(element_type, scale);
+  }
+
+  RankedTensorType type = RankedTensorType::get({channels}, element_type);
+  return DenseElementsAttr::get(type, scales);
+}
+
+bool IsBinaryFilter(Attribute filter_attr) {
+  if (!filter_attr.isa<DenseElementsAttr>()) return false;
+  auto filter = filter_attr.cast<DenseElementsAttr>();
+
+  auto shape = filter_attr.getType().cast<ShapedType>().getShape();
+  if (shape.size() != 4) return false;
+
+  std::size_t h, w, i, o;
+  for (h = 0; h < shape[0]; ++h) {
+    for (w = 0; w < shape[1]; ++w) {
+      for (i = 0; i < shape[2]; ++i) {
+        for (o = 0; o < shape[3]; ++o) {
+          auto scale = filter.getValue<float>({0, 0, 0, o});
+          if (scale == 0.0f) return false;
+          auto value = filter.getValue<float>({h, w, i, o});
+          if (std::abs(std::abs(value / scale) - 1.0f) > 0.005f) return false;
+        }
+      }
+    }
   }
   return true;
 }


### PR DESCRIPTION
## What do these changes do?
Some networks like BiReal-Net or XNOR-Net use scaled binary weights. This PR adds support for these networks in the converter and merges the scaling vectors into the batch norm multiplier.

## How Has This Been Tested?
mlir transform tests and manual conversion of Bi-Real Net
