### PR TITLE
Upgrade ARM gcc compiler to 9.2.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,15 +25,14 @@ http_archive(
 )
 
 http_archive(
-    # This is the latest `aarch64-linux-gnu` compiler provided by ARM
+    # This is the latest `aarch64-none-linux-gnu` compiler provided by ARM
     # See https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads
-    # Download size: 260 MB compressed, 1.5 GB uncompressed
-    # The archive contains GCC version 8.3.0
+    # The archive contains GCC version 9.2.1
     name = "aarch64_compiler",
     build_file = "//third_party:arm_compiler.BUILD",
-    sha256 = "8ce3e7688a47d8cd2d8e8323f147104ae1c8139520eca50ccf8a7fa933002731",
-    strip_prefix = "gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/",
-    url = "https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz?revision=2e88a73f-d233-4f96-b1f4-d8b36e9bb0b9&la=en&hash=167687FADA00B73D20EED2A67D0939A197504ACD",
+    sha256 = "8dfe681531f0bd04fb9c53cf3c0a3368c616aa85d48938eebe2b516376e06a66",
+    strip_prefix = "gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu",
+    urls = ["https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"],
 )
 
 load("//third_party/toolchains/cpus/arm:arm_compiler_configure.bzl", "arm_compiler_configure")

--- a/larq_compute_engine/tests/cc_tests_aarch64_qemu.sh
+++ b/larq_compute_engine/tests/cc_tests_aarch64_qemu.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export QEMU_LD_PREFIX="external/aarch64_compiler/aarch64-linux-gnu/libc"
+export QEMU_LD_PREFIX="external/aarch64_compiler/aarch64-none-linux-gnu/libc"
 
 for testfile in larq_compute_engine/core/tests/*_tests;
 do

--- a/third_party/arm_compiler.BUILD
+++ b/third_party/arm_compiler.BUILD
@@ -53,9 +53,9 @@ filegroup(
 filegroup(
     name = "aarch64_compiler_pieces",
     srcs = glob([
-        "aarch64-linux-gnu/**",
+        "aarch64-none-linux-gnu/**",
         "libexec/**",
-        "lib/gcc/aarch64-linux-gnu/**",
+        "lib/gcc/aarch64-none-linux-gnu/**",
         "include/**",
     ]),
 )

--- a/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
+++ b/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
@@ -490,16 +490,16 @@ def _impl(ctx):
                             flags = [
                                 "-std=c++11",
                                 "-isystem",
-                                "%{AARCH64_COMPILER_PATH}%/aarch64-linux-gnu/include/c++/8.3.0/",
+                                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
                                 #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
                                 "-isystem",
-                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-linux-gnu/8.3.0/include",
+                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
                                 #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
                                 "-isystem",
-                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-linux-gnu/8.3.0/include-fixed",
+                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
                                 #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
                                 "-isystem",
-                                "%{AARCH64_COMPILER_PATH}%/aarch64-linux-gnu/libc/usr/include/",
+                                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
                                 #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
                                 "-isystem",
                                 "%{PYTHON_INCLUDE_PATH}%",
@@ -775,13 +775,13 @@ def _impl(ctx):
         # I checked the directories of both compilers to confirm they have the same files
         # It is crucial that we change the order of the C++ directory to come *before* the others
         cxx_builtin_include_directories = [
-		"%{AARCH64_COMPILER_PATH}%/aarch64-linux-gnu/include/c++/8.3.0/",
+		"%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
 		#"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
-                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-linux-gnu/8.3.0/include",
+                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
                 #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
-                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-linux-gnu/8.3.0/include-fixed",
+                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
                 #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
-                "%{AARCH64_COMPILER_PATH}%/aarch64-linux-gnu/libc/usr/include/",
+                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
                 #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
                 "%{PYTHON_INCLUDE_PATH}%",
                 #"/usr/include",
@@ -844,44 +844,44 @@ def _impl(ctx):
         tool_paths = [
             tool_path(
                 name = "ar",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-ar",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-ar",
             ),
             tool_path(name = "compat-ld", path = "/bin/false"),
             tool_path(
                 name = "cpp",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-cpp",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-cpp",
             ),
             tool_path(
                 name = "dwp",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-dwp",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-dwp",
             ),
             tool_path(
                 name = "gcc",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-gcc",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-gcc",
             ),
             tool_path(
                 name = "gcov",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-gcov",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-gcov",
             ),
             tool_path(
                 name = "ld",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-ld",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-ld",
             ),
             tool_path(
                 name = "nm",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-nm",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-nm",
             ),
             tool_path(
                 name = "objcopy",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-objcopy",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-objcopy",
             ),
             tool_path(
                 name = "objdump",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-objdump",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-objdump",
             ),
             tool_path(
                 name = "strip",
-                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-linux-gnu-strip",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-strip",
             ),
         ]
     elif (ctx.attr.cpu == "local"):

--- a/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
+++ b/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
@@ -1,4 +1,5 @@
-load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "action_config",
     "artifact_name_pattern",
     "env_entry",
@@ -721,72 +722,72 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "local"):
         features = [
-                default_compile_flags_feature,
-                default_link_flags_feature,
-                supports_dynamic_linker_feature,
-                supports_pic_feature,
-                objcopy_embed_flags_feature,
-                opt_feature,
-                dbg_feature,
-                user_compile_flags_feature,
-                sysroot_feature,
-                unfiltered_compile_flags_feature,
-            ]
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            supports_dynamic_linker_feature,
+            supports_pic_feature,
+            objcopy_embed_flags_feature,
+            opt_feature,
+            dbg_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+        ]
     elif (ctx.attr.cpu == "armeabi"):
         features = [
-                default_compile_flags_feature,
-                default_link_flags_feature,
-                supports_dynamic_linker_feature,
-                supports_pic_feature,
-                opt_feature,
-                dbg_feature,
-                user_compile_flags_feature,
-                sysroot_feature,
-                unfiltered_compile_flags_feature,
-            ]
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            supports_dynamic_linker_feature,
+            supports_pic_feature,
+            opt_feature,
+            dbg_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+        ]
     elif (ctx.attr.cpu == "aarch64"):
         features = [
-                default_compile_flags_feature,
-                default_link_flags_feature,
-                supports_dynamic_linker_feature,
-                supports_pic_feature,
-                opt_feature,
-                dbg_feature,
-                user_compile_flags_feature,
-                sysroot_feature,
-                unfiltered_compile_flags_feature,
-            ]
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            supports_dynamic_linker_feature,
+            supports_pic_feature,
+            opt_feature,
+            dbg_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+        ]
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "armeabi"):
         # Fix by Tom: Move the C++ include to the top and remove the /usr/include
         cxx_builtin_include_directories = [
-		"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
-                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
-                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
-                "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
-                "%{PYTHON_INCLUDE_PATH}%",
-                #"/usr/include",
-                "/tmp/openblas_install/include/",
-            ]
+            "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
+            "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
+            "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
+            "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
+            "%{PYTHON_INCLUDE_PATH}%",
+            #"/usr/include",
+            "/tmp/openblas_install/include/",
+        ]
     elif (ctx.attr.cpu == "aarch64"):
         # Comment by Tom:
         # I checked the directories of both compilers to confirm they have the same files
         # It is crucial that we change the order of the C++ directory to come *before* the others
         cxx_builtin_include_directories = [
-		"%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
-		#"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
-                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
-                #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
-                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
-                #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
-                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
-                #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
-                "%{PYTHON_INCLUDE_PATH}%",
-                #"/usr/include",
-                "/tmp/openblas_install/include/",
-            ]
+            "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
+            #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
+            "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
+            #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
+            "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
+            #"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
+            "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
+            #"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
+            "%{PYTHON_INCLUDE_PATH}%",
+            #"/usr/include",
+            "/tmp/openblas_install/include/",
+        ]
     elif (ctx.attr.cpu == "local"):
         cxx_builtin_include_directories = ["/usr/lib/gcc/", "/usr/local/include", "/usr/include"]
     else:
@@ -901,7 +902,6 @@ def _impl(ctx):
     else:
         fail("Unreachable")
 
-
     out = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.write(out, "Fake executable")
     return [
@@ -922,16 +922,17 @@ def _impl(ctx):
             tool_paths = tool_paths,
             make_variables = make_variables,
             builtin_sysroot = builtin_sysroot,
-            cc_target_os = cc_target_os
+            cc_target_os = cc_target_os,
         ),
         DefaultInfo(
             executable = out,
         ),
     ]
-cc_toolchain_config =  rule(
+
+cc_toolchain_config = rule(
     implementation = _impl,
     attrs = {
-        "cpu": attr.string(mandatory=True, values=["armeabi", "aarch64", "local"]),
+        "cpu": attr.string(mandatory = True, values = ["armeabi", "aarch64", "local"]),
     },
     provides = [CcToolchainConfigInfo],
     executable = True,


### PR DESCRIPTION
## What do these changes do?
I tried to fix the build failure in #258 by upgrading the [Aarch64 gcc version to 9.2](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads). Unfortunately this didn't fix the build, but since the code is already here, this PR upgrades the compiler version anyway.
I don't think this upgrade has any downsides, but please correct me if I am wrong.

I ran buildifier, so only dfc27501e19cf2474c6263aaa097584bf8f5bae7 is relevant for review.

## How Has This Been Tested?
CI

## Benchmark Results
@Tombana do you think we should re-benchmark on the RP4?