### PR TITLE
AArch64 BMLA: Use pairwise addition to accumulate popcount results

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -19,14 +19,11 @@ using namespace ruy;
   "cnt v29.16b, v29.16b\n"                    \
   "cnt v30.16b, v30.16b\n"                    \
   "cnt v31.16b, v31.16b\n"                    \
-  "addv b28, v28.16b\n"                       \
-  "addv b29, v29.16b\n"                       \
-  "addv b30, v30.16b\n"                       \
-  "addv b31, v31.16b\n"                       \
-  "ins v28.s[1], v29.s[0]\n"                  \
-  "ins v28.s[2], v30.s[0]\n"                  \
-  "ins v28.s[3], v31.s[0]\n"                  \
-  "add " #Vd".4s, " #Vd".4s, v28.4s\n"
+  "addp v28.16b, v28.16b, v29.16b\n"          \
+  "addp v30.16b, v30.16b, v31.16b\n"          \
+  "addp v28.16b, v28.16b, v30.16b\n"          \
+  "uaddlp v28.8h, v28.16b\n"                  \
+  "uadalp " #Vd".4s, v28.8h\n"
 
 // temporary NEON registers: v28,v29,v30,v31
 #define LCE_BMLA_LD_RHS(Vd, Vr, Vl1, Vl2, Vl3, Vl4)      \
@@ -39,14 +36,11 @@ using namespace ruy;
   "cnt v29.16b, v29.16b\n"                              \
   "cnt v30.16b, v30.16b\n"                              \
   "cnt v31.16b, v31.16b\n"                              \
-  "addv b28, v28.16b\n"                                 \
-  "addv b29, v29.16b\n"                                 \
-  "addv b30, v30.16b\n"                                 \
-  "addv b31, v31.16b\n"                                 \
-  "ins v28.s[1], v29.s[0]\n"                            \
-  "ins v28.s[2], v30.s[0]\n"                            \
-  "ins v28.s[3], v31.s[0]\n"                            \
-  "add " #Vd".4s, " #Vd".4s, v28.4s\n"
+  "addp v28.16b, v28.16b, v29.16b\n"                    \
+  "addp v30.16b, v30.16b, v31.16b\n"                    \
+  "addp v28.16b, v28.16b, v30.16b\n"                    \
+  "uaddlp v28.8h, v28.16b\n"                            \
+  "uadalp " #Vd".4s, v28.8h\n"
 
 // temporary NEON registers: v28,v29,v30,v31
 #define LCE_BMLA_LD_ALL(Vd, Vr, Vl1, Vl2, Vl3, Vl4)      \
@@ -61,15 +55,12 @@ using namespace ruy;
   "cnt v30.16b, v30.16b\n"                              \
   "cnt v31.16b, v31.16b\n"                              \
   "ld1 {"#Vl2".2d}, [%[lhs_ptr]], #16\n"                \
-  "addv b28, v28.16b\n"                                 \
-  "addv b29, v29.16b\n"                                 \
+  "addp v28.16b, v28.16b, v29.16b\n"                    \
   "ld1 {"#Vl3".2d}, [%[lhs_ptr]], #16\n"                \
-  "addv b30, v30.16b\n"                                 \
-  "addv b31, v31.16b\n"                                 \
-  "ins v28.s[1], v29.s[0]\n"                            \
-  "ins v28.s[2], v30.s[0]\n"                            \
-  "ins v28.s[3], v31.s[0]\n"                            \
-  "add " #Vd".4s, " #Vd".4s, v28.4s\n"                  \
+  "addp v30.16b, v30.16b, v31.16b\n"                    \
+  "addp v28.16b, v28.16b, v30.16b\n"                    \
+  "uaddlp v28.8h, v28.16b\n"                            \
+  "uadalp " #Vd".4s, v28.8h\n"                          \
   "ld1 {"#Vl4".2d}, [%[lhs_ptr]], #16\n"
 
 // clang-format on


### PR DESCRIPTION
## What do these changes do?
This changes the accumulate of the popcount result in the AArch BMLA to use pairwise addition. See [Figure 7.9 in the arm docs](https://developer.arm.com/docs/den0024/latest/aarch64-floating-point-and-neon/aarch64-neon-instruction-format). The final accumulate is then done using [`uadalp`](https://developer.arm.com/docs/dui0801/j/a64-simd-vector-instructions/uadalp-vector).
This removes the need for the `ins` instructions, while keeping the same amount of arithmetic operations.
I couldn't find the cycle counts for these operations so I am not sure what the theoretical speedup of this should be, let me know if I am missing something here.

## How Has This Been Tested?
CI

## Benchmark Results
~~Initial benchmarks on my phone in the warm easter sun were promising, but I will properly benchmark the changes next week in a controlled environment without my phone overheating.~~

I ran some full model benchmarks on my phone with `num_calls=250`:

| Model          | Threads | master (ms)    | PR (ms)        |
| -------------- | ------- | -------------- | -------------- |
| QuickNet       | 1       | 25.2 ± 0.3     | **24.3 ± 0.3** |
| QuickNet       | 2       | 18.4 ± 0.3     | **17.5 ± 0.5** |
| QuickNet       | 4       | **15.0 ± 0.3** | 15.2 ± 0.4     |
|                |         |                |                |
| QuickNet Large | 1       | 36.8 ± 0.3     | **35.7 ± 0.3** |
| QuickNet Large | 2       | 26.4 ± 0.3     | **25.9 ± 0.3** |
| QuickNet Large | 4       | 21.8 ± 0.3     | **21.7 ± 0.5** |
|                |         |                |                |
| QuickNet XL    | 1       | 66.7 ± 0.3     | **64.2 ± 0.3** |
| QuickNet XL    | 2       | 47.1 ± 0.5     | **44.9 ± 0.4** |
| QuickNet XL    | 4       | 38.9 ± 0.3     | **37.9 ± 0.2** |