### PR TITLE
AArch64 BMLA: Reduce temporary register usage

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -9,56 +9,56 @@ using namespace ruy;
 
 // clang-format off
 
-// temporary NEON registers: v28,v29,v30,v31
+// temporary NEON registers: v28,v29,v30
 #define LCE_BMLA(Vd, Vr, Vl1, Vl2, Vl3, Vl4) \
   "eor v28.16b, " #Vr".16b, " #Vl1".16b\n"    \
   "eor v29.16b, " #Vr".16b, " #Vl2".16b\n"    \
-  "eor v30.16b, " #Vr".16b, " #Vl3".16b\n"    \
-  "eor v31.16b, " #Vr".16b, " #Vl4".16b\n"    \
   "cnt v28.16b, v28.16b\n"                    \
   "cnt v29.16b, v29.16b\n"                    \
-  "cnt v30.16b, v30.16b\n"                    \
-  "cnt v31.16b, v31.16b\n"                    \
   "addp v28.16b, v28.16b, v29.16b\n"          \
-  "addp v30.16b, v30.16b, v31.16b\n"          \
-  "addp v28.16b, v28.16b, v30.16b\n"          \
+  "eor v29.16b, " #Vr".16b, " #Vl3".16b\n"    \
+  "eor v30.16b, " #Vr".16b, " #Vl4".16b\n"    \
+  "cnt v29.16b, v29.16b\n"                    \
+  "cnt v30.16b, v30.16b\n"                    \
+  "addp v29.16b, v29.16b, v30.16b\n"          \
+  "addp v28.16b, v28.16b, v29.16b\n"          \
   "uaddlp v28.8h, v28.16b\n"                  \
   "uadalp " #Vd".4s, v28.8h\n"
 
-// temporary NEON registers: v28,v29,v30,v31
+// temporary NEON registers: v28,v29,v30
 #define LCE_BMLA_LD_RHS(Vd, Vr, Vl1, Vl2, Vl3, Vl4)      \
   "eor v28.16b, " #Vr".16b, " #Vl1".16b\n"              \
   "eor v29.16b, " #Vr".16b, " #Vl2".16b\n"              \
-  "eor v30.16b, " #Vr".16b, " #Vl3".16b\n"              \
-  "eor v31.16b, " #Vr".16b, " #Vl4".16b\n"              \
-  "ld1 {"#Vr".2d}, [%[rhs_ptr]], #16\n"                 \
   "cnt v28.16b, v28.16b\n"                              \
   "cnt v29.16b, v29.16b\n"                              \
-  "cnt v30.16b, v30.16b\n"                              \
-  "cnt v31.16b, v31.16b\n"                              \
   "addp v28.16b, v28.16b, v29.16b\n"                    \
-  "addp v30.16b, v30.16b, v31.16b\n"                    \
-  "addp v28.16b, v28.16b, v30.16b\n"                    \
+  "eor v29.16b, " #Vr".16b, " #Vl3".16b\n"              \
+  "eor v30.16b, " #Vr".16b, " #Vl4".16b\n"              \
+  "cnt v29.16b, v29.16b\n"                              \
+  "cnt v30.16b, v30.16b\n"                              \
+  "ld1 {"#Vr".2d}, [%[rhs_ptr]], #16\n"                 \
+  "addp v29.16b, v29.16b, v30.16b\n"                    \
+  "addp v28.16b, v28.16b, v29.16b\n"                    \
   "uaddlp v28.8h, v28.16b\n"                            \
   "uadalp " #Vd".4s, v28.8h\n"
 
-// temporary NEON registers: v28,v29,v30,v31
+// temporary NEON registers: v28,v29,v30
 #define LCE_BMLA_LD_ALL(Vd, Vr, Vl1, Vl2, Vl3, Vl4)      \
   "eor v28.16b, " #Vr".16b, " #Vl1".16b\n"              \
   "eor v29.16b, " #Vr".16b, " #Vl2".16b\n"              \
-  "eor v30.16b, " #Vr".16b, " #Vl3".16b\n"              \
-  "eor v31.16b, " #Vr".16b, " #Vl4".16b\n"              \
-  "ld1 {"#Vr".2d}, [%[rhs_ptr]], #16\n"                 \
   "cnt v28.16b, v28.16b\n"                              \
   "cnt v29.16b, v29.16b\n"                              \
   "ld1 {"#Vl1".2d}, [%[lhs_ptr]], #16\n"                \
-  "cnt v30.16b, v30.16b\n"                              \
-  "cnt v31.16b, v31.16b\n"                              \
+  "addp v28.16b, v28.16b, v29.16b\n"                    \
+  "eor v29.16b, " #Vr".16b, " #Vl3".16b\n"              \
+  "eor v30.16b, " #Vr".16b, " #Vl4".16b\n"              \
   "ld1 {"#Vl2".2d}, [%[lhs_ptr]], #16\n"                \
+  "cnt v29.16b, v29.16b\n"                              \
+  "cnt v30.16b, v30.16b\n"                              \
+  "ld1 {"#Vr".2d}, [%[rhs_ptr]], #16\n"                 \
+  "addp v29.16b, v29.16b, v30.16b\n"                    \
   "addp v28.16b, v28.16b, v29.16b\n"                    \
   "ld1 {"#Vl3".2d}, [%[lhs_ptr]], #16\n"                \
-  "addp v30.16b, v30.16b, v31.16b\n"                    \
-  "addp v28.16b, v28.16b, v30.16b\n"                    \
   "uaddlp v28.8h, v28.16b\n"                            \
   "uadalp " #Vd".4s, v28.8h\n"                          \
   "ld1 {"#Vl4".2d}, [%[lhs_ptr]], #16\n"


### PR DESCRIPTION
## What do these changes do?
This PR changes the order of the BMLA instructions reduce the usage of temporary registers. Since this changes the data dependency of instructions this PR requires a thorough review.

Register `v31` is now no longer used, do we need to change something [here](https://github.com/larq/compute-engine/blob/24d853fb964ff44204f60bfd6684ed0b8772dbf7/larq_compute_engine/core/bgemm_kernels_arm64.h#L444-L452) as well?

## How Has This Been Tested?
CI

## Benchmark Results
I ran benchmarks on my phone with `num_calls=250`:
| Model          | Threads | master (ms) | PR (ms)    |
| -------------- | ------- | ----------- | ---------- |
| QuickNet       | 1       | 24.0 ± 0.3  | 24.2 ± 0.3 |
| QuickNet       | 2       | 18.2 ± 0.3  | 18.0 ± 0.3 |
|                |         |             |            |
| QuickNet Large | 1       | 36.2 ± 0.4  | 35.3 ± 0.4 |
| QuickNet Large | 2       | 26.3 ± 0.3  | 26.3 ± 0.4 |
|                |         |             |            |
| QuickNet XL    | 1       | 64.4 ± 0.6  | 64.1 ± 0.3 |
| QuickNet XL    | 2       | 45.9 ± 0.4  | 45.5 ± 0.3 |

It looks like changing the order of the instructions doesn't introduce any slow down, but take the exact numbers with a grain of salt since my phone can have quite a high run variation.

## Related issue number
https://github.com/larq/compute-engine/pull/332#issuecomment-613387689
