### PR TITLE
Remove bitpacking dynamic memory allocations

### DIFF
--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <vector>
 
 #include "larq_compute_engine/core/types.h"
 #ifdef __aarch64__
@@ -15,11 +14,30 @@
 namespace compute_engine {
 namespace core {
 
-#define GET_POINTER_TO_ROW(array_pointer, lda, row_index) \
-  ((array_pointer) + ((row_index) * (lda)))
+// Utility functions
+constexpr int GetPackedElements(int unpacked_elements, int bitwidth) {
+  return (unpacked_elements + bitwidth - 1) / bitwidth;
+}
 
-#define GET_ELEM_INDEX(row_index, col_index, lda) \
-  ((row_index) * (lda) + (col_index))
+constexpr int GetPackedMatrixElements(int rows, int cols, int bitwidth) {
+  return rows * GetPackedElements(cols, bitwidth);
+}
+
+template <typename TBitpacked>
+constexpr int GetPackedElements(int unpacked_elements) {
+  return GetPackedElements(
+      unpacked_elements,
+      std::numeric_limits<
+          typename std::make_unsigned<TBitpacked>::type>::digits);
+}
+
+template <typename TBitpacked>
+constexpr int GetPackedMatrixElements(int rows, int cols) {
+  return GetPackedMatrixElements(
+      rows, cols,
+      std::numeric_limits<
+          typename std::make_unsigned<TBitpacked>::type>::digits);
+}
 
 template <class TIn, class TOut>
 inline void pack_canonical(const TIn* fptr, TOut* buf) {
@@ -368,89 +386,29 @@ inline void packbits_array(const TIn* input_array, const std::size_t n,
   }
 }
 
-// input/output matrices are stored in row-major mode
-// bitpacking_axis argument specifies the dimension in matrix where
-// the bitpacking operation is performed. For example for a RowWise
-// bitpacking operation compresses an MxN matrix to a Mx(N/bitwidth)
-// matrix.
-template <BitpackOrder bitpack_order, class TIn, class TOutContainer>
-inline void packbits_matrix(const TIn* input_data,
-                            const std::size_t input_num_rows,
-                            const std::size_t input_num_cols,
-                            TOutContainer& output, std::size_t& output_num_rows,
-                            std::size_t& output_num_cols,
-                            std::size_t& output_bitpadding,
-                            const Axis bitpacking_axis,
+// Bitpacks each row of a row-major matrix
+template <BitpackOrder bitpack_order, class TIn, class TOut_>
+inline void packbits_matrix(const TIn* input, const std::size_t input_num_rows,
+                            const std::size_t input_num_cols, TOut_* output,
                             const std::int32_t zero_point = 0) {
   // Force the types to be unsigned so that the function can be called on signed
   // types as well
-  using TOut =
-      typename std::make_unsigned<typename TOutContainer::value_type>::type;
-  const std::size_t bitwidth = std::numeric_limits<TOut>::digits;
+  using TOut = typename std::make_unsigned<TOut_>::type;
 
-  if (bitpacking_axis == Axis::RowWise) {
-    // calculate size of bitpacked matrix and allocate its memory
-    output_num_rows = input_num_rows;
-    output_num_cols = (input_num_cols + bitwidth - 1) / bitwidth;
+  // Calculate the size of the bitpacked rows
+  const std::size_t output_num_cols = GetPackedElements<TOut>(input_num_cols);
 
-    const auto output_size = output_num_cols * output_num_rows;
-    output.resize(output_size);
-
-    const auto input_row_size = input_num_cols;
-    const auto output_row_size = output_num_cols;
-
-    const auto num_extra_elems = input_num_cols % bitwidth;
-    output_bitpadding = num_extra_elems == 0 ? 0 : bitwidth - num_extra_elems;
-
-    // iterate through each row of the input matrix and bitpack the row into
-    // the corresponding memory location of the output matrix
-    TOut* output_data = reinterpret_cast<TOut*>(output.data());
-    for (size_t row_index = 0; row_index < input_num_rows; ++row_index)
-      packbits_array<bitpack_order>(
-          GET_POINTER_TO_ROW(input_data, input_row_size, row_index),
-          input_row_size,
-          GET_POINTER_TO_ROW(output_data, output_row_size, row_index),
-          zero_point);
-    return;
+  // Iterate through each row of the input matrix and bitpack the row into the
+  // corresponding memory location of the output matrix
+  const TIn* input_ptr = input;
+  TOut* output_ptr = reinterpret_cast<TOut*>(output);
+  for (size_t row_index = 0; row_index < input_num_rows; ++row_index) {
+    packbits_array<bitpack_order>(input_ptr, input_num_cols, output_ptr,
+                                  zero_point);
+    input_ptr += input_num_cols;
+    output_ptr += output_num_cols;
   }
-
-  if (bitpacking_axis == Axis::ColWise) {
-    // calculate size of bitpacked matrix and allocate its memory
-    output_num_rows = (input_num_rows + bitwidth - 1) / bitwidth;
-    output_num_cols = input_num_cols;
-    const auto output_size = output_num_cols * output_num_rows;
-    output.resize(output_size);
-
-    const auto input_row_size = input_num_cols;
-    const auto output_row_size = output_num_cols;
-
-    const auto num_extra_elems = input_num_rows % bitwidth;
-    output_bitpadding = num_extra_elems == 0 ? 0 : bitwidth - num_extra_elems;
-
-    // allocate temporary buffers
-    std::vector<TIn> input_buffer(input_num_rows);
-    std::vector<TOut> output_buffer(output_num_rows);
-
-    TOut* output_data = reinterpret_cast<TOut*>(output.data());
-
-    // iterate through the columns
-    for (size_t col_index = 0; col_index < input_num_cols; ++col_index) {
-      // store the values of the current column in a buffer
-      for (size_t row_index = 0; row_index < input_num_rows; ++row_index)
-        input_buffer[row_index] =
-            input_data[GET_ELEM_INDEX(row_index, col_index, input_row_size)];
-
-      // bitpack the buffer and store it in the the output matrix
-      packbits_array<bitpack_order>(input_buffer.data(), input_buffer.size(),
-                                    output_buffer.data(), zero_point);
-
-      // store the bitpacked values of the current column in the output matrix
-      for (size_t row_index = 0; row_index < output_num_rows; ++row_index)
-        output_data[GET_ELEM_INDEX(row_index, col_index, output_row_size)] =
-            output_buffer[row_index];
-    }
-    return;
-  }
+  return;
 }
 
 template <typename TBitpacked, typename TUnpacked>

--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -15,25 +15,25 @@ namespace compute_engine {
 namespace core {
 
 // Utility functions
-constexpr int GetPackedElements(int unpacked_elements, int bitwidth) {
+constexpr int GetPackedSize(int unpacked_elements, int bitwidth) {
   return (unpacked_elements + bitwidth - 1) / bitwidth;
 }
 
-constexpr int GetPackedMatrixElements(int rows, int cols, int bitwidth) {
-  return rows * GetPackedElements(cols, bitwidth);
+constexpr int GetPackedMatrixSize(int rows, int cols, int bitwidth) {
+  return rows * GetPackedSize(cols, bitwidth);
 }
 
 template <typename TBitpacked>
-constexpr int GetPackedElements(int unpacked_elements) {
-  return GetPackedElements(
+constexpr int GetPackedSize(int unpacked_elements) {
+  return GetPackedSize(
       unpacked_elements,
       std::numeric_limits<
           typename std::make_unsigned<TBitpacked>::type>::digits);
 }
 
 template <typename TBitpacked>
-constexpr int GetPackedMatrixElements(int rows, int cols) {
-  return GetPackedMatrixElements(
+constexpr int GetPackedMatrixSize(int rows, int cols) {
+  return GetPackedMatrixSize(
       rows, cols,
       std::numeric_limits<
           typename std::make_unsigned<TBitpacked>::type>::digits);
@@ -396,7 +396,7 @@ inline void packbits_matrix(const TIn* input, const std::size_t input_num_rows,
   using TOut = typename std::make_unsigned<TOut_>::type;
 
   // Calculate the size of the bitpacked rows
-  const std::size_t output_num_cols = GetPackedElements<TOut>(input_num_cols);
+  const std::size_t output_num_cols = GetPackedSize<TOut>(input_num_cols);
 
   // Iterate through each row of the input matrix and bitpack the row into the
   // corresponding memory location of the output matrix

--- a/larq_compute_engine/core/packbits_utils.h
+++ b/larq_compute_engine/core/packbits_utils.h
@@ -12,20 +12,19 @@ namespace ce = compute_engine;
 namespace core {
 
 template <typename TBitpacked>
-int GetPackedTensorElements(const RuntimeShape& shape) {
+int GetPackedTensorSize(const RuntimeShape& shape) {
   constexpr auto bitwidth = std::numeric_limits<
       typename std::make_unsigned<TBitpacked>::type>::digits;
   const int dims = shape.DimensionsCount();
   // Pack the tensor along the last dimension
   const int rows = FlatSizeSkipDim(shape, dims - 1);
   const int cols = shape.Dims(dims - 1);
-  return ce::core::GetPackedMatrixElements(rows, cols, bitwidth);
+  return ce::core::GetPackedMatrixSize(rows, cols, bitwidth);
 }
 
 // Convenience function for bitpacking a tensor along its last dimension
 // and updating the tensor shape
-template <BitpackOrder bitpack_order = ce::core::BitpackOrder::Canonical,
-          class T, class TBitpacked>
+template <class T, class TBitpacked>
 inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
                             const std::int32_t zero_point,
                             RuntimeShape& out_shape, TBitpacked* out_data) {
@@ -41,7 +40,7 @@ inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
   }
 
   out_shape.ReplaceWith(dims, in_shape.DimsData());
-  out_shape.SetDim(dims - 1, GetPackedElements<TBitpacked>(cols));
+  out_shape.SetDim(dims - 1, GetPackedSize<TBitpacked>(cols));
 }
 
 // Convenience function for going from a shape to the packed shape

--- a/larq_compute_engine/core/tests/packbits_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_tests.cc
@@ -31,7 +31,7 @@ void test_bitpacking_nonuniform_input() {
     expected = {0b01110100, 0b00111010};
 
   std::vector<std::uint8_t> output(
-      ce::core::GetPackedMatrixElements<std::uint8_t>(num_rows, num_cols));
+      ce::core::GetPackedMatrixSize<std::uint8_t>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output.data());
 
@@ -48,7 +48,7 @@ void test_bitpacking(const std::size_t expected_num_rows,
   input.fill(-1);
 
   std::vector<TOut> output(
-      ce::core::GetPackedMatrixElements<TOut>(num_rows, num_cols));
+      ce::core::GetPackedMatrixSize<TOut>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output.data());
 
@@ -91,7 +91,7 @@ TEST(BitpackingWithBitPaddingTests, RowMajorPadding) {
     expected = {0b10001011, 0b00000001, 0b11000101, 0b00000000};
 
   std::vector<std::uint8_t> output(
-      ce::core::GetPackedMatrixElements<std::uint8_t>(num_rows, num_cols));
+      ce::core::GetPackedMatrixSize<std::uint8_t>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
       input.data(), num_rows, num_cols, output.data());
 

--- a/larq_compute_engine/core/tests/packbits_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_tests.cc
@@ -16,9 +16,7 @@ namespace ce = compute_engine;
 // operation itself while the uniform tests are used to verify the bitpacking
 // with different bitwidths
 template <class TIn>
-void test_bitpacking_nonuniform_input_rowwise() {
-  const auto bitpacking_axis = ce::core::Axis::RowWise;
-
+void test_bitpacking_nonuniform_input() {
   // input matrix (row-major memory laytout)
   const std::size_t num_rows = 2, num_cols = 8;
   std::array<TIn, 16> input{1, 1,  -1, 1,  -1, -1, -1, 1,
@@ -32,50 +30,16 @@ void test_bitpacking_nonuniform_input_rowwise() {
   else
     expected = {0b01110100, 0b00111010};
 
-  std::vector<std::uint8_t> output;
-  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::vector<std::uint8_t> output(
+      ce::core::GetPackedMatrixElements<std::uint8_t>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-      input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
-      bitpadding, bitpacking_axis);
+      input.data(), num_rows, num_cols, output.data());
 
-  EXPECT_EQ(num_rows_bp, expected_num_rows);
-  EXPECT_EQ(num_cols_bp, expected_num_cols);
-  EXPECT_EQ(output.size(), num_rows_bp * num_cols_bp);
-  EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
-}
-
-template <class TIn>
-void test_bitpacking_nonuniform_input_colwise() {
-  const auto bitpacking_axis = ce::core::Axis::ColWise;
-
-  // input matrix (row-major memory laytout)
-  const std::size_t num_rows = 8, num_cols = 2;
-  std::array<TIn, 16> input{1,  1,  1,  -1, -1, 1, 1, -1,
-                            -1, -1, -1, -1, -1, 1, 1, 1};
-
-  // expected output matrix after bitpacking
-  const std::size_t expected_num_rows = 1, expected_num_cols = 2;
-  std::vector<std::uint8_t> expected;
-  if (CE_IS_BIG_ENDIAN)
-    expected = {0b00101110, 0b01011100};
-  else
-    expected = {0b01110100, 0b00111010};
-
-  std::vector<std::uint8_t> output;
-  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
-  ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-      input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
-      bitpadding, bitpacking_axis);
-
-  EXPECT_EQ(num_rows_bp, expected_num_rows);
-  EXPECT_EQ(num_cols_bp, expected_num_cols);
-  EXPECT_EQ(output.size(), num_rows_bp * num_cols_bp);
   EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
 }
 
 template <class TIn, class TOut, std::size_t num_rows, std::size_t num_cols>
-void test_bitpacking(const ce::core::Axis bitpacking_axis,
-                     const std::size_t expected_num_rows,
+void test_bitpacking(const std::size_t expected_num_rows,
                      const std::size_t expected_num_cols) {
   const std::size_t bitwidth = std::numeric_limits<TOut>::digits;
 
@@ -83,58 +47,36 @@ void test_bitpacking(const ce::core::Axis bitpacking_axis,
   std::array<TIn, num_elems> input;
   input.fill(-1);
 
-  std::vector<TOut> output;
-  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::vector<TOut> output(
+      ce::core::GetPackedMatrixElements<TOut>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-      input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
-      bitpadding, bitpacking_axis);
+      input.data(), num_rows, num_cols, output.data());
 
   TOut expected_value = std::numeric_limits<TOut>::max();
   const std::size_t num_elems_bp = num_elems / bitwidth;
   std::array<TOut, num_elems_bp> expected;
   expected.fill(expected_value);
 
-  EXPECT_EQ(num_rows_bp, expected_num_rows);
-  EXPECT_EQ(num_cols_bp, expected_num_cols);
-  EXPECT_EQ(bitpadding, 0);
-  EXPECT_EQ(output.size(), num_rows_bp * num_cols_bp);
   EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
 }
 
 TEST(BitpackingTests, BitpackingRowMajorUInt8NonUniformInput) {
-  test_bitpacking_nonuniform_input_rowwise<float>();
-}
-
-TEST(BitpackingTests, BitpackingColMajorUInt8NonUniformInput) {
-  test_bitpacking_nonuniform_input_colwise<float>();
+  test_bitpacking_nonuniform_input<float>();
 }
 
 TEST(BitpackingTests, BitpackingRowMajorUInt8) {
-  test_bitpacking<float, std::uint8_t, 2, 128>(ce::core::Axis::RowWise, 2, 16);
+  test_bitpacking<float, std::uint8_t, 2, 128>(2, 16);
 }
 
 TEST(BitpackingTests, BitpackingRowMajorUInt32) {
-  test_bitpacking<float, std::uint32_t, 2, 128>(ce::core::Axis::RowWise, 2, 4);
+  test_bitpacking<float, std::uint32_t, 2, 128>(2, 4);
 }
 
 TEST(BitpackingTests, BitpackingRowMajorUInt64) {
-  test_bitpacking<float, std::uint64_t, 2, 128>(ce::core::Axis::RowWise, 2, 2);
-}
-
-TEST(BitpackingTests, BitpackingColumnMajorUInt8) {
-  test_bitpacking<float, std::uint8_t, 128, 2>(ce::core::Axis::ColWise, 16, 2);
-}
-
-TEST(BitpackingTests, BitpackingColumnMajorUInt32) {
-  test_bitpacking<float, std::uint32_t, 128, 2>(ce::core::Axis::ColWise, 4, 2);
-}
-
-TEST(BitpackingTests, BitpackingColumnMajorUInt64) {
-  test_bitpacking<float, std::uint64_t, 128, 2>(ce::core::Axis::ColWise, 2, 2);
+  test_bitpacking<float, std::uint64_t, 2, 128>(2, 2);
 }
 
 TEST(BitpackingWithBitPaddingTests, RowMajorPadding) {
-  const auto bitpacking_axis = ce::core::Axis::RowWise;
   // input matrix
   const int num_rows = 2;
   const int num_cols = 9;
@@ -142,54 +84,17 @@ TEST(BitpackingWithBitPaddingTests, RowMajorPadding) {
                            -1, 1,  -1, 1,  1, 1, -1, -1, 1};
 
   // expected output matrix after bitpacking
-  const std::size_t expected_num_rows = 2;
-  const std::size_t expected_num_cols = 2;
   std::vector<std::uint8_t> expected;
   if (CE_IS_BIG_ENDIAN)
     expected = {0b11010001, 0b10000000, 0b10100011, 0b00000000};
   else
     expected = {0b10001011, 0b00000001, 0b11000101, 0b00000000};
 
-  std::vector<std::uint8_t> output;
-  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
+  std::vector<std::uint8_t> output(
+      ce::core::GetPackedMatrixElements<std::uint8_t>(num_rows, num_cols));
   ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-      input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
-      bitpadding, bitpacking_axis);
+      input.data(), num_rows, num_cols, output.data());
 
-  EXPECT_EQ(num_rows_bp, expected_num_rows);
-  EXPECT_EQ(num_cols_bp, expected_num_cols);
-  EXPECT_EQ(bitpadding, 7);
-  EXPECT_EQ(output.size(), num_rows_bp * num_cols_bp);
-  EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
-};
-
-TEST(BitpackingWithBitPaddingTests, ColMajorPadding) {
-  const auto bitpacking_axis = ce::core::Axis::ColWise;
-  // The input matrix is:
-  const int num_rows = 9;
-  const int num_cols = 2;
-  std::vector<float> input{-1, -1, -1, 1, 1,  -1, -1, 1,  1,
-                           1,  1,  1,  1, -1, -1, -1, -1, 1};
-
-  // expected output matrix after bitpacking
-  const std::size_t expected_num_rows = 2;
-  const std::size_t expected_num_cols = 2;
-  std::vector<std::uint8_t> expected;
-  if (CE_IS_BIG_ENDIAN)
-    expected = {0b11010001, 0b10100011, 0b10000000, 0b00000000};
-  else
-    expected = {0b10001011, 0b11000101, 0b00000001, 0b00000000};
-
-  std::vector<std::uint8_t> output;
-  std::size_t num_rows_bp = 0, num_cols_bp = 0, bitpadding = 0;
-  ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-      input.data(), num_rows, num_cols, output, num_rows_bp, num_cols_bp,
-      bitpadding, bitpacking_axis);
-
-  EXPECT_EQ(num_rows_bp, expected_num_rows);
-  EXPECT_EQ(num_cols_bp, expected_num_cols);
-  EXPECT_EQ(bitpadding, 7);
-  EXPECT_EQ(output.size(), num_rows_bp * num_cols_bp);
   EXPECT_THAT(output, ::testing::ElementsAreArray(expected));
 };
 

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -45,11 +45,9 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
   std::vector<PackedType> new_values(num_rows * packed_channels);
 
   const float* in_ptr = &(*dense_elements_iter.begin());
-  std::size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
   using namespace compute_engine::core;
-  packbits_matrix<BitpackOrder::Canonical>(
-      in_ptr, num_rows, unpacked_channels, new_values, filter_rows_bp,
-      filter_cols_bp, filter_bitpadding, Axis::RowWise);
+  packbits_matrix<BitpackOrder::Canonical>(in_ptr, num_rows, unpacked_channels,
+                                           new_values.data());
 
   RankedTensorType out_tensor_type =
       RankedTensorType::get({shape[0], shape[1], shape[2], packed_channels},

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -43,7 +43,8 @@ enum class KernelType {
 
 inline void decide_bitpack_before_im2col(KernelType kernel_type,
                                          TfLiteBConv2DParams* conv_params) {
-  if (kernel_type == kGenericRef || conv_params->read_bitpacked_input ||
+  if (kernel_type == KernelType::kGenericRef ||
+      conv_params->read_bitpacked_input ||
       conv_params->channels_in >= conv_params->bitpacking_bitwidth / 4) {
     conv_params->bitpack_before_im2col = true;
   } else {

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -674,7 +674,7 @@ void OneTimeSetup(TfLiteContext* context, TfLiteNode* node,
     }
 
     std::vector<TBitpacked> filter_data_bp(
-        ce::core::GetPackedMatrixElements<TBitpacked>(rows, cols));
+        ce::core::GetPackedMatrixSize<TBitpacked>(rows, cols));
     if (std::is_same<SrcScalar, std::int32_t>::value) {
       // If the input is already bitpacked, we require canonical order
       ce::core::packbits_matrix<ce::core::BitpackOrder::Canonical>(

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -336,6 +336,9 @@ TfLiteStatus Prepare(KernelType kernel_type,
   decide_bitpack_before_im2col(conv_params);
 
   if (kernel_type == KernelType::kGenericRef) {
+    // In this case we always bitpack along the channels since there's no im2col
+    conv_params->bitpack_before_im2col = true;
+
     // We require 32-bit bitpacking in the reference implementation
     TF_LITE_ENSURE_EQ(context, conv_params->bitpacking_bitwidth, 32);
     // We only support one-padding or valid-padding in the reference
@@ -344,6 +347,9 @@ TfLiteStatus Prepare(KernelType kernel_type,
                               conv_params->padding_type ==
                                   TfLitePadding::kTfLitePaddingSame));
   }
+
+  // Figure out how many temporary buffers we need
+  int temporaries_count = 0;
 
   // pre-allocate temporary tensors for optimized version
   if (kernel_type == KernelType::kRuyOptimized) {
@@ -354,28 +360,31 @@ TfLiteStatus Prepare(KernelType kernel_type,
          conv_params->dilations[1] /* height */ != 1 ||
          conv_params->filter_width != 1 || conv_params->filter_height != 1);
 
-    // Figure out how many temporary buffers we need
-    int temporaries_count = 0;
     if (conv_params->need_im2col) {
       conv_params->im2col_index = temporaries_count++;
     }
+  }
 
+  // See if we need a temporary buffer for bitpacked activations
+  if (!conv_params->read_bitpacked_input) {
+    conv_params->packed_input_index = temporaries_count++;
+  }
+
+  if (temporaries_count != 0) {
     // Allocate int array of that size
     TfLiteIntArrayFree(node->temporaries);
     node->temporaries = TfLiteIntArrayCreate(temporaries_count);
-
-    // Now allocate the buffers
-    if (conv_params->need_im2col) {
-      if (conv_params->im2col_id == kTensorNotAllocated) {
-        context->AddTensors(context, 1, &conv_params->im2col_id);
-        node->temporaries->data[conv_params->im2col_index] =
-            conv_params->im2col_id;
-      }
-    }
   }
 
-  // Resize the im2col tensor
+  // Now allocate the buffers
   if (conv_params->need_im2col) {
+    if (conv_params->im2col_id == kTensorNotAllocated) {
+      context->AddTensors(context, 1, &conv_params->im2col_id);
+      node->temporaries->data[conv_params->im2col_index] =
+          conv_params->im2col_id;
+    }
+
+    // Resize the im2col tensor
     int channels_in = conv_params->bitpack_before_im2col
                           ? ((conv_params->channels_in +
                               conv_params->bitpacking_bitwidth - 1) /
@@ -414,6 +423,56 @@ TfLiteStatus Prepare(KernelType kernel_type,
     im2col->allocation_type = kTfLiteArenaRw;
     TF_LITE_ENSURE_OK(context,
                       context->ResizeTensor(context, im2col, im2col_size));
+  }
+
+  if (!conv_params->read_bitpacked_input) {
+    if (conv_params->packed_input_id == kTensorNotAllocated) {
+      context->AddTensors(context, 1, &conv_params->packed_input_id);
+      node->temporaries->data[conv_params->packed_input_index] =
+          conv_params->packed_input_id;
+    }
+    // Determine the size
+    int flat_size = 0;
+    if (conv_params->bitpack_before_im2col) {
+      const int packed_channels =
+          ((conv_params->channels_in + conv_params->bitpacking_bitwidth - 1) /
+           conv_params->bitpacking_bitwidth);
+      flat_size = conv_params->batch * conv_params->input_height *
+                  conv_params->input_width * packed_channels;
+    } else {
+      const int packed_depth =
+          (conv_params->channels_in * conv_params->filter_height *
+               conv_params->filter_width +
+           conv_params->bitpacking_bitwidth - 1) /
+          conv_params->bitpacking_bitwidth;
+
+      flat_size = conv_params->batch * conv_params->out_height *
+                  conv_params->out_width * packed_depth;
+    }
+    // We will simply request a flat tensor
+    TfLiteIntArray* packed_input_size = TfLiteIntArrayCreate(1);
+    packed_input_size->data[0] = flat_size;
+
+    // Get the newly created tensor
+    TfLiteTensor* packed_input =
+        GetTemporary(context, node, conv_params->packed_input_index);
+
+    // Set its type
+    switch (conv_params->bitpacking_bitwidth) {
+      case 32:
+        packed_input->type = kTfLiteInt32;
+        break;
+      case 64:
+        packed_input->type = kTfLiteInt64;
+        break;
+      default:
+        TF_LITE_ENSURE(context, false);
+        break;
+    }
+    packed_input->allocation_type = kTfLiteArenaRw;
+    // Request a resize
+    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, packed_input,
+                                                     packed_input_size));
   }
 
   // Prepare could be called multiple times, when the input tensor is resized,
@@ -615,18 +674,16 @@ void OneTimeSetup(TfLiteContext* context, TfLiteNode* node,
       rows = params->channels_out;
     }
 
-    std::vector<TBitpacked> filter_data_bp;
-    std::size_t filter_rows_bp, filter_cols_bp, filter_bitpadding;
+    std::vector<TBitpacked> filter_data_bp(
+        ce::core::GetPackedMatrixElements<TBitpacked>(rows, cols));
     if (std::is_same<SrcScalar, std::int32_t>::value) {
       // If the input is already bitpacked, we require canonical order
       ce::core::packbits_matrix<ce::core::BitpackOrder::Canonical>(
-          filter_unpacked, rows, cols, filter_data_bp, filter_rows_bp,
-          filter_cols_bp, filter_bitpadding, ce::core::Axis::RowWise);
+          filter_unpacked, rows, cols, filter_data_bp.data());
     } else {
       // Input is int8 or float, use the optimized order
       ce::core::packbits_matrix<ce::core::BitpackOrder::Optimized>(
-          filter_unpacked, rows, cols, filter_data_bp, filter_rows_bp,
-          filter_cols_bp, filter_bitpadding, ce::core::Axis::RowWise);
+          filter_unpacked, rows, cols, filter_data_bp.data());
     }
 
     std::size_t num_bytes = filter_data_bp.size() * sizeof(TBitpacked);
@@ -655,6 +712,12 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
                              ? GetTemporary(context, node, params->im2col_index)
                              : nullptr;
 
+  TBitpacked* packed_input_data =
+      !params->read_bitpacked_input
+          ? GetTensorData<TBitpacked>(
+                GetTemporary(context, node, params->packed_input_index))
+          : nullptr;
+
   // Using the standard TF Lite ConvParams struct.
   // This requires extra step of converting the TfLiteBConv2DParams
   // but unifies the interface with the default TF lite API for CONV params
@@ -679,7 +742,7 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
   // write bitpacked output directly.
   BConv2D<SrcScalar, TBitpacked, std::int32_t, DstScalar>(
       op_params, GetTensorShape(input), GetTensorData<SrcScalar>(input),
-      unpacked_filter_shape,
+      packed_input_data, unpacked_filter_shape,
       reinterpret_cast<TBitpacked*>(params->filter_packed.data()),
       output_transform, unpacked_output_shape, GetTensorData<DstScalar>(output),
       GetTensorShape(im2col), GetTensorData<SrcScalar>(im2col),
@@ -711,10 +774,12 @@ void EvalRef(TfLiteContext* context, TfLiteNode* node,
     packed_input_shape.ReplaceWith(4, input_shape.DimsData());
     packed_input_data = reinterpret_cast<const TBitpacked*>(input_data);
   } else {
-    static std::vector<TBitpacked> packed_input_data_vector;
+    TfLiteTensor* packed_input =
+        GetTemporary(context, node, params->packed_input_index);
     ce::core::packbits_tensor(input_shape, input_data, input->params.zero_point,
-                              packed_input_shape, packed_input_data_vector);
-    packed_input_data = packed_input_data_vector.data();
+                              packed_input_shape,
+                              GetTensorData<TBitpacked>(packed_input));
+    packed_input_data = GetTensorData<TBitpacked>(packed_input);
   }
 
   // Using the standard TF Lite ConvParams struct.

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -73,6 +73,9 @@ typedef struct {
   // So in pseudo-code: `node->temporaries[index] = id;`
   std::int32_t im2col_index;
 
+  int packed_input_id = kTensorNotAllocated;
+  std::int32_t packed_input_index;
+
   std::vector<float> padding_buffer;
   bool is_padding_correction_cached = false;
 

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -339,11 +339,10 @@ void set_lce_op_input(const RuntimeShape& input_shape,
                       std::vector<TData> input_data, std::int32_t zero_point,
                       BConv2DOpModel<std::int32_t, PostType, TOutput>& m_lce) {
   std::vector<std::int32_t> input_data_bp(
-      core::GetPackedTensorElements<std::int32_t>(input_shape));
+      core::GetPackedTensorSize<std::int32_t>(input_shape));
   RuntimeShape output_shape;
-  core::packbits_tensor<core::BitpackOrder::Canonical>(
-      input_shape, input_data.data(), zero_point, output_shape,
-      input_data_bp.data());
+  core::packbits_tensor(input_shape, input_data.data(), zero_point,
+                        output_shape, input_data_bp.data());
   m_lce.SetInput(input_data_bp);
 }
 
@@ -357,11 +356,10 @@ void test_lce_op_output(const std::vector<std::int32_t>& lce_output_data,
   RuntimeShape out_shape;
   out_shape.BuildFrom(builtin_output_shape);
   std::vector<std::int32_t> builtin_output_data_bp(
-      core::GetPackedTensorElements<std::int32_t>(out_shape));
+      core::GetPackedTensorSize<std::int32_t>(out_shape));
   RuntimeShape packed_shape;
-  core::packbits_tensor<core::BitpackOrder::Canonical>(
-      out_shape, builtin_output_data.data(), zero_point, packed_shape,
-      builtin_output_data_bp.data());
+  core::packbits_tensor(out_shape, builtin_output_data.data(), zero_point,
+                        packed_shape, builtin_output_data_bp.data());
 
   // We need the outputs here to be bit-exact, so don't allow for floating
   // point imprecision.
@@ -435,7 +433,7 @@ void runTest(const TestParam& param) {
       filter_height * filter_width * input_depth * filter_count;
 
   const int packed_channels =
-      core::GetPackedElements<PackedFilterType>(input_depth);
+      core::GetPackedSize<PackedFilterType>(input_depth);
   const int packed_num_elem =
       filter_count * filter_height * filter_width * packed_channels;
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
This PR removes the `std::vector`s that we use during inference for storing bitpacked activations, and instead uses the TfLite temporary buffer system for this.
This required changing the `packbits_matrix` interface to no longer accept a `std::vector` but a plain buffer instead.
Since the `packbits_matrix` interface had to be updated, this also removed the 'ColWise' option that was no longer being used.

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
The `packbits_matrix` unittests have been updated.

## Benchmark Results

Quicknet on the Pixel 1 is `20.35 ms`.
