### PR TITLE
Fix GTEST_FILTER on CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,13 +48,9 @@ jobs:
         run: ./configure.sh <<< $'n\n'
         shell: bash
       - name: "TF Lite Arm32: Cross-compile and run unit tests in qemu"
-        run: ./bazelisk test larq_compute_engine/tests:cc_tests_arm32_qemu --config=rpi3 --test_output=all
-        env:
-            GTEST_FILTER: -*BigTest*
+        run: ./bazelisk test larq_compute_engine/tests:cc_tests_arm32_qemu --config=rpi3 --test_output=all --action_env=GTEST_FILTER="-*BigTest*"
       - name: "TF Lite Aarch64: Cross-compile and run unit tests in qemu"
-        run: ./bazelisk test larq_compute_engine/tests:cc_tests_aarch64_qemu --config=aarch64 --test_output=all
-        env:
-            GTEST_FILTER: -*BigTest*
+        run: ./bazelisk test larq_compute_engine/tests:cc_tests_aarch64_qemu --config=aarch64 --test_output=all --action_env=GTEST_FILTER="-*BigTest*"
       - name: "Benchmark utility: check it builds successfully"
         run: ./bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=aarch64 --compilation_mode=fastbuild
       - name: "ImageNet evaluation utility: check it builds successfully"


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
The environment variable `GTEST_FILTER` that we use for the Qemu tests was not working properly on CI.

