### PR TITLE
Reformat summaries in python.converter.py

### DIFF
--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -48,10 +48,10 @@ def convert_keras_model(model: tf.keras.Model) -> bytes:
         ```
 
     # Arguments
-    model: A [`tf.keras.Model`](https://www.tensorflow.org/api_docs/python/tf/keras/Model) to convert.
+        model: The model to convert.
 
     # Returns
-    The converted data in serialized format.
+        The converted data in serialized format.
     """
     if not tf.executing_eagerly():
         raise RuntimeError(


### PR DESCRIPTION
This adds indentations to docstrings so that [keras-autodoc](https://github.com/keras-team/keras-autodoc) understands sections with lists of arguments, input shapes, output shapes, returns, etc. It also removes type hints from descriptions since we now add those in automatically. See larq/docs#68.

Before:

```
# Arguments:
arg_name: this is the description.
```

After:

```
# Arguments:
    arg_name: this is the description.
```

We'll probably need to do a minor release of Compute Engine once we do this, and then bump the version that larq/docs uses to that version.