### PR TITLE
Setup possibility to build  nightly wheels on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
     tags:
       - v*
+  push:
+    branches:
+      - "releases/nightly"
 
 jobs:
   macos-release-wheel:
@@ -73,6 +76,7 @@ jobs:
 
   upload-wheels:
     name: Publish wheels to PyPi
+    if: github.event_name == 'release'
     needs: [manylinux-release-wheel, macos-release-wheel]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This adds to possibility to build wheels by pushing to the `releases/nightly` branch which will trigger a new wheel build. These wheels won't be published on PyPI but will be available to download as release artefacts on the GitHub actions workflow. This is useful for testing changes to the wheel build scripts or to build a nightly version that might not be ready to be released as a stable version.