### PR TITLE
Add support for prebuilt Python 3.8 wheels 

### DIFF
--- a/.github/tools/release_linux.sh
+++ b/.github/tools/release_linux.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 set -e -x
 
-# Remove the now private ppa. This can be removed after the docker image removes the
-# pre-installed python packages from this ppa.
-rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
-
 ln -sf /usr/bin/python3.5 /usr/bin/python3 # Py36 has issues with add-apt
 add-apt-repository -y ppa:deadsnakes/ppa
 
 apt-get -y -qq update
 
-apt-get -y -qq install python${PYTHON_VERSION}-dev --no-install-recommends
+apt-get -y -qq install python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils --no-install-recommends
 ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
 
@@ -20,6 +16,8 @@ ls /dt7/usr/include/x86_64-linux-gnu/
 # This really shouldn't be required to get 3.7 builds working
 ln -sf /usr/include/x86_64-linux-gnu/python3.7m /dt7/usr/include/x86_64-linux-gnu/python3.7m || true
 ln -sf /usr/include/x86_64-linux-gnu/python3.7m /dt8/usr/include/x86_64-linux-gnu/python3.7m || true
+ln -sf /usr/include/x86_64-linux-gnu/python3.8 /dt7/usr/include/x86_64-linux-gnu/python3.8 || true
+ln -sf /usr/include/x86_64-linux-gnu/python3.8 /dt8/usr/include/x86_64-linux-gnu/python3.8 || true
 
 curl https://bootstrap.pypa.io/get-pip.py | python
 python --version

--- a/.github/tools/release_linux.sh
+++ b/.github/tools/release_linux.sh
@@ -6,7 +6,8 @@ add-apt-repository -y ppa:deadsnakes/ppa
 
 apt-get -y -qq update
 
-apt-get -y -qq install python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils --no-install-recommends
+apt-get -y -qq install python${PYTHON_VERSION}-dev --no-install-recommends
+apt-get -y -qq install python${PYTHON_VERSION}-distutils --no-install-recommends || true
 ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## What do these changes do?

This will build wheels for Python 3.8 when pushing a release.

## How Has This Been Tested?
I tested this at https://github.com/larq/compute-engine/actions/runs/97998739 (note that the build failure is unrelated and only due to me trying out Windows builds in parallel)