### PR TITLE
Add TF 2.2 to converter test matrix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0]
+        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.2.0rc4]
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.2.0rc4]
+        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.2.0]
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What do these changes do?
This add tests against TF 2.2 to the Python side of our converter.
Currently the 2.2.0 pip package hasn't been uploaded but 2.2.0rc4 includes all relevant Python changes so it is fine to use it for testing.

## How Has This Been Tested?
CI