### PR TITLE
Unify Arm64 kernels, independent of bitpacking bitwidth

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -1,3 +1,11 @@
+/**
+ * All optimised Arm64 kernels assume that the input datatype is uint64, i.e.
+ * that the LHS and RHS have been 64-bit bitpacked. However, they can still be
+ * used with uint32 (32-bit bitpacked) input data as long as the parameters
+ * `depth`, `lhs_stride`, and `rhs_stride` are adjusted appropriately. We
+ * delegate that responsibility to the `MakeBinaryKernelParams` function.
+ */
+
 #include <cstdint>
 
 #include "bgemm_kernels_common.h"
@@ -84,412 +92,7 @@ using namespace ruy;
 #define RUY_OFFSET_FLAGS 92
 
 template <typename Params>
-void CheckOffsetsInKernelParams32BP(const Params&) {
-  static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
-  static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
-  static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, post_activation_multiplier) ==
-                    RUY_OFFSET_POST_ACTIVATION_MULTIPLIER,
-                "");
-  static_assert(
-      offsetof(Params, post_activation_bias) == RUY_OFFSET_POST_ACTIVATION_BIAS,
-      "");
-  static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
-  static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
-  static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
-  static_assert(offsetof(Params, last_col) == RUY_OFFSET_LAST_COL, "");
-  static_assert(offsetof(Params, lhs_stride) == RUY_OFFSET_LHS_STRIDE, "");
-  static_assert(offsetof(Params, rhs_stride) == RUY_OFFSET_RHS_STRIDE, "");
-  static_assert(offsetof(Params, dst_stride) == RUY_OFFSET_DST_STRIDE, "");
-  static_assert(offsetof(Params, depth) == RUY_OFFSET_DEPTH, "");
-  static_assert(offsetof(Params, clamp_min) == RUY_OFFSET_CLAMP_MIN, "");
-  static_assert(offsetof(Params, clamp_max) == RUY_OFFSET_CLAMP_MAX, "");
-  static_assert(
-      offsetof(Params, backtransform_add) == RUY_OFFSET_BACKTRANSFORM_ADD, "");
-  static_assert(offsetof(Params, flags) == RUY_OFFSET_FLAGS, "");
-}
-
-// This is a very naive and first attempt on using the SIMD registers for BGEMM.
-// The following optimizations still need to be implemented:
-// 1. Using the entire register space which the architecture provides. This can
-// be achieved in two ways:
-// - 4x4 destination matrices and unrolling the depth loop
-// - 8x8 destination matrices (requires dymanic changing of temporary
-// registers in BMLA)
-// 2. taking advantage of out-of-order cpu by dual dispatching the load/compute
-// instructions
-
-// clang-format off
-
-// The asm kernel below has the following NEON register allocation:
-//
-// v16, v18, v20, v22 are int32 accumulators.
-// During accumulation, v0 -- v3 are used to load data from LHS and
-// v4 -- v7 from RHS:
-//
-//                                      int32 RHS 4x4 block
-//                          /--------------------------------------\
-//                          |v4.s[0]         ...          v7.s[0]  |
-//                          |  ...                         ...     |
-//                          |v4.s[3]         ...          v7.s[3]  |
-//                          \--------------------------------------/
-//    int32 LHS 4x4 block
-//  /--------------------\  /--------------------------------------\
-//  |v0.s[0] ... v0.s[3] |  |v16.s[0]        ...         v22.s[0]  |
-//  |v1.s[0] ... v1.s[3] |  |v16.s[1]        ...         v22.s[1]  |
-//  |v2.s[0] ... v2.s[3] |  |v16.s[2]        ...         v22.s[2]  |
-//  |v3.s[0] ... v3.s[3] |  |v16.s[3]        ...         v22.s[3]  |
-//  \--------------------/  \--------------------------------------/
-//                                  int32 accumulators 4x4 block
-//
-// No attempt had been made so far at implementing the RUY_OPT_MAX_STREAMING
-// optimization for this kernel.
-
-// clang-format on
-
-void BinaryKernelNeonOutOfOrder32BP4x4(
-    const BinaryKernelParams<4, 4, std::uint32_t>& params) {
-  CheckOffsetsInKernelParams32BP(params);
-  ruy::profiler::ScopeLabel label(
-      "Binary Kernel (4x4) 32BP (kNeon, optimized for out-of-order cores)");
-
-  std::uint32_t* lhs_col_ptr = const_cast<std::uint32_t*>(params.lhs_base_ptr);
-  std::uint32_t* rhs_col_ptr = const_cast<std::uint32_t*>(params.rhs_base_ptr);
-  std::uint32_t* lhs_ptr = lhs_col_ptr;
-  std::uint32_t* rhs_ptr = rhs_col_ptr;
-
-  float* dst_col_ptr = params.dst_base_ptr;
-  float* dst_ptr = dst_col_ptr;
-  int row = params.start_row;
-  int col = params.start_col;
-
-  asm volatile(
-#define RUY_MAKE_ZERO(reg) "dup " #reg ".4s, wzr\n"
-
-      // clang-format off
-
-      // Load some parameters into registers.
-      "ldr x5, [%[params], #" RUY_STR(RUY_OFFSET_LHS_BASE_PTR) "]\n"
-      "ldr w6, [%[params], #" RUY_STR(RUY_OFFSET_START_ROW) "]\n"
-      "ldr w7, [%[params], #" RUY_STR(RUY_OFFSET_LAST_ROW) "]\n"
-      "ldr w8, [%[params], #" RUY_STR(RUY_OFFSET_LAST_COL) "]\n"
-      "ldr w9, [%[params], #" RUY_STR(RUY_OFFSET_LHS_STRIDE) "]\n"
-      "ldr w10, [%[params], #" RUY_STR(RUY_OFFSET_RHS_STRIDE) "]\n"
-      "ldr w11, [%[params], #" RUY_STR(RUY_OFFSET_DST_STRIDE) "]\n"
-      "ldr w12, [%[params], #" RUY_STR(RUY_OFFSET_DEPTH) "]\n"
-
-      // Load the first 64 bytes of LHS and RHS data.
-      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
-      "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[rhs_ptr]], #64\n"
-
-      // Clear accumulators.
-      RUY_MAKE_ZERO(v16)
-      RUY_MAKE_ZERO(v18)
-      RUY_MAKE_ZERO(v20)
-      RUY_MAKE_ZERO(v22)
-
-      // w1 is the number of levels of depth that we have already loaded
-      // LHS and RHS data for. The RHS is stored in col-wise. Therefore, for 32-bit elements,
-      // one register can hold 4 levels of depth.
-      "mov w1, #4\n"
-
-      // Main loop of the whole GEMM, over rows and columns of the
-      // destination matrix.
-      "1:\n"
-
-      LCE_BMLA(v16, v4, v0, v1, v2, v3)
-      LCE_BMLA(v18, v5, v0, v1, v2, v3)
-      LCE_BMLA(v20, v6, v0, v1, v2, v3)
-      LCE_BMLA(v22, v7, v0, v1, v2, v3)
-
-      // Accumulation loop
-      "cmp w1, w12\n"
-      "beq 79f\n"
-
-      "2:\n"
-      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
-      "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[rhs_ptr]], #64\n"
-
-      "add w1, w1, #4\n"
-      "cmp w1, w12\n"
-
-      LCE_BMLA(v16, v4, v0, v1, v2, v3)
-      LCE_BMLA(v18, v5, v0, v1, v2, v3)
-      LCE_BMLA(v20, v6, v0, v1, v2, v3)
-      LCE_BMLA(v22, v7, v0, v1, v2, v3)
-
-      "blt 2b\n"
-
-      "79:\n"
-
-      // End of accumulation. The registers v16 -- v22 contain the final
-      // int32 accumulator values of the current 4x4 destination block.
-
-      // Logic to advance to the next block in preparation for the next
-      // iteration of the main loop. For now, we only want to compute
-      // the LHS and RHS data pointers, lhs_col_ptr and rhs_col_ptr. We are
-      // not yet ready to update the values of row and col, as we still need
-      // the current values for the rest of the work on the current block.
-
-      "cmp %w[row], w7\n"  // Have we finished the last row?
-      "bge 4f\n"           // If finished last row, go to 4
-      // Not finished last row: then advance to next row.
-      // x9 is the LHS stride
-      "add %[lhs_col_ptr], %[lhs_col_ptr], x9, lsl #2\n"
-      "b 5f\n"
-      "4:\n"  // Finished last row...
-      "mov %[lhs_col_ptr], x5\n"  // Go back to first row
-      // Now we need to advance to the next column. If we already
-      // finished the last column, then in principle we are done, however
-      // we can't just return here, as we need to allow the end work of the
-      // current block to complete. The good news is that at this point it
-      // doesn't matter what data we load for the next column, since
-      // we will exit from the main loop below before actually storing
-      // anything computed from that data.
-      "cmp %w[col], w8\n"  // Have we finished the last column?
-      "bge 5f\n" // If yes, just carry on without updating the column pointer.
-      // Not finished last column: then advance to next column.
-      // x10 is the RHS stride
-      "add %[rhs_col_ptr], %[rhs_col_ptr], x10, lsl #2\n"
-      "5:\n"
-
-      // Set the LHS and RHS data pointers to the start of the columns just
-      // computed.
-      "mov %[lhs_ptr], %[lhs_col_ptr]\n"
-      "mov %[rhs_ptr], %[rhs_col_ptr]\n"
-
-      // Load some parameters needed for the end work on current block.
-      "ldrb w4, [%[params], #" RUY_STR(RUY_OFFSET_FLAGS) "]\n"
-
-      // Load backtransform add (duplicate 4 times into v13)
-      "ldr w1, [%[params], #" RUY_STR(RUY_OFFSET_BACKTRANSFORM_ADD) "]\n"
-      "dup v13.4s, w1 \n"
-
-      // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_MULTIPLIER) "]\n"
-      // Offset these base pointers as needed given the current row, col.
-      "add x2, x1, %x[row], lsl #2\n"
-      "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
-      "csel x1, x1, x2, eq\n"
-      // Load 4 bias-multiplication values.
-      "ld1 {v14.4s}, [x1], #16\n"
-
-      // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_BIAS) "]\n"
-      // Offset these base pointers as needed given the current row, col.
-      "add x2, x1, %x[row], lsl #2\n"
-      "tst w4, #" RUY_STR(RUY_ASM_FLAG_HAS_BIAS) "\n"
-      "csel x1, x1, x2, eq\n"
-      // Load 4 bias-addition values.
-      "ld1 {v15.4s}, [x1], #16\n"
-
-      // Now that we know what LHS and RHS data the next iteration of the
-      // main loop will need to load, we start loading the first 64 bytes of
-      // each of LHS and RHS, into v0 -- v3 and v4 -- v7 as we don't need
-      // them anymore in the rest of the work on the current block.
-      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
-      "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[rhs_ptr]], #64\n"
-
-      // Perform the backtransformation (in int32)
-      "shl v16.4s, v16.4s, #1\n"
-      "shl v18.4s, v18.4s, #1\n"
-      "shl v20.4s, v20.4s, #1\n"
-      "shl v22.4s, v22.4s, #1\n"
-
-      // Load the clamp_max bound (in parallel with the sub)
-      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
-      "dup v12.4s, w2\n"  // clamp_min
-
-      "sub v16.4s, v13.4s, v16.4s\n"
-      "sub v18.4s, v13.4s, v18.4s\n"
-      "sub v20.4s, v13.4s, v20.4s\n"
-      "sub v22.4s, v13.4s, v22.4s\n"
-
-      // Load the clamp_max bound (in parallel with the clamp_min)
-      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"
-      "dup v13.4s, w3\n"  // clamp_max
-
-      // Perform the activation function, by clamping
-      // Apply the clamp_min bound
-      "smax v16.4s, v16.4s, v12.4s\n"
-      "smax v18.4s, v18.4s, v12.4s\n"
-      "smax v20.4s, v20.4s, v12.4s\n"
-      "smax v22.4s, v22.4s, v12.4s\n"
-      // Apply the clamp_max bound
-      "smin v16.4s, v16.4s, v13.4s\n"
-      "smin v18.4s, v18.4s, v13.4s\n"
-      "smin v20.4s, v20.4s, v13.4s\n"
-      "smin v22.4s, v22.4s, v13.4s\n"
-
-      // Convert to single precision float
-      "scvtf v16.4s, v16.4s\n"
-      "scvtf v18.4s, v18.4s\n"
-      "scvtf v20.4s, v20.4s\n"
-      "scvtf v22.4s, v22.4s\n"
-
-      // Perform the post multiplications
-      "fmul v16.4s, v16.4s, v14.4s\n"
-      "fmul v18.4s, v18.4s, v14.4s\n"
-      "fmul v20.4s, v20.4s, v14.4s\n"
-      "fmul v22.4s, v22.4s, v14.4s\n"
-      // Perform the post additions
-      "fadd v16.4s, v16.4s, v15.4s\n"
-      "fadd v18.4s, v18.4s, v15.4s\n"
-      "fadd v20.4s, v20.4s, v15.4s\n"
-      "fadd v22.4s, v22.4s, v15.4s\n"
-
-      // Compute how much of the 4x4 block of destination values that
-      // we have computed, fit in the destination matrix. Typically, all of
-      // it fits, but when the destination matrix shape is not a multiple
-      // of 4x4, there are some 4x4 blocks along the boundaries that do
-      // not fit entirely.
-      "sub w1, %w[dst_rows], %w[row]\n"
-      "sub w2, %w[dst_cols], %w[col]\n"
-      "mov w3, #4\n"
-      "cmp w1, #4\n"
-      // Compute w1 = how many rows of the 4x4 block fit
-      "csel w1, w1, w3, le\n"
-      "cmp w2, #4\n"
-      // Compute w2 = how many cols of the 4x4 block fit
-      "csel w2, w2, w3, le\n"
-
-      // Test if w1==4 && w2 == 4, i.e. if all of the 4x4 block fits.
-      "cmp w1, w3\n"
-      "ccmp w2, w3, 0, eq\n"
-      // Yes, all of the 4x4 block fits, go to fast path.
-      "beq 30f\n"
-      // Not all of the 4x4 block fits.
-      // Set (x3 address, x4 stride) to write to dst_tmp_buf
-      "mov x3, %[dst_tmp_buf]\n"
-      "mov x4, #16\n"
-      "b 31f\n"
-      "30:\n"
-      // Yes, all of the 4x4 block fits.
-      // Set (x3 address, x4 stride) to write directly to destination matrix.
-      "mov x3, %[dst_ptr]\n"
-      "mov x4, x11\n"
-      "31:\n"
-
-      // Write our values to the destination described by
-      // (x3 address, x4 stride).
-      "str q16, [x3, #0]\n"
-      "add x3, x3, x4\n"
-      "str q18, [x3, #0]\n"
-      "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v16)
-      RUY_MAKE_ZERO(v18)
-      "str q20, [x3, #0]\n"
-      "add x3, x3, x4\n"
-      "str q22, [x3, #0]\n"
-      "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v20)
-      RUY_MAKE_ZERO(v22)
-
-      // If all of the 4x4 block fits, we just finished writing it to the
-      // destination, so we skip the next part.
-      "beq 41f\n"
-      // Not all of the 4x4 block fits in the destination matrix.  We just
-      // wrote it to dst_tmp_buf. Now we perform the slow scalar loop over
-      // it to copy into the destination matrix the part that fits.
-      "mov x3, %[dst_tmp_buf]\n"
-      "mov x4, %[dst_ptr]\n"
-      "mov w14, #0\n"
-      "50:\n"
-      "mov w15, #0\n"
-      "51:\n"
-      "ldr w13, [x3, x15, lsl #2]\n"
-      "str w13, [x4, x15, lsl #2]\n"
-      "add w15, w15, #1\n"
-      "cmp w15, w1\n"
-      "blt 51b\n"
-      "add w14, w14, #1\n"
-      "add x3, x3, #16\n"
-      "add x4, x4, x11\n"
-      "cmp w14, w2\n"
-      "blt 50b\n"
-      "41:\n"
-      "add %[dst_ptr], %[dst_ptr], #16\n"
-
-      // At this point we have completely finished writing values to the
-      // destination matrix for the current block.
-
-      // Move to the next block of the destination matrix, for the next iter
-      // of the main loop.  Notice that lhs_col_ptr, rhs_col_ptr have already
-      // been updated earlier.
-      // Have we reached the end row?
-      "cmp %w[row], w7\n"
-      "beq 20f\n"  // yes, end row.
-      // Not end row. Move to the next row.
-      "add %w[row], %w[row], #4\n"
-      "b 21f\n"
-      "20:\n"
-      // Was already at end row.
-      "mov %w[row], w6\n"  // Move back to first row.
-      "add %w[col], %w[col], #4\n"  // Move to the next column.
-      "add %[dst_col_ptr], %[dst_col_ptr], x11, lsl #2\n"
-      "mov %[dst_ptr], %[dst_col_ptr]\n"
-      "21:\n"
-
-      // Main loop exit condition: have we hit the end column?
-      "cmp %w[col], w8\n"
-
-      // w1 is the number of levels of depth that we have already loaded
-      // LHS and RHS data for.
-      "mov w1, #4\n"
-
-      "ble 1b\n"
-
-      // clang-format on
-
-      : [ lhs_col_ptr ] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
-        [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
-        [dst_col_ptr] "+r"(dst_col_ptr), [dst_ptr] "+r"(dst_ptr), [row] "+r"(row), [col] "+r"(col)
-      : [ params ] "r"(&params), [dst_rows] "r"(params.dst_rows),
-        [dst_cols] "r"(params.dst_cols), [dst_tmp_buf] "r"(params.dst_tmp_buf)
-      : "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "cc",
-        "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12",
-        "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25",
-        "v26", "v27", "v28", "v29", "v30", "v31");
-}
-
-#undef RUY_OFFSET_BACKTRANSFORM_ADD
-#undef RUY_OFFSET_POST_ACTIVATION_MULTIPLIER
-#undef RUY_OFFSET_POST_ACTIVATION_BIAS
-#undef RUY_OFFSET_FLAGS
-#undef RUY_OFFSET_LHS_BASE_PTR
-#undef RUY_OFFSET_CLAMP_MIN
-#undef RUY_OFFSET_CLAMP_MAX
-#undef RUY_OFFSET_START_ROW
-#undef RUY_OFFSET_LAST_ROW
-#undef RUY_OFFSET_LAST_COL
-#undef RUY_OFFSET_LHS_STRIDE
-#undef RUY_OFFSET_RHS_STRIDE
-#undef RUY_OFFSET_DST_STRIDE
-#undef RUY_OFFSET_DEPTH
-#undef RUY_OFFSET_START_COL
-#undef RUY_OFFSET_RHS_BASE_PTR
-#undef RUY_OFFSET_DST_BASE_PTR
-
-#define RUY_OFFSET_LHS_BASE_PTR 0
-#define RUY_OFFSET_RHS_BASE_PTR 8
-#define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_POST_ACTIVATION_MULTIPLIER 24
-#define RUY_OFFSET_POST_ACTIVATION_BIAS 32
-#define RUY_OFFSET_START_ROW 40
-#define RUY_OFFSET_START_COL 44
-#define RUY_OFFSET_LAST_ROW 48
-#define RUY_OFFSET_LAST_COL 52
-#define RUY_OFFSET_LHS_STRIDE 64
-#define RUY_OFFSET_RHS_STRIDE 68
-#define RUY_OFFSET_DST_STRIDE 72
-#define RUY_OFFSET_DEPTH 76
-#define RUY_OFFSET_CLAMP_MIN 80
-#define RUY_OFFSET_CLAMP_MAX 84
-#define RUY_OFFSET_BACKTRANSFORM_ADD 88
-#define RUY_OFFSET_FLAGS 92
-
-template <typename Params>
-void CheckOffsetsInKernelParams64BP4x4(const Params&) {
+void CheckOffsetsInKernelParams(const Params&) {
   static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
   static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
   static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
@@ -541,9 +144,9 @@ void CheckOffsetsInKernelParams64BP4x4(const Params&) {
 
 // clang-format on
 
-void BinaryKernelNeonOutOfOrder64BP4x4(
+void BinaryKernelNeonOutOfOrder4x4(
     const BinaryKernelParams<4, 4, std::uint64_t>& params) {
-  CheckOffsetsInKernelParams64BP4x4(params);
+  CheckOffsetsInKernelParams(params);
   ruy::profiler::ScopeLabel label(
       "Binary Kernel (4x4) 64BP (kNeon, optimized for out-of-order cores)");
 
@@ -875,10 +478,10 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
 
       // clang-format on
 
-      : [ lhs_col_ptr ] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
+      : [lhs_col_ptr] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
         [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
         [dst_col_ptr] "+r"(dst_col_ptr), [dst_ptr] "+r"(dst_ptr), [row] "+r"(row), [col] "+r"(col)
-      : [ params ] "r"(&params), [dst_rows] "r"(params.dst_rows),
+      : [params] "r"(&params), [dst_rows] "r"(params.dst_rows),
         [dst_cols] "r"(params.dst_cols), [dst_tmp_buf] "r"(params.dst_tmp_buf)
       : "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "cc",
         "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12",
@@ -1030,32 +633,6 @@ void BinaryKernelNeonOutOfOrder64BP4x4(
 #define RUY_OFFSET_BACKTRANSFORM_ADD 88
 #define RUY_OFFSET_FLAGS 92
 
-template <typename Params>
-void CheckOffsetsInKernelParams64BP8x4(const Params&) {
-  static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
-  static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
-  static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, post_activation_multiplier) ==
-                    RUY_OFFSET_POST_ACTIVATION_MULTIPLIER,
-                "");
-  static_assert(
-      offsetof(Params, post_activation_bias) == RUY_OFFSET_POST_ACTIVATION_BIAS,
-      "");
-  static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
-  static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
-  static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
-  static_assert(offsetof(Params, last_col) == RUY_OFFSET_LAST_COL, "");
-  static_assert(offsetof(Params, lhs_stride) == RUY_OFFSET_LHS_STRIDE, "");
-  static_assert(offsetof(Params, rhs_stride) == RUY_OFFSET_RHS_STRIDE, "");
-  static_assert(offsetof(Params, dst_stride) == RUY_OFFSET_DST_STRIDE, "");
-  static_assert(offsetof(Params, depth) == RUY_OFFSET_DEPTH, "");
-  static_assert(offsetof(Params, clamp_min) == RUY_OFFSET_CLAMP_MIN, "");
-  static_assert(offsetof(Params, clamp_max) == RUY_OFFSET_CLAMP_MAX, "");
-  static_assert(
-      offsetof(Params, backtransform_add) == RUY_OFFSET_BACKTRANSFORM_ADD, "");
-  static_assert(offsetof(Params, flags) == RUY_OFFSET_FLAGS, "");
-}
-
 // clang-format off
 
 // The asm kernel below has the following NEON register allocation:
@@ -1087,9 +664,9 @@ void CheckOffsetsInKernelParams64BP8x4(const Params&) {
 
 // clang-format on
 
-void BinaryKernelNeonOutOfOrder64BP8x4(
+void BinaryKernelNeonOutOfOrder8x4(
     const BinaryKernelParams<8, 4, std::uint64_t>& params) {
-  CheckOffsetsInKernelParams64BP8x4(params);
+  CheckOffsetsInKernelParams(params);
   ruy::profiler::ScopeLabel label(
       "Binary Kernel (8x4) 64BP (kNeon, optimized for out-of-order cores)");
 
@@ -1455,10 +1032,10 @@ void BinaryKernelNeonOutOfOrder64BP8x4(
 
       // clang-format on
 
-      : [ lhs_col_ptr ] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
+      : [lhs_col_ptr] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
         [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
         [dst_col_ptr] "+r"(dst_col_ptr), [dst_ptr] "+r"(dst_ptr), [row] "+r"(row), [col] "+r"(col)
-      : [ params ] "r"(&params), [dst_rows] "r"(params.dst_rows),
+      : [params] "r"(&params), [dst_rows] "r"(params.dst_rows),
         [dst_cols] "r"(params.dst_cols), [dst_tmp_buf] "r"(params.dst_tmp_buf)
       : "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "cc",
         "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12",

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -104,4 +104,54 @@ inline void MakeBinaryKernelParams(
   RUY_DCHECK_LT(params->last_col, params->dst_cols);
 }
 
+// A specialised template for the case when the LHS and RHS are uint32 bitpacked
+// but we're using a kernel designed for uint64 bitpacked inputs.
+template <int LhsCols, int RhsCols, typename AccumScalar>
+inline void MakeBinaryKernelParams(
+    const PackedMatrix<std::uint32_t>& lhs,
+    const PackedMatrix<std::uint32_t>& rhs,
+    const BinaryMulParams<AccumScalar, float>& spec, int start_row,
+    int start_col, int end_row, int end_col, Matrix<float>* dst,
+    BinaryKernelParams<LhsCols, RhsCols, std::uint64_t>* params) {
+  const int depth = lhs.layout.rows;
+  RUY_DCHECK_EQ(start_row % LhsCols, 0);
+  RUY_DCHECK_EQ(start_col % RhsCols, 0);
+  RUY_DCHECK_EQ(end_row % LhsCols, 0);
+  RUY_DCHECK_EQ(end_col % RhsCols, 0);
+
+  params->lhs_base_ptr = reinterpret_cast<std::uint64_t*>(
+      lhs.data + start_row * lhs.layout.stride);
+  params->rhs_base_ptr = reinterpret_cast<std::uint64_t*>(
+      rhs.data + start_col * rhs.layout.stride);
+  params->dst_base_ptr =
+      dst->data.get() + start_col * dst->layout.stride + start_row;
+
+  std::uint8_t flags = 0;
+  params->post_activation_multiplier =
+      spec.output_transform.post_activation_multiplier;
+  params->post_activation_bias = spec.output_transform.post_activation_bias;
+  if (params->post_activation_multiplier && params->post_activation_bias) {
+    flags |= RUY_ASM_FLAG_HAS_BIAS;
+  }
+  params->backtransform_add = spec.output_transform.backtransform_add;
+  params->flags = flags;
+  params->start_row = start_row;
+  params->start_col = start_col;
+  params->last_row = end_row - LhsCols;
+  params->last_col = end_col - RhsCols;
+  params->lhs_stride = sizeof(std::uint32_t) * lhs.layout.stride;
+  params->rhs_stride = sizeof(std::uint32_t) * rhs.layout.stride;
+  params->dst_stride = sizeof(float) * dst->layout.stride;
+  // We halve the depth to pretend that the input data is uint64.
+  RUY_DCHECK_EQ(depth % 2, 0);
+  params->depth = depth / 2;
+  params->clamp_min = spec.output_transform.clamp_min;
+  params->clamp_max = spec.output_transform.clamp_max;
+  params->dst_rows = dst->layout.rows;
+  params->dst_cols = dst->layout.cols;
+
+  RUY_DCHECK_LT(params->last_row, params->dst_rows);
+  RUY_DCHECK_LT(params->last_col, params->dst_cols);
+}
+
 #endif  // COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_COMMON_H_

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -801,17 +801,15 @@ TfLiteStatus EvalChooseKernelType(TfLiteContext* context, TfLiteNode* node,
                                   TfLiteBConv2DParams* params) {
   if (kernel_type == KernelType::kRuyOptimized) {
 #if RUY_PLATFORM(ARM_64)
-    // On 64 bit Arm only there is an optimised kernel for 64-bit bitpacking,
-    // float output, and 16-bit accumulators. It is safe to use this without
-    // risk of overflow as long as the maximum value of the convolution (filter
-    // height * filter width * input channels, plus some overhead to account for
-    // potential padding) is less than 2^16.
-    //     We will almost always take this path: for a 3x3 filter there would
-    // need to be > 7000 input channels to present an overflow risk.
+    // On 64 bit Arm only there is an optimised kernel for 16-bit accumulators
+    // and float output. It is safe to use this without risk of overflow as long
+    // as the maximum value of the convolution (filter height * filter width *
+    // input channels, plus some overhead to account for potential padding) is
+    // less than 2^16. We will almost always take this path: for a 3x3 filter
+    // there would need to be > 7000 input channels to present an overflow risk.
     const int depth =
         params->filter_height * params->filter_width * params->channels_in;
-    if (std::is_same<TBitpacked, std::uint64_t>::value &&
-        std::is_same<DstScalar, float>::value && depth + 512 < 1 << 16) {
+    if (std::is_same<DstScalar, float>::value && depth + 512 < 1 << 16) {
       EvalOpt<SrcScalar, TBitpacked, std::int16_t, DstScalar>(context, node,
                                                               params);
       return kTfLiteOk;

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -738,8 +738,8 @@ INSTANTIATE_TEST_SUITE_P(
     TestParam::TestNameSuffix);
 
 // Separately, for 64-bit optimised kernels only, test a very large input
-// channels and filter size that would overflow 16-bit accumulators (to check
-// that we successfully fall back to the 32-bit accumulator kernels).
+// channel and filter size combination that would overflow 16-bit accumulators
+// (to check that we successfully fall back to the 32-bit accumulator kernels).
 INSTANTIATE_TEST_SUITE_P(
     OptimizedKernel16BitOverflowTest, BConv2DOpTest,
     ::testing::Combine(


### PR DESCRIPTION
See comment [here](https://github.com/larq/compute-engine/pull/350#issuecomment-626310229).

~~This depends on #350, so will be a draft PR until that is merged.~~

## What do these changes do?

At the moment there are three optimised assembly kernels for Aarch64: a 4x4 uint32 kernel, a 4x4 uint64 kernel, and an 8x4 uint64 kernel.

I can't see a reason to maintain a distinction between uint32 input and uint64 input at a kernel level, because a kernel that's written to accept uint64 input can accept uint32 input as long as some kernel parameters are adjusted (e.g. kernel depth halved) and the Ruy LHS/RHS packing is done correctly.

This PR removes the separate uint32 4x4 kernel, and makes 8x4 kernel and the remaining 4x4 kernels usable with either uint64 or uint32 input. Whereas there were previously three Aarch64 kernel code-paths and three kernel registrations, now there are two Aarch64 kernel code paths (8x4 and 4x4) and four kernel registrations (uint64 and uint32 for each of the code paths).

The main benefit is reduced code and binary size. However, this will also speed up binary convolutions which use uint32 input, as they were previously unable to use a faster 8x4 kernel.

## How Has This Been Tested?

CI tests. The 'big' tests that don't run on CI have be run locally (and pass).

## Benchmark Results

N/A.

## Related issue number

N/A.