### PR TITLE
Allow to set fake default ranges to enable latency test of int8 models 

### DIFF
--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -1,4 +1,6 @@
 from packaging import version
+import warnings
+from typing import Optional, Tuple
 import tensorflow as tf
 
 from larq_compute_engine.mlir._graphdef_tfl_flatbuffer import (
@@ -50,6 +52,7 @@ def _contains_training_quant_op(graph_def):
 def convert_keras_model(
     model: tf.keras.Model,
     *,  # Require remaining arguments to be keyword-only.
+    default_ranges: Optional[Tuple[float, float]] = None,
     experimental_enable_bitpacked_activations: bool = False,
 ) -> bytes:
     """Converts a Keras model to TFLite flatbuffer.
@@ -63,6 +66,9 @@ def convert_keras_model(
 
     # Arguments
         model: The model to convert.
+        default_ranges: Tuple of integers representing `(min, max)` range values for all
+            arrays without a specified range. Intended for experimenting with
+            quantization via "dummy quantization". (default None)
         experimental_enable_bitpacked_activations: Enable an experimental
             converter optimisation that attempts to reduce intermediate
             activation memory usage by bitpacking the activation tensor between
@@ -76,6 +82,11 @@ def convert_keras_model(
             "Graph mode is not supported. Please enable eager execution using "
             "tf.enable_eager_execution() when using TensorFlow 1.x"
         )
+    if default_ranges:
+        warnings.warn(
+            "Using `default_ranges` as fallback quantization stats. "
+            "This should only be used for latency tests."
+        )
     func = concrete_function_from_keras_model(model)
     if version.parse(tf.__version__) >= version.parse("1.15"):
         frozen_func = convert_variables_to_constants_v2(func, lower_control_flow=False)
@@ -87,7 +98,9 @@ def convert_keras_model(
     output_tensors = frozen_func.outputs
 
     graph_def = frozen_func.graph.as_graph_def()
-    should_quantize = _contains_training_quant_op(graph_def)
+    should_quantize = (
+        _contains_training_quant_op(graph_def) or default_ranges is not None
+    )
 
     # Checks dimensions in input tensor.
     for tensor in input_tensors:
@@ -111,5 +124,6 @@ def convert_keras_model(
         [tensor.shape.as_list() for tensor in input_tensors],
         [get_tensor_name(tensor) for tensor in output_tensors],
         should_quantize,
+        default_ranges,
         experimental_enable_bitpacked_activations,
     )

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -25,6 +25,7 @@ class TestConverter(unittest.TestCase):
             [[1, 224, 224, 3]],
             ["Identity"],
             False,
+            None,
             False,
         )
 

--- a/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
@@ -41,6 +41,7 @@ pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
     const std::vector<string>& input_dtypes,
     const std::vector<std::vector<int>>& input_shapes,
     const std::vector<string>& output_arrays, const bool should_quantize,
+    const pybind11::object& default_ranges,
     const bool experimental_enable_bitpacked_activations) {
   GraphDef graphdef;
   if (!tensorflow::LoadProtoFromBuffer(std::string(graphdef_bytes), &graphdef)
@@ -79,6 +80,11 @@ pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
       // Input inference type is DT_FLOAT, so set the default input ranges
       // which default to mean=0.0 and std=1.0.
       quant_specs.input_ranges.push_back({-128.0, 127.0});
+    }
+    if (!default_ranges.is_none()) {
+      quant_specs.inference_input_type = tensorflow::DT_QINT8;
+      quant_specs.default_ranges =
+          default_ranges.cast<std::pair<double, double>>();
     }
   }
   mlir::PassManager pm(&context);

--- a/larq_compute_engine/mlir/tf_tfl_passes.cc
+++ b/larq_compute_engine/mlir/tf_tfl_passes.cc
@@ -25,6 +25,18 @@ void AddQuantizationPasses(const mlir::TFL::QuantizationSpecs& quant_specs,
       quant_specs.inference_type != quant_specs.inference_input_type;
   pass_manager->addPass(
       mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
+
+  if (quant_specs.default_ranges.first.hasValue() ||
+      quant_specs.default_ranges.second.hasValue()) {
+    pass_manager->addPass(mlir::TFL::CreateDefaultQuantParamsPass(
+        quant_specs.default_ranges.first.getValueOr(0.0),
+        quant_specs.default_ranges.second.getValueOr(0.0),
+        quant_specs.IsSignedInferenceType()));
+    pass_manager->addPass(mlir::TFL::CreateHybridQuantizePass());
+    pass_manager->addPass(
+        mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
+  }
+
   pass_manager->addPass(mlir::TFL::CreateOpRemovalPass());
   pass_manager->addPass(
       mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));


### PR DESCRIPTION
## What do these changes do?
This allows for passing default int8 quantization ranges to the converter to enable latency testing without needing to correctly have fake-quant nodes in the graph.

This currently relies on a fork of TensorFlow to include https://github.com/tensorflow/tensorflow/pull/39171.
#363 still needs some work which would include the relevant commits, but this PR can already be reviewed until we incorporate the Ruy API changes of #363 

## How Has This Been Tested?
CI and manual testing.