### PR TITLE
Make PyPI release condition less strict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
 
   upload-wheels:
     name: Publish wheels to PyPi
-    if: github.event_name == 'release'
+    if: github.event_name != 'push'
     needs: [manylinux-release-wheel, macos-release-wheel, windows-release-wheel]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This loosens the GitHub action check to publish a PyPI package which allows for manually retriggering a release workflow via the UI if some builds timeout.
I noticed this since one of the 0.3 release builds didn't trigger correctly due to a service degredation of GitHub actions and rerunning via the UI wasn't possible due to this check blocking the upload to PyPI.