### PR TITLE
Upgrade TensorFlow to eaacee173897b77cdb6afd22d5e78154177a10f3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,10 +47,10 @@ arm_compiler_configure(
 #    reliable downloads.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "8e86547c8238637cdc895ec53f02adedad4dfa2a7fcfee06dbdeb9f0e3be6168",
-    strip_prefix = "tensorflow-a80d96c6634cd005b3841d462030448f9f551a14",
+    sha256 = "b2676f96085f816483c6ce17c8a461cb1c2e9d4c6133467b3f4bb1d73b3dc322",
+    strip_prefix = "tensorflow-eaacee173897b77cdb6afd22d5e78154177a10f3",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/a80d96c6634cd005b3841d462030448f9f551a14.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/eaacee173897b77cdb6afd22d5e78154177a10f3.tar.gz",
     ],
 )
 

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -3,8 +3,8 @@
 
 #include "bgemm_kernels_common.h"
 #include "ruy/common.h"
-#include "ruy/internal_matrix.h"
 #include "ruy/kernel_common.h"
+#include "ruy/mat.h"
 #include "ruy/matrix.h"
 #include "ruy/mul_params.h"
 #include "ruy/opt_set.h"
@@ -27,10 +27,9 @@ struct BgemmKernel<ruy::Path::kNeon, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(ruy::Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     TFLITE_DCHECK(false);
   }
 };
@@ -44,10 +43,9 @@ struct BgemmKernel<ruy::Path::kNeonDotprod, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(ruy::Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     TFLITE_DCHECK(false);
   }
 };
@@ -68,12 +66,12 @@ struct BgemmKernel<ruy::Path::kNeon, std::uint64_t, std::uint64_t, float,
   using LhsLayout = FixedKernelLayout<Order::kColMajor, 2, 8>;
   using RhsLayout = FixedKernelLayout<Order::kColMajor, 2, 4>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<std::uint64_t>& lhs,
-           const ruy::PackedMatrix<std::uint64_t>& rhs,
-           const BinaryMulParams<std::int16_t /* accum. scalar */, float>&
+  void Run(const ruy::PMat<std::uint64_t>& lhs,
+           const ruy::PMat<std::uint64_t>& rhs,
+           const BinaryMulParams<std::int32_t /* accum. scalar */, float>&
                mul_params,
            int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<float>* dst) const {
+           ruy::Mat<float>* dst) const {
     BinaryKernelParams<LhsLayout::kCols, RhsLayout::kCols, std::uint64_t>
         params;
     MakeBinaryKernelParams(lhs, rhs, mul_params, start_row, start_col, end_row,
@@ -91,12 +89,12 @@ struct BgemmKernel<ruy::Path::kNeon, std::uint64_t, std::uint64_t, float,
   using LhsLayout = FixedKernelLayout<Order::kColMajor, 2, 4>;
   using RhsLayout = FixedKernelLayout<Order::kColMajor, 2, 4>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<std::uint64_t>& lhs,
-           const ruy::PackedMatrix<std::uint64_t>& rhs,
+  void Run(const ruy::PMat<std::uint64_t>& lhs,
+           const ruy::PMat<std::uint64_t>& rhs,
            const BinaryMulParams<std::int32_t /* accum. scalar */, float>&
                mul_params,
            int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<float>* dst) const {
+           ruy::Mat<float>* dst) const {
     BinaryKernelParams<LhsLayout::kCols, RhsLayout::kCols, std::uint64_t>
         params;
     MakeBinaryKernelParams(lhs, rhs, mul_params, start_row, start_col, end_row,
@@ -146,12 +144,12 @@ struct BgemmKernel<ruy::Path::kNeon, std::uint32_t, std::uint32_t, float,
   using LhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
   using RhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<std::uint32_t>& lhs,
-           const ruy::PackedMatrix<std::uint32_t>& rhs,
+  void Run(const ruy::PMat<std::uint32_t>& lhs,
+           const ruy::PMat<std::uint32_t>& rhs,
            const BinaryMulParams<std::int32_t /* accum. scalar */, float>&
                mul_params,
            int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<float>* dst) const {
+           ruy::Mat<float>* dst) const {
     BinaryKernelParams<LhsLayout::kCols, RhsLayout::kCols, std::uint64_t>
         params;
     MakeBinaryKernelParams(lhs, rhs, mul_params, start_row, start_col, end_row,

--- a/larq_compute_engine/core/bgemm_kernels_arm.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm.h
@@ -68,7 +68,7 @@ struct BgemmKernel<ruy::Path::kNeon, std::uint64_t, std::uint64_t, float,
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
   void Run(const ruy::PMat<std::uint64_t>& lhs,
            const ruy::PMat<std::uint64_t>& rhs,
-           const BinaryMulParams<std::int32_t /* accum. scalar */, float>&
+           const BinaryMulParams<std::int16_t /* accum. scalar */, float>&
                mul_params,
            int start_row, int start_col, int end_row, int end_col,
            ruy::Mat<float>* dst) const {
@@ -121,12 +121,12 @@ struct BgemmKernel<ruy::Path::kNeon, std::uint32_t, std::uint32_t, float,
   using LhsLayout = FixedKernelLayout<Order::kColMajor, 4, 8>;
   using RhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<std::uint32_t>& lhs,
-           const ruy::PackedMatrix<std::uint32_t>& rhs,
+  void Run(const ruy::PMat<std::uint32_t>& lhs,
+           const ruy::PMat<std::uint32_t>& rhs,
            const BinaryMulParams<std::int16_t /* accum. scalar */, float>&
                mul_params,
            int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<float>* dst) const {
+           ruy::Mat<float>* dst) const {
     BinaryKernelParams<LhsLayout::kCols, RhsLayout::kCols, std::uint64_t>
         params;
     MakeBinaryKernelParams(lhs, rhs, mul_params, start_row, start_col, end_row,

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -102,10 +102,9 @@ inline void MakeBinaryKernelParams(
 // but we're using a kernel designed for uint64 bitpacked inputs.
 template <int LhsCols, int RhsCols, typename AccumScalar>
 inline void MakeBinaryKernelParams(
-    const PackedMatrix<std::uint32_t>& lhs,
-    const PackedMatrix<std::uint32_t>& rhs,
+    const ruy::PMat<std::uint32_t>& lhs, const ruy::PMat<std::uint32_t>& rhs,
     const BinaryMulParams<AccumScalar, float>& spec, int start_row,
-    int start_col, int end_row, int end_col, Matrix<float>* dst,
+    int start_col, int end_row, int end_col, Mat<float>* dst,
     BinaryKernelParams<LhsCols, RhsCols, std::uint64_t>* params) {
   const int depth = lhs.layout.rows;
   RUY_DCHECK_EQ(start_row % LhsCols, 0);

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -62,9 +62,9 @@ struct BinaryKernelParams {
 
 template <int LhsCols, int RhsCols, typename AccumScalar, typename T>
 inline void MakeBinaryKernelParams(
-    const PackedMatrix<T>& lhs, const PackedMatrix<T>& rhs,
+    const PMat<T>& lhs, const PMat<T>& rhs,
     const BinaryMulParams<AccumScalar, float>& spec, int start_row,
-    int start_col, int end_row, int end_col, Matrix<float>* dst,
+    int start_col, int end_row, int end_col, Mat<float>* dst,
     BinaryKernelParams<LhsCols, RhsCols, T>* params) {
   const int depth = lhs.layout.rows;
   RUY_DCHECK_EQ(start_row % LhsCols, 0);

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -30,10 +30,9 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = typename Spec::StandardCppKernelLhsLayout;
   using RhsLayout = typename Spec::StandardCppKernelRhsLayout;
   explicit BgemmKernel(ruy::Tuning) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
-           int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<DstScalar>* dst) const {
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+           const Spec& spec, int start_row, int start_col, int end_row,
+           int end_col, ruy::Mat<DstScalar>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(
@@ -88,10 +87,9 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::int32_t,
   using LhsLayout = typename Spec::StandardCppKernelLhsLayout;
   using RhsLayout = typename Spec::StandardCppKernelRhsLayout;
   explicit BgemmKernel(ruy::Tuning) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs, const Spec& spec,
-           int start_row, int start_col, int end_row, int end_col,
-           ruy::Matrix<std::int32_t>* dst) const {
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+           const Spec& spec, int start_row, int start_col, int end_row,
+           int end_col, ruy::Mat<std::int32_t>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(
@@ -169,12 +167,10 @@ struct BgemmKernel<ruy::Path::kStandardCpp, LhsScalar, RhsScalar, std::int32_t,
 
 template <ruy::Path ThePath, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename Spec>
-void RunBgemmKernelTyped(ruy::Tuning tuning,
-                         const ruy::PackedMatrix<LhsScalar>& lhs,
-                         const ruy::PackedMatrix<RhsScalar>& rhs,
-                         const Spec& spec, int start_row, int start_col,
-                         int end_row, int end_col,
-                         ruy::Matrix<DstScalar>* dst) {
+void RunBgemmKernelTyped(ruy::Tuning tuning, const ruy::PMat<LhsScalar>& lhs,
+                         const ruy::PMat<RhsScalar>& rhs, const Spec& spec,
+                         int start_row, int start_col, int end_row, int end_col,
+                         ruy::Mat<DstScalar>* dst) {
   using BKernel = BgemmKernel<ThePath, LhsScalar, RhsScalar, DstScalar, Spec>;
   BKernel kernel(tuning);
   using LhsLayout = typename BKernel::LhsLayout;
@@ -208,13 +204,13 @@ void RunBgemmKernelTyped(ruy::Tuning tuning,
 
 template <ruy::Path ThePath, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename Spec>
-void RunBgemmKernel(ruy::Tuning tuning, const ruy::SidePair<ruy::PMatrix>& src,
+void RunBgemmKernel(ruy::Tuning tuning, const ruy::SidePair<ruy::PEMat>& src,
                     void* spec, const ruy::SidePair<int>& start,
-                    const ruy::SidePair<int>& end, ruy::DMatrix* dst) {
-  ruy::Matrix<DstScalar> mdst = ruy::ToMatrix<DstScalar>(*dst);
+                    const ruy::SidePair<int>& end, ruy::EMat* dst) {
+  ruy::Mat<DstScalar> mdst = ruy::UneraseType<DstScalar>(*dst);
   RunBgemmKernelTyped<ThePath, LhsScalar, RhsScalar, DstScalar, Spec>(
-      tuning, ruy::ToPackedMatrix<LhsScalar>(src[ruy::Side::kLhs]),
-      ruy::ToPackedMatrix<RhsScalar>(src[ruy::Side::kRhs]),
+      tuning, ruy::UneraseType<LhsScalar>(src[ruy::Side::kLhs]),
+      ruy::UneraseType<RhsScalar>(src[ruy::Side::kRhs]),
       *static_cast<const Spec*>(spec), start[ruy::Side::kLhs],
       start[ruy::Side::kRhs], end[ruy::Side::kLhs], end[ruy::Side::kRhs],
       &mdst);

--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -2,8 +2,8 @@
 #define COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_X86_H_
 
 #include "ruy/common.h"
-#include "ruy/internal_matrix.h"
 #include "ruy/kernel_common.h"
+#include "ruy/mat.h"
 #include "ruy/matrix.h"
 #include "ruy/mul_params.h"
 #include "ruy/opt_set.h"
@@ -23,10 +23,9 @@ struct BgemmKernel<ruy::Path::kAvx2, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(
@@ -47,10 +46,9 @@ struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(
@@ -71,10 +69,9 @@ struct BgemmKernel<ruy::Path::kAvxVnni, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(
@@ -95,10 +92,9 @@ struct BgemmKernel<Path::kSse42, LhsScalar, RhsScalar, DstScalar,
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PackedMatrix<LhsScalar>& lhs,
-           const ruy::PackedMatrix<RhsScalar>& rhs,
+  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
-           int end_row, int end_col, ruy::Matrix<DstScalar>* dst) const {
+           int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
     static_assert(std::is_same<LhsScalar, RhsScalar>::value,
                   "Inputs to binary kernel should have the same type.");
     static_assert(

--- a/larq_compute_engine/core/bgemm_trmul_params.h
+++ b/larq_compute_engine/core/bgemm_trmul_params.h
@@ -19,8 +19,6 @@ namespace tflite {
 template <ruy::Path ThePath, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename MulParamsType>
 void PopulateBinaryTrMulParams(ruy::TrMulParams* params) {
-  static_assert((ThePath & ruy::Path::kReference) == ruy::Path::kNone,
-                "Path::kReference should not do TrMul");
   // The optimized code paths don't handle the full generality of Ruy's API.
   // Fall back to Path::kStandardCpp if necessary.
   bool fallback_to_standard_cpp = false;
@@ -62,7 +60,6 @@ void PopulateBinaryTrMulParams(ruy::TrMulParams* params) {
   params->run_kernel =
       &RunBgemmKernel<ThePath, PackedLhsScalar, PackedRhsScalar, DstScalar,
                       MulParamsType>;
-  return;
 }
 
 // PopulateTrMulParamsAllCompiledPaths calls into one of multiple
@@ -175,15 +172,15 @@ void PopulateBinaryTrMulParamsAllCompiledPaths(ruy::Path the_path,
 
 template <ruy::Path CompiledPaths, typename LhsScalar, typename RhsScalar,
           typename DstScalar, typename MulParamsType>
-void CreateBinaryTrMulParams(const Matrix<LhsScalar>& lhs,
-                             const Matrix<RhsScalar>& rhs,
-                             const MulParamsType& mul_params, Context* context,
-                             Matrix<DstScalar>* dst, Path the_path,
+void CreateBinaryTrMulParams(const Mat<LhsScalar>& lhs,
+                             const Mat<RhsScalar>& rhs,
+                             const MulParamsType& mul_params, Ctx* ctx,
+                             Mat<DstScalar>* dst, Path the_path,
                              TrMulParams* params) {
   // Fill in the fields we already know.
-  params->src[Side::kLhs] = ToDMatrix(lhs);
-  params->src[Side::kRhs] = ToDMatrix(rhs);
-  params->dst = ToDMatrix(*dst);
+  params->src[Side::kLhs] = EraseType(lhs);
+  params->src[Side::kRhs] = EraseType(rhs);
+  params->dst = EraseType(*dst);
   params->mul_params = ToVoidPtr(&mul_params);
 
   // Create inner loops and packed matrices based on the Path.


### PR DESCRIPTION
## What do these changes do?
This PR upgrades the TensorFlow dependency in order to include [`eaacee173897b77cdb6afd22d5e78154177a10f3`](https://github.com/tensorflow/tensorflow/commit/eaacee173897b77cdb6afd22d5e78154177a10f3).

Ruy heavily changed their internal API which requires quite a few code changes. A full diff of the changes in ruy can be seen [here](https://github.com/google/ruy/compare/9f53ba413e6fc879236dcaa3e008915973d67a4f...1b313682ef8b8fc8ed08719c610d1c3503b016bf). This is a first stab at trying to adapt our kernels to the API changes.

## How Has This Been Tested?
CI

## Related issue number
This is a required update to enable easy int8 benchmarking in #357
