### PR TITLE
Move RUY profiling out of core files

### DIFF
--- a/larq_compute_engine/core/bgemm_functor.h
+++ b/larq_compute_engine/core/bgemm_functor.h
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <limits>
 
-#include "larq_compute_engine/core/macros.h"
-
 namespace compute_engine {
 namespace core {
 

--- a/larq_compute_engine/core/packbits_utils.h
+++ b/larq_compute_engine/core/packbits_utils.h
@@ -2,7 +2,6 @@
 #define COMPUTE_ENGINE_CORE_PACKBITS_UTILS_H_
 
 #include "larq_compute_engine/core/packbits.h"
-#include "ruy/profiler/instrumentation.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 
 using namespace tflite;
@@ -33,11 +32,8 @@ inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
   const int rows = FlatSizeSkipDim(in_shape, dims - 1);
   const int cols = in_shape.Dims(dims - 1);
 
-  {
-    ruy::profiler::ScopeLabel label("Packbits");
-    ce::core::packbits_matrix<bitpack_order>(in_data, rows, cols, out_data,
-                                             zero_point);
-  }
+  ce::core::packbits_matrix<bitpack_order>(in_data, rows, cols, out_data,
+                                           zero_point);
 
   out_shape.ReplaceWith(dims, in_shape.DimsData());
   out_shape.SetDim(dims - 1, GetPackedSize<TBitpacked>(cols));

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -769,6 +769,7 @@ void EvalRef(TfLiteContext* context, TfLiteNode* node,
   } else {
     TfLiteTensor* packed_input =
         GetTemporary(context, node, params->packed_input_index);
+    ruy::profiler::ScopeLabel label("Bitpack activations (EvalRef)");
     ce::core::packbits_tensor<ce::core::BitpackOrder::Canonical>(
         input_shape, input_data, input->params.zero_point, packed_input_shape,
         GetTensorData<TBitpacked>(packed_input));

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -145,6 +145,7 @@ inline void BConv2D(
     } else {
       // The input tensor has this shape which we bitpack along the channels
       // dimension [batch, input height, input width, channels].
+      ruy::profiler::ScopeLabel label("Bitpack activations (before im2col)");
       ce::core::packbits_tensor<ce::core::BitpackOrder::Optimized>(
           input_shape, input_data, params.input_offset, packed_input_shape,
           packed_input_data);
@@ -167,9 +168,12 @@ inline void BConv2D(
     // The RHS tensor has this shape which we bitpack along the last dimension
     //  [batch, output_height, output_width, k * bitwidth]
     RuntimeShape packed_input_shape;
-    ce::core::packbits_tensor<ce::core::BitpackOrder::Optimized>(
-        result_shape, result_data, params.input_offset, packed_input_shape,
-        packed_input_data);
+    {
+      ruy::profiler::ScopeLabel lable("Bitpack activations (after im2col)");
+      ce::core::packbits_tensor<ce::core::BitpackOrder::Optimized>(
+          result_shape, result_data, params.input_offset, packed_input_shape,
+          packed_input_data);
+    }
     rhs_data = packed_input_data;
 
     k = packed_input_shape.Dims(3);

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -169,7 +169,7 @@ inline void BConv2D(
     //  [batch, output_height, output_width, k * bitwidth]
     RuntimeShape packed_input_shape;
     {
-      ruy::profiler::ScopeLabel lable("Bitpack activations (after im2col)");
+      ruy::profiler::ScopeLabel label("Bitpack activations (after im2col)");
       ce::core::packbits_tensor<ce::core::BitpackOrder::Optimized>(
           result_shape, result_data, params.input_offset, packed_input_shape,
           packed_input_data);


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This simply moves the RUY profiling labels out of the core files, into the tflite files. This is required for LCE-micro.

## How Has This Been Tested?
CI