### PR TITLE
Add binary maxpool dead op cleanup pattern.

### DIFF
--- a/larq_compute_engine/mlir/tests/op-removal.mlir
+++ b/larq_compute_engine/mlir/tests/op-removal.mlir
@@ -72,3 +72,19 @@ func @used_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf32>, 
 
   // CHECK-NEXT: %0 = "tf.LceBconv2d"
 }
+
+// CHECK-LABEL: @unused_bmaxpool2d
+func @unused_bmaxpool2d(%arg0: tensor<256x32x32x3xi32>) -> tensor<256x32x32x3xi32> {
+  %0 = "tf.LceBMaxPool2d"(%arg0) {filter_height = 2 : i32, filter_width = 2 : i32, padding = "SAME", stride_height = 2 : i32, stride_width = 2 : i32} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
+  return %arg0 : tensor<256x32x32x3xi32>
+
+  // CHECK-NEXT: return %arg0 : tensor<256x32x32x3xi32>
+}
+
+// CHECK-LABEL: @used_bmaxpool2d
+func @used_bmaxpool2d(%arg0: tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32> {
+  %0 = "tf.LceBMaxPool2d"(%arg0) {filter_height = 2 : i32, filter_width = 2 : i32, padding = "SAME", stride_height = 2 : i32, stride_width = 2 : i32} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
+  return %0 : tensor<256x16x16x3xi32>
+
+  // CHECK-NEXT: %0 = "tf.LceBMaxPool2d"
+}

--- a/larq_compute_engine/mlir/transforms/op_removal_patterns.td
+++ b/larq_compute_engine/mlir/transforms/op_removal_patterns.td
@@ -24,11 +24,14 @@ def : Pat<(TF_IdentityNOp $arg), (replaceWithValue $arg)>;
 
 
 // Cleanup dead ops manually. LCE ops are not registered to the TF dialect so
-// op->hasNoSideEffect() will return false. Therefor
+// op->hasNoSideEffect() will return false. Therefore
 // applyPatternsAndFoldGreedily won't automatically remove the dead nodes. See
 // https://github.com/llvm/llvm-project/blob/master/mlir/include/mlir/IR/Operation.h#L457-L462
 def : Pat<(TF_LceBsignOp:$op $x), (replaceWithValue $x), [(HasNoUseOf:$op)]>;
 def : Pat<(TF_LceBconv2dOp:$op $input, $filter, $post_activation_multiplier,
             $post_activation_bias, $channels_in, $strides, $padding, $pad_values,
             $data_format, $dilations, $filter_format, $act),
+          (replaceWithValue $input), [(HasNoUseOf:$op)]>;
+def : Pat<(TF_LceBMaxPool2dOp:$op $input, $padding, $stride_width,
+            $stride_height, $filter_width, $filter_height),
           (replaceWithValue $input), [(HasNoUseOf:$op)]>;


### PR DESCRIPTION
## What do these changes do?

I forgot to add an op removal pattern for the new Binary Maxpool op (in #364); this fixes that oversight. Now, dead ops will be correctly removed.

## How Has This Been Tested?
CI.

## Benchmark Results
N/A.

## Related issue number
N/A.
