### PR TITLE
Fix bitpacked activation pass when interacting with fused BN/activation.

### DIFF
--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -68,123 +68,88 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
 
 #include "larq_compute_engine/mlir/transforms/generated_optimize.inc"
 
-struct SetBconvReadWriteBitpacked : public OpRewritePattern<TF::LceBconv2dOp> {
-  using OpRewritePattern<TF::LceBconv2dOp>::OpRewritePattern;
+/**
+ * Returns `false` if some assumption does not hold (the consumer should then
+ * consider the rewrite pattern match to have failed).
+ */
+bool getBitpackedType(PatternRewriter& rewriter, ShapedType existing_type,
+                      RankedTensorType& bitpacked_type) {
+  if (existing_type.getElementType().isInteger(32)) return false;
 
-  LogicalResult matchAndRewrite(TF::LceBconv2dOp outer_bconv_op,
+  const auto existing_shape = existing_type.getShape();
+
+  if (existing_shape.size() != 4) return false;
+
+  const auto channels = existing_shape[3];
+  const auto packed_channels = (channels + 32 - 1) / 32;
+  bitpacked_type = RankedTensorType::get({existing_shape[0], existing_shape[1],
+                                          existing_shape[2], packed_channels},
+                                         rewriter.getIntegerType(32));
+  return true;
+}
+
+template <typename BinaryOp>
+struct SetBitpackedActivations : public OpRewritePattern<BinaryOp> {
+  using OpRewritePattern<BinaryOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BinaryOp outer_binary_op,
                                 PatternRewriter& rewriter) const override {
-    /*************
-     * Match ops *
-     *************/
+    Operation* input_op = outer_binary_op.input().getDefiningOp();
 
-    auto intermediate_maxpool_op = dyn_cast_or_null<TFL::MaxPool2DOp>(
-        outer_bconv_op.input().getDefiningOp());
+    // If the input op has more than one use, we can't apply an optimisation.
+    if (!input_op || !input_op->hasOneUse()) return failure();
 
-    if (intermediate_maxpool_op &&
-        intermediate_maxpool_op.fused_activation_function() != "NONE") {
-      return failure();
-    }
-
-    auto inner_bconv_op =
-        intermediate_maxpool_op
-            ? dyn_cast_or_null<TF::LceBconv2dOp>(
-                  intermediate_maxpool_op.input().getDefiningOp())
-            : dyn_cast_or_null<TF::LceBconv2dOp>(
-                  outer_bconv_op.input().getDefiningOp());
-
-    if (inner_bconv_op && inner_bconv_op.padding() == "SAME" &&
-        inner_bconv_op.pad_values() != 1) {
-      // We don't return `failure()` here because we still want to match the
-      // pattern `binary maxpool -> binary conv`.
-      inner_bconv_op = nullptr;
-    }
-
-    if (!inner_bconv_op && !intermediate_maxpool_op) return failure();
-
-    if (!outer_bconv_op.input().hasOneUse() ||
-        (intermediate_maxpool_op && inner_bconv_op &&
-         !intermediate_maxpool_op.input().hasOneUse())) {
-      return failure();
-    }
-
-    constexpr int bitwidth = 32;  // We use 32-bit bitpacking.
-
-    /*********************
-     * Compute new types *
-     *********************/
-
-    RankedTensorType new_inner_bconv_op_type;
-    RankedTensorType new_intermediate_maxpool_op_type;
-
-    // If applicable, compute the new type for the inner bconv op.
+    // Try and match `input_op` to a binary convolution.
+    auto inner_bconv_op = dyn_cast_or_null<TF::LceBconv2dOp>(input_op);
     if (inner_bconv_op) {
-      ShapedType inner_bconv_op_type =
-          inner_bconv_op.getType().cast<ShapedType>();
-
-      // Don't apply this transformation if the type is already I32.
-      if (inner_bconv_op_type.getElementType().isInteger(bitwidth)) {
+      if (inner_bconv_op.padding() == "SAME" &&
+          inner_bconv_op.pad_values() != 1) {
         return failure();
       }
 
-      // Compute the new type for the inner bconv op.
-      const auto inner_bconv_op_shape = inner_bconv_op_type.getShape();
-      if (inner_bconv_op_shape.size() != 4) return failure();
-      const auto channels = inner_bconv_op_shape[3];
-      const auto packed_channels = (channels + bitwidth - 1) / bitwidth;
-      new_inner_bconv_op_type = RankedTensorType::get(
-          {inner_bconv_op_shape[0], inner_bconv_op_shape[1],
-           inner_bconv_op_shape[2], packed_channels},
-          rewriter.getIntegerType(bitwidth));
-    }
-
-    // If applicable, compute the new type for the intermediate maxpool op.
-    if (intermediate_maxpool_op) {
-      ShapedType intermediate_maxpool_op_type =
-          intermediate_maxpool_op.getType().cast<ShapedType>();
-
-      // Don't apply this transformation if the type is already I32.
-      if (intermediate_maxpool_op_type.getElementType().isInteger(bitwidth)) {
+      RankedTensorType bitpacked_type;
+      if (!getBitpackedType(rewriter,
+                            inner_bconv_op.getType().cast<ShapedType>(),
+                            bitpacked_type)) {
         return failure();
       }
 
-      const auto intermediate_maxpool_op_shape =
-          intermediate_maxpool_op_type.getShape();
-      if (intermediate_maxpool_op_shape.size() != 4) return failure();
-      const auto channels = intermediate_maxpool_op_shape[3];
-      const auto packed_channels = (channels + bitwidth - 1) / bitwidth;
-      new_intermediate_maxpool_op_type = RankedTensorType::get(
-          {intermediate_maxpool_op_shape[0], intermediate_maxpool_op_shape[1],
-           intermediate_maxpool_op_shape[2], packed_channels},
-          rewriter.getIntegerType(bitwidth));
-    }
-
-    /***************************
-     * Perform op replacements *
-     ***************************/
-
-    // We have to replace the inner-bconv op first...
-    if (inner_bconv_op) {
       rewriter.replaceOpWithNewOp<TF::LceBconv2dOp>(
-          inner_bconv_op, new_inner_bconv_op_type, inner_bconv_op.getOperands(),
+          inner_bconv_op, bitpacked_type, inner_bconv_op.getOperands(),
           inner_bconv_op.getAttrs());
-    }
-    // ...then the maxpool.
-    if (intermediate_maxpool_op) {
-      rewriter.replaceOpWithNewOp<TF::LceBMaxPool2dOp>(
-          intermediate_maxpool_op, new_intermediate_maxpool_op_type,
-          intermediate_maxpool_op.input(),
-          rewriter.getStringAttr(intermediate_maxpool_op.padding()),
-          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
-                                  intermediate_maxpool_op.stride_h()),
-          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
-                                  intermediate_maxpool_op.stride_w()),
-          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
-                                  intermediate_maxpool_op.filter_width()),
-          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
-                                  intermediate_maxpool_op.filter_height()));
+
+      return success();
     }
 
-    return success();
+    // Otherwise, try and match `input_op` to a maxpool.
+    auto maxpool_op = dyn_cast_or_null<TFL::MaxPool2DOp>(input_op);
+    if (maxpool_op) {
+      if (maxpool_op.fused_activation_function() != "NONE") {
+        return failure();
+      }
+
+      RankedTensorType bitpacked_type;
+      if (!getBitpackedType(rewriter, maxpool_op.getType().cast<ShapedType>(),
+                            bitpacked_type)) {
+        return failure();
+      }
+
+      rewriter.replaceOpWithNewOp<TF::LceBMaxPool2dOp>(
+          maxpool_op, bitpacked_type, maxpool_op.input(),
+          rewriter.getStringAttr(maxpool_op.padding()),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
+                                  maxpool_op.stride_h()),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
+                                  maxpool_op.stride_w()),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
+                                  maxpool_op.filter_width()),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(32),
+                                  maxpool_op.filter_height()));
+
+      return success();
+    }
+
+    return failure();
   };
 };
 
@@ -195,7 +160,8 @@ void OptimizeLCE::runOnFunction() {
 
   TFL::populateWithGenerated(ctx, &patterns);
   if (experimental_enable_bitpacked_activations_) {
-    patterns.insert<SetBconvReadWriteBitpacked>(ctx);
+    patterns.insert<SetBitpackedActivations<TF::LceBconv2dOp>>(ctx);
+    patterns.insert<SetBitpackedActivations<TF::LceBMaxPool2dOp>>(ctx);
   }
   applyPatternsAndFoldGreedily(func, patterns);
 }


### PR DESCRIPTION
Closes #371.

This has the benefit of being a much cleaner implementation as well: it replaces the previous three-level pattern match with a single two-level pattern match (templated to accept both bconv and bmaxpool). As a result, any of the following will be bitpacked `bconv -> bconv`, `bconv -> bmaxpool`, `bmaxpool -> bmaxpool`, `bmaxpool -> bconv`.

With this PR, the rewrite pattern now works nicely even when there are fused activations and batch-norms that previously interfered:

<img width="150" alt="image" src="https://user-images.githubusercontent.com/7688302/82582838-8d802880-9b8a-11ea-95a0-6df9be03713e.png">
