### PR TITLE
Make sure end2end tests fail when assertions fail in C++

### DIFF
--- a/larq_compute_engine/tests/end2end_verify.cc
+++ b/larq_compute_engine/tests/end2end_verify.cc
@@ -31,10 +31,9 @@ bool getFlatTensor(Interpreter* interpreter, int tensor_id, float** data,
   return true;
 }
 
-#define MINIMAL_CHECK(x)                                    \
-  if (!(x)) {                                               \
-    std::cerr << "Error at line " << __LINE__ << std::endl; \
-    return result;                                          \
+#define MINIMAL_CHECK(x)                                                   \
+  if (!(x)) {                                                              \
+    throw std::runtime_error("Error at line " + std::to_string(__LINE__)); \
   }
 
 std::vector<std::vector<float>> runModel(const pybind11::bytes& _flatbuffer,


### PR DESCRIPTION
## What do these changes do?

This PR changes the end2end tests to make sure that they exit with error code 1 if an assertion inside C++ happens.

In particular this now checks that `run_model` doesn't return an empty list, that both inference runs match with a small tolerance and that errors in C++ now correctly bubble up to Python to make debugging easier.

This also fixes our int8 tests that silently failed due to a shape mismatch in the input.

## How Has This Been Tested?
CI :)

## Related issue number
This was discovered in #373, since I expected CI to fail which it didn't.
