### PR TITLE
Add pattern to ensure post_activation_multipliers are always positiv

### DIFF
--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -144,6 +144,18 @@ func @do_not_fuse_relu_into_bconv2d_no_post_activation_multiplier(%arg0: tensor<
   // CHECK-NEXT: return %1
 }
 
+// CHECK-LABEL: @tranform_negative_multipliers
+func @tranform_negative_multipliers(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
+  %multiplier = constant dense<-3.0> : tensor<16xf32>
+  %filter = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  return %0 : tensor<256x30x30x16xf32>
+
+  // CHECK: %cst_0 = constant dense<3.000000e+00> : tensor<16xf32>
+  // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %cst_0, %arg1)
+  // CHECK-NEXT: return %0
+}
+
 // CHECK-LABEL: @do_not_change_multiplier_if_fused_activation
 func @do_not_change_multiplier_if_fused_activation(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %multiplier = constant dense<-3.0> : tensor<16xf32>
@@ -157,10 +169,9 @@ func @do_not_change_multiplier_if_fused_activation(%arg0: tensor<256x32x32x3xf32
 }
 
 // CHECK-LABEL: @bitpack_bconv2d_filters
-func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
-  %multiplier = constant dense<-3.0> : tensor<16xf32>
-  %filter = constant dense<1.0> : tensor<16x3x3x3xf32>
-  %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
+  %cst = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
   // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -147,10 +147,11 @@ func @do_not_fuse_relu_into_bconv2d_no_post_activation_multiplier(%arg0: tensor<
 // CHECK-LABEL: @tranform_negative_multipliers
 func @tranform_negative_multipliers(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %multiplier = constant dense<-3.0> : tensor<16xf32>
-  %filter = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %filter = constant dense<-1.0> : tensor<16x3x3x3xf32>
   %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
+  // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>
   // CHECK: %cst_0 = constant dense<3.000000e+00> : tensor<16xf32>
   // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %cst_0, %arg1)
   // CHECK-NEXT: return %0
@@ -164,6 +165,7 @@ func @do_not_change_multiplier_if_fused_activation(%arg0: tensor<256x32x32x3xf32
   return %0 : tensor<256x30x30x16xf32>
 
   // CHECK: %cst = constant dense<-3.000000e+00> : tensor<16xf32>
+  // CHECK: %cst_0 = constant dense<0> : tensor<16x3x3x1xi32>
   // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst_0, %cst, %arg1)
   // CHECK-NEXT: return %0
 }

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -144,6 +144,18 @@ func @do_not_fuse_relu_into_bconv2d_no_post_activation_multiplier(%arg0: tensor<
   // CHECK-NEXT: return %1
 }
 
+// CHECK-LABEL: @do_not_change_multiplier_if_fused_activation
+func @do_not_change_multiplier_if_fused_activation(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
+  %multiplier = constant dense<-3.0> : tensor<16xf32>
+  %filter = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {activation = "RELU", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  return %0 : tensor<256x30x30x16xf32>
+
+  // CHECK: %cst = constant dense<-3.000000e+00> : tensor<16xf32>
+  // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst_0, %cst, %arg1)
+  // CHECK-NEXT: return %0
+}
+
 // CHECK-LABEL: @bitpack_bconv2d_filters
 func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
   %multiplier = constant dense<-3.0> : tensor<16xf32>

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -145,9 +145,10 @@ func @do_not_fuse_relu_into_bconv2d_no_post_activation_multiplier(%arg0: tensor<
 }
 
 // CHECK-LABEL: @bitpack_bconv2d_filters
-func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
-  %cst = constant dense<1.0> : tensor<16x3x3x3xf32>
-  %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
+  %multiplier = constant dense<-3.0> : tensor<16xf32>
+  %filter = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
   // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -50,12 +50,12 @@ def ComputeBSignAndExpandTo4D : NativeCodeCall<"ComputeBSignAndExpandTo4D($0)">;
 def : Pat<(TF_LceBconv2dOp $input, (ConstantOp F32ElementsAttr:$filter),
             (ConstantOp HasNegativeValues:$post_activation_multiplier),
             $post_activation_bias, $channels_in, $strides, $padding,
-            $pad_values, $dilations, $filter_format, $act),
+            $pad_values, $dilations, $filter_format, TFL_AF_None),
           (TF_LceBconv2dOp $input,
             (TFL_MulOp (ConstantOp $filter), (ConstantOp (ComputeBSignAndExpandTo4D $post_activation_multiplier)), TFL_AF_None),
             (TFL_AbsOp (ConstantOp $post_activation_multiplier)),
             $post_activation_bias, $channels_in, $strides, $padding,
-            $pad_values, $dilations, $filter_format, $act),
+            $pad_values, $dilations, $filter_format, TFL_AF_None),
           [], (addBenefit 90)>;
 
 foreach binaryOp = [TFL_DivOp, TFL_MulOp] in

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -21,7 +21,7 @@ multiclass FuseAddOrSubWithBConv2D<dag binaryOp> {
                           (binaryOp (ConstantOp $post_activation_bias), (ConstantOp $value), TFL_AF_None),
                           $channels_in, $strides, $padding, $pad_values,
                           $dilations, $filter_format, $activation),
-            [(HasOneUse $output)]>;
+            [(HasOneUse $output)], (addBenefit 100)>;
 }
 foreach binaryOp = [TFL_AddOp, TFL_SubOp] in
   defm : FuseAddOrSubWithBConv2D<binaryOp>;
@@ -41,8 +41,22 @@ multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
                                   (ConstantOp $value), TFL_AF_None),
                         $channels_in, $strides, $padding, $pad_values,
                         $dilations, $filter_format, $activation),
-         [(HasOneUse $conv_output)]>;
+         [(HasOneUse $conv_output)], (addBenefit 100)>;
 }
+
+def HasNegativeValues : AttrConstraint<CPred<"HasNegativeValues($_self)">>;
+def ComputeBSignAndExpandTo4D : NativeCodeCall<"ComputeBSignAndExpandTo4D($0)">;
+
+def : Pat<(TF_LceBconv2dOp $input, (ConstantOp F32ElementsAttr:$filter),
+            (ConstantOp HasNegativeValues:$post_activation_multiplier),
+            $post_activation_bias, $channels_in, $strides, $padding,
+            $pad_values, $dilations, $filter_format, $act),
+          (TF_LceBconv2dOp $input,
+            (TFL_MulOp (ConstantOp $filter), (ConstantOp (ComputeBSignAndExpandTo4D $post_activation_multiplier)), TFL_AF_None),
+            (TFL_AbsOp (ConstantOp $post_activation_multiplier)),
+            $post_activation_bias, $channels_in, $strides, $padding,
+            $pad_values, $dilations, $filter_format, $act),
+          [], (addBenefit 90)>;
 
 foreach binaryOp = [TFL_DivOp, TFL_MulOp] in
   defm : FuseMulOrDivWithBConv2D<binaryOp>;


### PR DESCRIPTION
## What do these changes do?
This PR makes sure that `post_activation_multiplier`s will always  be positive if no fused activation is present by absorbing the sign in the binary weights. This will enable future optimizations to precompute thresholds in the converter when writing bitpacked output.

## How Has This Been Tested?
CI