### PR TITLE
(Slightly) faster Aarch64 bitpacking.

### DIFF
--- a/larq_compute_engine/core/packbits_aarch64.h
+++ b/larq_compute_engine/core/packbits_aarch64.h
@@ -10,62 +10,42 @@
 namespace compute_engine {
 namespace core {
 
-// This will bitpack exactly 64 floats.
-// It will be packed in a weird order which is described in the comments
+// This will bitpack the sign-bits from 64 floats, in a deterministic but
+// non-consecutive order.
 inline void packbits_aarch64_64(const float* input, std::uint64_t* output) {
   asm volatile(
-      "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%0], #64    \n"
-      "sri    v0.4s, v2.4s, #1    \n"
-      "sri    v1.4s, v3.4s, #1    \n"
-      "ld1    {v2.4s, v3.4s, v4.4s, v5.4s}, [%0], #64    \n"
-      "sri    v2.4s, v4.4s, #1    \n"
-      "sri    v3.4s, v5.4s, #1    \n"
-      "sri    v0.4s, v2.4s, #2    \n"
-      "sri    v1.4s, v3.4s, #2    \n"
-      // v0,v1 contain 4 signbits in each lane
-      "ld1    {v2.4s, v3.4s, v4.4s, v5.4s}, [%0], #64    \n"
-      "sri    v2.4s, v4.4s, #1    \n"
-      "sri    v3.4s, v5.4s, #1    \n"
-      "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%0], #64    \n"
-      "sri    v4.4s, v6.4s, #1    \n"
-      "sri    v5.4s, v7.4s, #1    \n"
-      "sri    v2.4s, v4.4s, #2    \n"
-      "sri    v3.4s, v5.4s, #2    \n"
-      "sri    v0.4s, v2.4s, #4    \n"
-      "sri    v1.4s, v3.4s, #4    \n"
-      "sri    v0.4s, v1.4s, #8    \n"
-      // v0-0 ... v0-3 all hold 16 signbits
-      // Now its tricky because everything is already
-      // inside the single SIMD register v0 now.
-      // Now we will treat v0 as consisting of 8 times
-      // a 16-bit number instead of 4 times a 32-bit number:
-      // v0.h[0] -- garbage <--\
-      // v0.h[1] -- signs      |
-      // v0.h[2] -- garbage <--|--\
-      // v0.h[3] -- signs      |  |
-      // v0.h[4] -- garbage    |  |
-      // v0.h[5] -- signs -----/  |
-      // v0.h[6] -- garbage       |
-      // v0.h[7] -- signs --------/
-      "mov    v0.h[0], v0.h[5] \n"
-      "mov    v0.h[2], v0.h[7] \n"
-      // Store in output. %1 is the output pointer, post-increment it
-      "st1    {v0.1d}, [%1], #8 \n"
-
-      // clang-format off
-      // Final result:
-      //Bit i comes from input:
-      //  62  46  30  14  54  38  22   6 |  58  42  26  10  50  34  18   2 |  60  44  28  12  52  36  20   4 |  56  40  24   8  48  32  16   0
-      //  63  47  31  15  55  39  23   7 |  59  43  27  11  51  35  19   3 |  61  45  29  13  53  37  21   5 |  57  41  25   9  49  33  17   1
-      //
-      //Input i goes to bit:
-      //  31  63  15  47  23  55   7  39 |  27  59  11  43  19  51   3  35 |  30  62  14  46  22  54   6  38 |  26  58  10  42  18  50   2  34
-      //  29  61  13  45  21  53   5  37 |  25  57   9  41  17  49   1  33 |  28  60  12  44  20  52   4  36 |  24  56   8  40  16  48   0  32
-      // clang-format on
-      : "+r"(input),  // %0
-        "+r"(output)  // %1
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[in_ptr]], #64\n"
+      "sri v0.4s, v1.4s, #1\n"
+      "ld1 {v4.4s, v5.4s}, [%[in_ptr]], #32\n"
+      "sri v2.4s, v3.4s, #1\n"
+      "ld1 {v6.4s, v7.4s}, [%[in_ptr]], #32\n"
+      "sri v4.4s, v5.4s, #1\n"
+      "ld1 {v8.4s, v9.4s}, [%[in_ptr]], #32\n"
+      "sri v6.4s, v7.4s, #1\n"
+      "ld1 {v10.4s, v11.4s}, [%[in_ptr]], #32\n"
+      "sri v8.4s, v9.4s, #1\n"
+      "ld1 {v12.4s, v13.4s}, [%[in_ptr]], #32\n"
+      "sri v10.4s, v11.4s, #1\n"
+      "ld1 {v14.4s, v15.4s}, [%[in_ptr]], #32\n"
+      "sri v12.4s, v13.4s, #1\n"
+      "sri v14.4s, v15.4s, #1\n"
+      "sri v0.4s, v2.4s, #2\n"
+      "sri v4.4s, v6.4s, #2\n"
+      "sri v8.4s, v10.4s, #2\n"
+      "sri v12.4s, v14.4s, #2\n"
+      "sri v0.4s, v4.4s, #4\n"
+      "sri v8.4s, v12.4s, #4\n"
+      "sri v0.4s, v8.4s, #8\n"
+      // v0.s[0] ... v0.s[3] all hold 16 signbits in the high half, and 16 bits
+      // of junk data in the low half.
+      //     With a 'unsigned saturating shift right and narrow' instruction, we
+      // can collect all of the sign bits in v0.d[0].
+      "uqshrn v0.4h, v0.4s, #16\n"
+      "st1 {v0.1d}, [%[out_ptr]]\n"
+      : [ in_ptr ] "+r"(input), [ out_ptr ] "+r"(output)
       :
-      : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7");
+      : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+        "v9", "v10", "v11", "v12", "v13", "v14", "v15");
   return;
 }
 


### PR DESCRIPTION
## What do these changes do?

This PR updates the inline assembly for 64-bit bitpacking on Aarch64.

It uses more vector registers; this makes it possible to pipeline the register load instructions with the next compute instruction (all except the first register load), which wasn't the case previously.

Additionally, the final two `mov` instructions have been replaced with a single `uqshrn` (unsigned saturating shift right and narrow) instruction. This means that the overall compute instruction count (excluding register loads and stores) reduces from 17 to 16.

## How Has This Been Tested?
CI.

## Benchmark Results

I have run benchmarks using the LCE benchmark tool (`num_runs=250`) on a Raspberry Pi.

The results are pretty much within the margin of error, but there seems to be a slight speed up.

| Device | Model         | Threads | Baseline      | PR            | Relative change |
|--------|---------------|---------|---------------|---------------|-----------------|
| RPi 4  | QuickNet      | 1       | 34.58 +- 0.13 | 34.50 +- 0.09 | -0.2%           |
| RPi 4  | QuickNet      | 4       | 17.08 +- 0.06 | 17.12 +- 0.05 | +0.2%           |
| RPi 4  | QuickNetLarge | 1       | 52.45 +- 0.09 | 52.44 +- 0.07 | 0.0%            |
| RPi 4  | QuickNetLarge | 4       | 25.79 +- 0.83 | 25.56 +- 0.06 | -0.9%           |
| RPi 4  | QuickNetXL    | 1       | 92.11 +- 0.22 | 91.83 +- 0.13 | -0.3%           |
| RPi 4  | QuickNetXL    | 4       | 41.69 +- 0.37 | 41.39 +- 0.12 | -0.7%           |

## Related issue number
N/A.
