### PR TITLE
Fix weight bitpacking which could lead to non-deterministic behaviour 

### DIFF
--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -150,6 +150,7 @@ func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf
   %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {activation = "NONE", channels_in = 3 : i32, filter_format = "OHWI", padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
+  // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>
   // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {activation = "NONE", channels_in = 3 : i32, dilations = [1, 1, 1, 1], filter_format = "OHWI_PACKED", pad_values = 0 : i32, padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<256x32x32x3xf32>, tensor<16x3x3x1xi32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   // CHECK-NEXT: return %0
 }

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -55,11 +55,17 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
   int packed_channels = (unpacked_channels + bitwidth - 1) / bitwidth;
 
   std::vector<PackedType> new_values(num_rows * packed_channels);
+  std::vector<float> old_values(num_rows * unpacked_channels);
 
-  const float* in_ptr = &(*dense_elements_iter.begin());
+  int i = 0;
+  for (float x : dense_elements_iter) {
+    old_values[i++] = x;
+  }
+  assert(i == num_rows * unpacked_channels);
+
   using namespace compute_engine::core;
-  packbits_matrix<BitpackOrder::Canonical>(in_ptr, num_rows, unpacked_channels,
-                                           new_values.data());
+  packbits_matrix<BitpackOrder::Canonical>(
+      old_values.data(), num_rows, unpacked_channels, new_values.data());
 
   RankedTensorType out_tensor_type =
       RankedTensorType::get({shape[0], shape[1], shape[2], packed_channels},

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -37,8 +37,9 @@ bool IsConstantValue(Attribute values, float expected_value) {
 
 bool IsConv2DFilter(Attribute filter) {
   if (!filter.isa<DenseElementsAttr>()) return false;
-  if (filter.getType().cast<ShapedType>().getShape().size() != 4) return false;
-  return true;
+  auto filter_type = filter.getType().cast<ShapedType>();
+  return filter_type.getElementType().isF32() &&
+         filter_type.getShape().size() == 4;
 }
 
 DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {


### PR DESCRIPTION
## What do these changes do?

While writing tests for #375 I this covered that the previous implementation could lead to non-deterministic bitpacking of the weights during conversion

## How Has This Been Tested?
Added a filecheck test which will run on CI.

This bugfix could influence network accuracy, so I will double check if this is an issue in 0.3 as well and will backport the fix.
