### PR TITLE
Add testing script for faster model conversions debugging

### DIFF
--- a/larq_compute_engine/tests/BUILD
+++ b/larq_compute_engine/tests/BUILD
@@ -29,6 +29,14 @@ py_test(
     ],
 )
 
+py_test(
+    name = "convert_model",
+    srcs = ["convert_model.py"],
+    deps = [
+        "//larq_compute_engine/mlir:converter",
+    ],
+)
+
 test_suite(
     name = "cc_tests",
     tests = [

--- a/larq_compute_engine/tests/convert_model.py
+++ b/larq_compute_engine/tests/convert_model.py
@@ -24,7 +24,7 @@ def model_fn():
 @click.option(
     "--outfile",
     default="model.tflite",
-    help="Destination used to save converted TFLite flatbuffer.",
+    help="Destination (relative to bazel rundir) used to save converted TFLite flatbuffer.",
     type=click.Path(writable=True, resolve_path=True),
 )
 def convert_model(outfile):

--- a/larq_compute_engine/tests/convert_model.py
+++ b/larq_compute_engine/tests/convert_model.py
@@ -1,0 +1,41 @@
+"""Convert model script.
+
+This can be used to test model conversion via the CLI. Callers should overwrite
+`model_fn` to return a Keras model to be converted.
+
+Usage Examples:
+- bazelisk test larq_compute_engine/tests:convert_model
+- bazelisk test larq_compute_engine/tests:convert_model --test_arg="--outfile=/tmp/model.tflite"
+- bazelisk run larq_compute_engine/tests:convert_model -- --outfile=/tmp/model.tflite
+"""
+
+import click
+
+from larq_compute_engine.mlir.python.converter import convert_keras_model
+
+
+def model_fn():
+    raise NotImplementedError(
+        "No model defined. This function should be overwritten by caller."
+    )
+
+
+@click.command()
+@click.option(
+    "--outfile",
+    default="model.tflite",
+    help="Destination used to save converted TFLite flatbuffer.",
+    type=click.Path(writable=True, resolve_path=True),
+)
+def convert_model(outfile):
+    model_lce = convert_keras_model(
+        model_fn(), experimental_enable_bitpacked_activations=True
+    )
+    with open(outfile, "wb") as f:
+        f.write(model_lce)
+
+    click.secho(f"TFLite flatbuffer saved to '{outfile}'.")
+
+
+if __name__ == "__main__":
+    convert_model()


### PR DESCRIPTION
## What do these changes do?

This PR adds a small script that converts a model and saves the generated flatbuffer on disk. This enable easier debugging when developing new conversion features that need to be tested on a full model without the need to build the pip package or modify the end2end tests to write the file to disk (which I found myself manually doing quite often).

## How Has This Been Tested?
Tested manually with quicknet.