### PR TITLE
Upgrade github/actions

### DIFF
--- a/.github/tools/release_linux.sh
+++ b/.github/tools/release_linux.sh
@@ -24,7 +24,7 @@ curl https://bootstrap.pypa.io/get-pip.py | python
 python --version
 python -m pip --version
 
-curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 > /usr/bin/bazelisk
+curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > /usr/bin/bazelisk
 chmod +x /usr/bin/bazelisk
 
 python -m pip install numpy six --no-cache-dir

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Install Lint Dependencies
@@ -26,6 +26,6 @@ jobs:
       - name: Black code style
         run: black larq_compute_engine --check --target-version py36 --exclude 'build/|buck-out/|dzzist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|larq/snapshots/'
       - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.5
+        uses: DoozyX/clang-format-lint-action@v0.6
       - name: Lint bazel files
         run: buildifier -mode=check -r ./

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,6 +9,6 @@ jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: toolmantim/release-drafter@v5.7.0
+      - uses: toolmantim/release-drafter@v5.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build macOS wheels
@@ -48,7 +48,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build manylinux2010 wheels
@@ -78,7 +78,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build Windows wheels

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,12 +14,12 @@ jobs:
       image: tensorflow/tensorflow:custom-op-ubuntu16
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Install Bazelisk
         run: |
-          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 > bazelisk
+          curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > bazelisk
           chmod +x bazelisk
       - name: Configure Bazel
         run: ./configure.sh <<< $'yes\n' #yes for manylinux2010
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-user
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Configure Bazel
@@ -66,7 +66,7 @@ jobs:
         with:
           service_account_key: ${{ secrets.gcs_bazel_cache }}
           export_default_credentials: true
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Configure Bazel
@@ -87,7 +87,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -100,11 +100,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: cache
         with:
           path: /tmp/lce_android

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,10 +14,9 @@ jobs:
       image: tensorflow/tensorflow:custom-op-ubuntu16
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           submodules: true
-          fetch-depth: 0
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > bazelisk

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
       - name: Install Bazelisk
         run: |
           curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > bazelisk
@@ -101,6 +102,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7


### PR DESCRIPTION
## What do these changes do?
The main reason for this upgrade is to use `actions/checkout@v2` and `actions/cache@v2`  which should improve CI time.

## How Has This Been Tested?
CI