### PR TITLE
Support dilated convolutions in converter

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -126,6 +126,7 @@ cc_library(
         ":larq_compute_engine",
         "@llvm-project//mlir:StandardOps",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_legalize_tf",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:validators",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
     ],


### PR DESCRIPTION
## What do these changes do?
@koenhelwegen noticed that we currently do not correctly convert dilated convolutions since they may be represented using `SpaceToBatchND` on the TF side instead of properly set `dilation` arguments.

This PR copies the `ConvertTFDilatedConvOp` pattern from the `TFPass` to the `LCEPass` so it happens earlier which allows us to properly convert dilated binary convolutions.

## How Has This Been Tested?
mlir tests