### PR TITLE
Set padding and fused activations as enums

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -112,6 +112,7 @@ cc_library(
         "@flatbuffers",
         "@llvm-project//mlir:QuantOps",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
+        "@org_tensorflow//tensorflow/lite/c:common",
     ],
     alwayslink = 1,
 )

--- a/larq_compute_engine/mlir/tests/BUILD
+++ b/larq_compute_engine/mlir/tests/BUILD
@@ -22,5 +22,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@flatbuffers",
         "@llvm-project//mlir:IR",
+        "@org_tensorflow//tensorflow/lite/c:common",
     ],
 )

--- a/larq_compute_engine/mlir/tests/lce_ops_options_test.cc
+++ b/larq_compute_engine/mlir/tests/lce_ops_options_test.cc
@@ -4,6 +4,7 @@
 #include "larq_compute_engine/mlir/ir/lce_ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OperationSupport.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
 
 using namespace mlir;
 
@@ -46,8 +47,9 @@ TEST(LCEOpsSerializationTest, BConv2dTest) {
   ASSERT_EQ(m["stride_height"].AsInt32(), 1);
   ASSERT_EQ(m["stride_width"].AsInt32(), 2);
   ASSERT_EQ(m["pad_values"].AsInt32(), 1);
-  ASSERT_EQ(m["fused_activation_function"].ToString(), "RELU");
-  ASSERT_EQ(m["padding"].ToString(), "SAME");
+  ASSERT_EQ((TfLiteFusedActivation)m["fused_activation_function"].AsInt32(),
+            kTfLiteActRelu);
+  ASSERT_EQ((TfLitePadding)m["padding"].AsInt32(), kTfLitePaddingSame);
 }
 
 TEST(LCEOpsSerializationTest, BMaxPool2dTest) {
@@ -66,7 +68,7 @@ TEST(LCEOpsSerializationTest, BMaxPool2dTest) {
   std::vector<uint8_t> v = cast<TF::BMaxPool2dOp>(op).buildCustomOptions();
   const flexbuffers::Map& m = flexbuffers::GetRoot(v).AsMap();
 
-  ASSERT_EQ(m["padding"].ToString(), "SAME");
+  ASSERT_EQ((TfLitePadding)m["padding"].AsInt32(), kTfLitePaddingSame);
   ASSERT_EQ(m["stride_width"].AsInt32(), 2);
   ASSERT_EQ(m["stride_height"].AsInt32(), 1);
   ASSERT_EQ(m["filter_width"].AsInt32(), 3);

--- a/larq_compute_engine/mlir/tests/legalize-lce.mlir
+++ b/larq_compute_engine/mlir/tests/legalize-lce.mlir
@@ -5,7 +5,7 @@ func @legalize_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf3
   %0 = "lq.Bconv2d"(%arg0, %arg1, %arg2, %arg3, %arg4) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
-  // CHECK: %0 = "tfl.custom"(%arg0, %arg1, %arg2, %arg3, %arg4) {custom_code = "LceBconv2d", custom_option = opaque<"lq", "0x6368616E6E656C735F696E0064696C6174696F6E5F6865696768745F666163746F720064696C6174696F6E5F77696474685F666163746F720066757365645F61637469766174696F6E5F66756E6374696F6E00044E4F4E45007061645F76616C7565730070616464696E67000556414C4944007374726964655F686569676874007374726964655F776964746800088F846E593A30221508010803010149003201010404041404140404102401"> : tensor<173xi8>} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
+  // CHECK: %0 = "tfl.custom"(%arg0, %arg1, %arg2, %arg3, %arg4) {custom_code = "LceBconv2d", custom_option = opaque<"lq", "0x6368616E6E656C735F696E0064696C6174696F6E5F6865696768745F666163746F720064696C6174696F6E5F77696474685F666163746F720066757365645F61637469766174696F6E5F66756E6374696F6E007061645F76616C7565730070616464696E67007374726964655F686569676874007374726964655F776964746800088277614C3329221508010803010100000201010404040404040404102401"> : tensor<160xi8>} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
   // CHECK-NEXT: return %0
 }
 
@@ -14,7 +14,7 @@ func @legalize_bmax_pool2d(%arg0: tensor<256x32x32x3xi32>) -> tensor<256x16x16x3
   %0 = "lq.BMaxPool2d"(%arg0) {filter_height = 2 : i32, filter_width = 2 : i32, padding = "SAME", stride_height = 2 : i32, stride_width = 2 : i32} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
   return %0 : tensor<256x16x16x3xi32>
 
-  // CHECK: %0 = "tfl.custom"(%arg0) {custom_code = "LceBMaxPool2d", custom_option = opaque<"lq", "0x70616464696E67000453414D45007374726964655F7769647468007374726964655F6865696768740066696C7465725F77696474680066696C7465725F68656967687400050F1D472D3B050105020246020204041404040A2401"> : tensor<90xi8>} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
+  // CHECK: %0 = "tfl.custom"(%arg0) {custom_code = "LceBMaxPool2d", custom_option = opaque<"lq", "0x70616464696E67007374726964655F7769647468007374726964655F6865696768740066696C7465725F77696474680066696C7465725F68656967687400050F1D412D3B050105020201020204040404040A2401"> : tensor<84xi8>} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
   // CHECK-NEXT: return %0
 }
 

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -72,6 +72,9 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
   LCE_ENSURE_PARAM(conv_params, context, !m["stride_width"].IsNull());
   LCE_ENSURE_PARAM(conv_params, context, !m["dilation_height_factor"].IsNull());
   LCE_ENSURE_PARAM(conv_params, context, !m["dilation_width_factor"].IsNull());
+  LCE_ENSURE_PARAM(conv_params, context, !m["padding"].IsNull());
+  LCE_ENSURE_PARAM(conv_params, context,
+                   !m["fused_activation_function"].IsNull());
 
   // reading strides
   conv_params->stride_height = m["stride_height"].AsInt32();

--- a/larq_compute_engine/tflite/kernels/bmaxpool.cc
+++ b/larq_compute_engine/tflite/kernels/bmaxpool.cc
@@ -29,16 +29,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   poolparams->filter_width = m["filter_width"].AsInt32();
   poolparams->stride_height = m["stride_height"].AsInt32();
   poolparams->stride_width = m["stride_width"].AsInt32();
-
-  if (m["padding"].ToString() == "VALID" ||
-      m["padding"].ToString() == "valid") {
-    poolparams->padding_type = kTfLitePaddingValid;
-  } else if (m["padding"].ToString() == "SAME" ||
-             m["padding"].ToString() == "same") {
-    poolparams->padding_type = kTfLitePaddingSame;
-  } else {
-    context->ReportError(context, "BMaxPool: invalid padding attribute.");
-  }
+  poolparams->padding_type = (TfLitePadding)m["padding"].AsInt32();
 
   return poolparams;
 }

--- a/larq_compute_engine/tflite/tests/bconv2d_op_model.h
+++ b/larq_compute_engine/tflite/tests/bconv2d_op_model.h
@@ -53,9 +53,10 @@ class BaseBConv2DOpModel : public SingleOpModel {
       fbb.Int("stride_width", stride_width);
       fbb.Int("dilation_height_factor", dilation_height_factor);
       fbb.Int("dilation_width_factor", dilation_width_factor);
-      fbb.String("padding", GetPaddingName(padding));
+      fbb.Int("padding", (int)GetTfLitePadding(padding));
       fbb.Int("pad_values", pad_values);
-      fbb.String("fused_activation_function", getActivationString(activation));
+      fbb.Int("fused_activation_function",
+              (int)GetTfLiteActivation(activation));
     });
     fbb.Finish();
     SetCustomOp("LceBconv2d", fbb.GetBuffer(), registration);

--- a/larq_compute_engine/tflite/tests/bmaxpool_test.cc
+++ b/larq_compute_engine/tflite/tests/bmaxpool_test.cc
@@ -72,7 +72,7 @@ class BaseBMaxPoolOpModel : public SingleOpModel {
       fbb.Int("stride_width", stride_width);
       fbb.Int("filter_height", filter_height);
       fbb.Int("filter_width", filter_width);
-      fbb.String("padding", GetPaddingName(padding));
+      fbb.Int("padding", (int)GetTfLitePadding(padding));
     });
     fbb.Finish();
     SetCustomOp("LceBMaxPool2d", fbb.GetBuffer(), registration);

--- a/larq_compute_engine/tflite/tests/utils.h
+++ b/larq_compute_engine/tflite/tests/utils.h
@@ -32,6 +32,24 @@ std::string getActivationString(const enum ActivationFunctionType activation) {
   return "UNKOWN";
 }
 
+TfLitePadding GetTfLitePadding(enum Padding padding) {
+  switch (padding) {
+    case Padding_VALID:
+      return kTfLitePaddingValid;
+    case Padding_SAME:
+      return kTfLitePaddingSame;
+  };
+}
+
+TfLiteFusedActivation GetTfLiteActivation(
+    const enum ActivationFunctionType activation) {
+  if (activation == ActivationFunctionType_RELU) {
+    return kTfLiteActRelu;
+  } else if (activation == ActivationFunctionType_NONE) {
+    return kTfLiteActNone;
+  }
+}
+
 // Helper for determining the type for the builtin convolution that we are
 // comparing with
 template <typename TInput, typename TOutput>


### PR DESCRIPTION
## What do these changes do?
This changes the padding and fused activation attributes to be enums instead of strings to more closely follow TFLite and simplify the kernel implementation.

~~I marked it as a draft PR since it is built ontop of #384~~

## How Has This Been Tested?
CI