### PR TITLE
Remove RUY_ASM_FLAG_HAS_BIAS

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -57,7 +57,6 @@ struct BinaryKernelParams {
   std::int32_t clamp_min;
   std::int32_t clamp_max;
   std::int32_t backtransform_add;
-  std::uint8_t flags;
   float dst_tmp_buf[LhsCols * RhsCols];
 };
 
@@ -78,12 +77,10 @@ inline void MakeBinaryKernelParams(
   params->dst_base_ptr =
       dst->data.get() + start_col * dst->layout.stride + start_row;
 
-  std::uint8_t flags = 0;
   params->post_activation_multiplier =
       spec.output_transform.post_activation_multiplier;
   params->post_activation_bias = spec.output_transform.post_activation_bias;
   params->backtransform_add = spec.output_transform.backtransform_add;
-  params->flags = flags;
   params->start_row = start_row;
   params->start_col = start_col;
   params->last_row = end_row - LhsCols;
@@ -123,12 +120,10 @@ inline void MakeBinaryKernelParams(
   params->dst_base_ptr =
       dst->data.get() + start_col * dst->layout.stride + start_row;
 
-  std::uint8_t flags = 0;
   params->post_activation_multiplier =
       spec.output_transform.post_activation_multiplier;
   params->post_activation_bias = spec.output_transform.post_activation_bias;
   params->backtransform_add = spec.output_transform.backtransform_add;
-  params->flags = flags;
   params->start_row = start_row;
   params->start_col = start_col;
   params->last_row = end_row - LhsCols;

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -82,9 +82,6 @@ inline void MakeBinaryKernelParams(
   params->post_activation_multiplier =
       spec.output_transform.post_activation_multiplier;
   params->post_activation_bias = spec.output_transform.post_activation_bias;
-  if (params->post_activation_multiplier && params->post_activation_bias) {
-    flags |= RUY_ASM_FLAG_HAS_BIAS;
-  }
   params->backtransform_add = spec.output_transform.backtransform_add;
   params->flags = flags;
   params->start_row = start_row;
@@ -130,9 +127,6 @@ inline void MakeBinaryKernelParams(
   params->post_activation_multiplier =
       spec.output_transform.post_activation_multiplier;
   params->post_activation_bias = spec.output_transform.post_activation_bias;
-  if (params->post_activation_multiplier && params->post_activation_bias) {
-    flags |= RUY_ASM_FLAG_HAS_BIAS;
-  }
   params->backtransform_add = spec.output_transform.backtransform_add;
   params->flags = flags;
   params->start_row = start_row;


### PR DESCRIPTION
## What do these changes do?

This PR removes the handling of cases where `post_activation_bias` can be null from the optimized convolution kernels.
In the converter `post_activation_bias` and `post_activation_multiplier` will always be set, so since we don't check for the existence of `post_activation_multiplier` in the optimized assembly we can also get rid of the check for `post_activation_bias`. This check has been added moved over from TFLite which allows biases to be null. This is not the case here so I think this can be savely removed from the optimized code path.

## How Has This Been Tested?

This has purely been tested on CI since I originally made these changes when experiment with #263 only now rebased them onto the latest master.

## Benchmark Results
I didn't ran any benchmarks for these changes, but I am happy to do so if you think it would be useful

## Related issue number
Removing these checks might make implementing AArch64 support for #387 a bit easier.