### PR TITLE
Add custom dev docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install curl unzip build-essential openjdk-8-jdk python3-dev python3-pip qemu-user -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > /usr/local/bin/bazelisk && chmod +x /usr/local/bin/bazelisk
+RUN ln -s /usr/bin/python3 /usr/local/bin/python && ln -s /usr/bin/pip3 /usr/local/bin/pip
+RUN pip install six numpy --no-cache-dir
+
+WORKDIR /compute-engine
+COPY . .
+RUN ./third_party/install_android.sh
+RUN yes n | ./configure.sh
+RUN bazelisk --version

--- a/third_party/install_android.sh
+++ b/third_party/install_android.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 # default LCE Android Env. variables
 export ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip"
 export ANDROID_HOME="/tmp/lce_android"


### PR DESCRIPTION
## What do these changes do?

This adds a custom dockerfile to our repo that is fully setup to build binaries for Android and AArch64. The current custom-op image is very large and doesn't come with all the dependencies we need to build the LCE runtime for different platforms.
Once we'll get closer to 0.4 I will automatically publish this image for every release tag so the install docs can be simplified and users won't run into version conflicts.

Currently the goal of this image is not to replace the image used to build the manylinux2010 converter wheels but it is still useful for our own development since on macOS one can't natively cross-compile to AArch64.

## How Has This Been Tested?
I built the image locally and verified that I can built the benchmarking binaries for Android and AArch64 in it.