### PR TITLE
Move weight bitpacking into its own converter pass.

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -66,6 +66,23 @@ gentbl(
 )
 
 gentbl(
+    name = "bitpack_weights_lce_inc_gen",
+    tbl_outs = [
+        ("-gen-rewriters", "transforms/generated_bitpack_weights.inc"),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "transforms/bitpack_weights_patterns.td",
+    td_srcs = [
+        "ir/lce_ops.td",
+        "transforms/bitpack_weights_patterns.td",
+        "transforms/op_removal_patterns.td",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_ops_td_files",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
+        "@llvm-project//mlir:StdOpsTdFiles",
+    ],
+)
+
+gentbl(
     name = "quantize_lce_inc_gen",
     tbl_outs = [
         ("-gen-rewriters", "transforms/generated_quantize.inc"),
@@ -144,6 +161,24 @@ cc_library(
     ],
     deps = [
         ":larq_compute_engine",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:IR",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "larq_compute_engine_bitpack_weights",
+    srcs = [
+        "transforms/bitpack_weights.cc",
+        "transforms/generated_bitpack_weights.inc",
+    ],
+    hdrs = [
+        "transforms/passes.h",
+    ],
+    deps = [
+        ":larq_compute_engine",
         "//larq_compute_engine/core:packbits",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
     ],
@@ -173,6 +208,7 @@ cc_library(
         "tf_tfl_passes.h",
     ],
     deps = [
+        ":larq_compute_engine_bitpack_weights",
         ":larq_compute_engine_op_removal",
         ":larq_compute_engine_optimize",
         ":larq_compute_engine_prepare",

--- a/larq_compute_engine/mlir/tests/bitpack-weights.mlir
+++ b/larq_compute_engine/mlir/tests/bitpack-weights.mlir
@@ -1,0 +1,12 @@
+// RUN: lce-tf-opt %s -tfl-lce-bitpack-weights | FileCheck %s --dump-input-on-failure
+
+// CHECK-LABEL: @bitpack_bconv2d_filters
+func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
+  %cst = constant dense<1.0> : tensor<16x3x3x3xf32>
+  %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  return %0 : tensor<256x30x30x16xf32>
+
+  // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>
+  // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x1xi32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
+  // CHECK-NEXT: return %0
+}

--- a/larq_compute_engine/mlir/tests/optimize.mlir
+++ b/larq_compute_engine/mlir/tests/optimize.mlir
@@ -151,7 +151,7 @@ func @tranform_negative_multipliers(%arg0: tensor<256x32x32x3xf32>, %arg1: tenso
   %0 = "tf.LceBconv2d"(%arg0, %filter, %multiplier, %arg1) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
-  // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>
+  // CHECK: %cst = constant dense<1.000000e+00> : tensor<16x3x3x3xf32>
   // CHECK: %cst_0 = constant dense<3.000000e+00> : tensor<16xf32>
   // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %cst_0, %arg1)
   // CHECK-NEXT: return %0
@@ -165,19 +165,8 @@ func @do_not_change_multiplier_if_fused_activation(%arg0: tensor<256x32x32x3xf32
   return %0 : tensor<256x30x30x16xf32>
 
   // CHECK: %cst = constant dense<-3.000000e+00> : tensor<16xf32>
-  // CHECK: %cst_0 = constant dense<0> : tensor<16x3x3x1xi32>
+  // CHECK: %cst_0 = constant dense<1.000000e+00> : tensor<16x3x3x3xf32>
   // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst_0, %cst, %arg1)
-  // CHECK-NEXT: return %0
-}
-
-// CHECK-LABEL: @bitpack_bconv2d_filters
-func @bitpack_bconv2d_filters(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> tensor<256x30x30x16xf32> {
-  %cst = constant dense<1.0> : tensor<16x3x3x3xf32>
-  %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
-  return %0 : tensor<256x30x30x16xf32>
-
-  // CHECK: %cst = constant dense<0> : tensor<16x3x3x1xi32>
-  // CHECK: %0 = "tf.LceBconv2d"(%arg0, %cst, %arg1, %arg2) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x1xi32>, tensor<16xf32>, tensor<16xf32>) -> tensor<256x30x30x16xf32>
   // CHECK-NEXT: return %0
 }
 

--- a/larq_compute_engine/mlir/transforms/bitpack_weights.cc
+++ b/larq_compute_engine/mlir/transforms/bitpack_weights.cc
@@ -1,0 +1,77 @@
+#include "larq_compute_engine/core/packbits.h"
+#include "larq_compute_engine/mlir/ir/lce_ops.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace TFL {
+
+namespace {
+
+struct BitpackWeightsLCE : public PassWrapper<BitpackWeightsLCE, FunctionPass> {
+  void runOnFunction() override;
+};
+
+bool IsConv2DFilter(Attribute filter) {
+  if (!filter.isa<DenseElementsAttr>()) return false;
+  auto filter_type = filter.getType().cast<ShapedType>();
+  return filter_type.getElementType().isF32() &&
+         filter_type.getShape().size() == 4;
+}
+
+DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
+  const auto& dense_elements_iter =
+      x.cast<DenseElementsAttr>().getValues<float>();
+
+  using PackedType = std::uint32_t;
+  constexpr int bitwidth = std::numeric_limits<PackedType>::digits;
+
+  auto shape = x.getType().cast<ShapedType>().getShape();
+  int num_rows = shape[0] * shape[1] * shape[2];
+  int unpacked_channels = shape[3];
+  int packed_channels = (unpacked_channels + bitwidth - 1) / bitwidth;
+
+  std::vector<PackedType> new_values(num_rows * packed_channels);
+  std::vector<float> old_values(num_rows * unpacked_channels);
+
+  int i = 0;
+  for (float x : dense_elements_iter) {
+    old_values[i++] = x;
+  }
+  assert(i == num_rows * unpacked_channels);
+
+  using namespace compute_engine::core;
+  packbits_matrix<BitpackOrder::Canonical>(
+      old_values.data(), num_rows, unpacked_channels, new_values.data());
+
+  RankedTensorType out_tensor_type =
+      RankedTensorType::get({shape[0], shape[1], shape[2], packed_channels},
+                            builder.getIntegerType(bitwidth));
+
+  return DenseElementsAttr::get<PackedType>(out_tensor_type, new_values);
+}
+
+#include "larq_compute_engine/mlir/transforms/generated_bitpack_weights.inc"
+
+void BitpackWeightsLCE::runOnFunction() {
+  OwningRewritePatternList patterns;
+  auto* ctx = &getContext();
+  auto func = getFunction();
+
+  TFL::populateWithGenerated(ctx, &patterns);
+  applyPatternsAndFoldGreedily(func, patterns);
+}
+
+}  // namespace
+
+// Creates an instance of the TensorFlow dialect BitpackWeights pass.
+std::unique_ptr<OperationPass<FuncOp>> CreateBitpackWeightsLCEPass() {
+  return std::make_unique<BitpackWeightsLCE>();
+}
+
+static PassRegistration<BitpackWeightsLCE> pass("tfl-lce-bitpack-weights",
+                                                "Bitpack binary weights");
+
+}  // namespace TFL
+}  // namespace mlir

--- a/larq_compute_engine/mlir/transforms/bitpack_weights_patterns.td
+++ b/larq_compute_engine/mlir/transforms/bitpack_weights_patterns.td
@@ -1,0 +1,36 @@
+include "mlir/Dialect/StandardOps/IR/Ops.td"
+include "tensorflow/compiler/mlir/lite/ir/tfl_ops.td"
+include "larq_compute_engine/mlir/ir/lce_ops.td"
+include "larq_compute_engine/mlir/transforms/op_removal_patterns.td"
+
+// Bitpack weights
+def Conv2DFilter : AttrConstraint<CPred<"IsConv2DFilter($_self)">>;
+def Bitpack : NativeCodeCall<"Bitpack($_builder, $0)">;
+
+def : Pat<(TF_LceBconv2dOp
+              $input,
+              (ConstantOp Conv2DFilter:$filter),
+              $post_activation_multiplier,
+              $post_activation_bias,
+              $channels_in,
+              $dilation_height_factor,
+              $dilation_width_factor,
+              $fused_activation_function,
+              $pad_values,
+              $padding,
+              $stride_height,
+              $stride_width),
+          (TF_LceBconv2dOp
+              $input,
+              (ConstantOp (Bitpack $filter)),
+              $post_activation_multiplier,
+              $post_activation_bias,
+              $channels_in,
+              $dilation_height_factor,
+              $dilation_width_factor,
+              $fused_activation_function,
+              $pad_values,
+              $padding,
+              $stride_height,
+              $stride_width),
+          []>;

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -1,4 +1,3 @@
-#include "larq_compute_engine/core/packbits.h"
 #include "larq_compute_engine/mlir/ir/lce_ops.h"
 #include "llvm/ADT/Optional.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -35,13 +34,6 @@ bool IsConstantValue(Attribute values, float expected_value) {
   return true;
 }
 
-bool IsConv2DFilter(Attribute filter) {
-  if (!filter.isa<DenseElementsAttr>()) return false;
-  auto filter_type = filter.getType().cast<ShapedType>();
-  return filter_type.getElementType().isF32() &&
-         filter_type.getShape().size() == 4;
-}
-
 DenseElementsAttr ComputeBSignAndExpandTo4D(Attribute attr) {
   auto tensor = attr.cast<DenseElementsAttr>();
   auto channels = tensor.getNumElements();
@@ -66,38 +58,6 @@ bool HasNegativeValues(Attribute attr) {
     if (value < 0.0f) return true;
   }
   return false;
-}
-
-DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
-  const auto& dense_elements_iter =
-      x.cast<DenseElementsAttr>().getValues<float>();
-
-  using PackedType = std::uint32_t;
-  constexpr int bitwidth = std::numeric_limits<PackedType>::digits;
-
-  auto shape = x.getType().cast<ShapedType>().getShape();
-  int num_rows = shape[0] * shape[1] * shape[2];
-  int unpacked_channels = shape[3];
-  int packed_channels = (unpacked_channels + bitwidth - 1) / bitwidth;
-
-  std::vector<PackedType> new_values(num_rows * packed_channels);
-  std::vector<float> old_values(num_rows * unpacked_channels);
-
-  int i = 0;
-  for (float x : dense_elements_iter) {
-    old_values[i++] = x;
-  }
-  assert(i == num_rows * unpacked_channels);
-
-  using namespace compute_engine::core;
-  packbits_matrix<BitpackOrder::Canonical>(
-      old_values.data(), num_rows, unpacked_channels, new_values.data());
-
-  RankedTensorType out_tensor_type =
-      RankedTensorType::get({shape[0], shape[1], shape[2], packed_channels},
-                            builder.getIntegerType(bitwidth));
-
-  return DenseElementsAttr::get<PackedType>(out_tensor_type, new_values);
 }
 
 #include "larq_compute_engine/mlir/transforms/generated_optimize.inc"

--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -108,19 +108,3 @@ foreach actFnPair = [[TFL_ReluOp, TFL_AF_Relu],
                      [TFL_Relu1Op, TFL_AF_Relu1],
                      [TFL_Relu6Op, TFL_AF_Relu6]] in
   defm : FuseActFnIntoConvOpPat<actFnPair[0], actFnPair[1]>;
-
-
-// Bitpack weights
-def Conv2DFilter : AttrConstraint<CPred<"IsConv2DFilter($_self)">>;
-def Bitpack : NativeCodeCall<"Bitpack($_builder, $0)">;
-
-def : Pat<(TF_LceBconv2dOp $input, (ConstantOp Conv2DFilter:$filter),
-            $post_activation_multiplier, $post_activation_bias,
-            $channels_in, $dilation_height_factor, $dilation_width_factor,
-            $fused_activation_function,
-            $pad_values, $padding, $stride_height, $stride_width),
-          (TF_LceBconv2dOp $input, (ConstantOp (Bitpack $filter)),
-            $post_activation_multiplier, $post_activation_bias,
-            $channels_in, $dilation_height_factor, $dilation_width_factor,
-            $fused_activation_function,
-            $pad_values, $padding, $stride_height, $stride_width)>;


### PR DESCRIPTION
## What do these changes do?

Weight bitpacking in the converter is moved out of the optimise pass and into its own dedicated pass that runs after the optimise pass.

## How Has This Been Tested?

CI.

## Benchmark Results

N/A.

## Related issue number

This is a prerequisite for #391.
