### PR TITLE
Publish dev docker images for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "releases/nightly"
 
+env:
+  IMAGE_NAME: dev
+
 jobs:
   macos-release-wheel:
     name: Build release wheels for macOS
@@ -130,3 +133,35 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
+
+  push-docker-image:
+    name: Push Docker image to GitHub Package Registry
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
## What do these changes do?
This PR adds an action that automatically publishes a development docker image for every release with the required dependencies for building LCE.

A few users filed issues due to converter / runtime version conflicts. Having a properly versioned image makes this allows us to simplify our docs so issues like this will be less likely. The custom-op container currently used in the docs is really big and doesn't include all necessary dependencies which makes it cumbersome to use.

The docker image can be pulled using
```
docker pull docker.pkg.github.com/larq/compute-engine/dev:0.3.1
```

For now I opted to not push images with a `latest` tag to make the version explicit.

While GitHub packages makes it really easy for us to distribute containers unfortunately, it requires users to be [authenticated with their GitHub token](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token). This is an [open issue](https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358) on GitHub packages so hopefully this limitation will be lifted soon.

## How Has This Been Tested?
This code has been copied from the GitHub actions docker example and worked out of the box to buid a package for the 0.3.1 release: https://github.com/larq/compute-engine/packages/256695