### PR TITLE
Slightly optimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install curl unzip build-essential openjdk-8-jdk python3-dev python3-pip qemu-user -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install curl zip unzip git build-essential openjdk-8-jdk-headless python3-dev python3-pip qemu-user -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64 > /usr/local/bin/bazelisk && chmod +x /usr/local/bin/bazelisk
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && ln -s /usr/bin/pip3 /usr/local/bin/pip
 RUN pip install six numpy --no-cache-dir


### PR DESCRIPTION
## What do these changes do?
This swiches to the headless version of openjdk to slightly reduce the size of the docker image and installes git and zip so we can also build the AAR package