### PR TITLE
Fix BMaxPool IR definition

### DIFF
--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -123,7 +123,7 @@ Computes a MaxPool2D operation and outputs bitpacked binary values, for consumpt
   }];
 
   let arguments = (ins
-    TensorOf<[F32, I32]>:$input,
+    TensorOf<[F32, I32, QI8]>:$input,
     TFL_PaddingAttr:$padding,
     I32Attr:$stride_width,
     I32Attr:$stride_height,


### PR DESCRIPTION
The BMaxPool kernel allows for  `qint8` input which was missing from the op definition.