### PR TITLE
Improve error message when passing wrong converter arg

### DIFF
--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -77,6 +77,10 @@ def convert_keras_model(
     # Returns
         The converted data in serialized format.
     """
+    if not isinstance(model, tf.keras.Model):
+        raise ValueError(
+            f"Expected `model` argument to be a `tf.keras.Model` instance, got `{model}`."
+        )
     if not tf.executing_eagerly():
         raise RuntimeError(
             "Graph mode is not supported. Please enable eager execution using "

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -29,6 +29,10 @@ class TestConverter(unittest.TestCase):
             False,
         )
 
+    def test_wrong_arg(self):
+        with self.assertRaises(ValueError):
+            convert_keras_model("./model.h5")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What do these changes do?
This raises a proper error message when wrong arguments are passed to the converter.

## How Has This Been Tested?
CI

## Related issue number
Adresses https://github.com/larq/larq/issues/508#issuecomment-650031286
