### PR TITLE
Upgrade TensorFlow to 2.3.0rc0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,10 +47,10 @@ arm_compiler_configure(
 #    reliable downloads.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "b2eb4a3c5d0b0c323fbc90f33012912fcd03513ce041d16efd2594a227735547",
-    strip_prefix = "tensorflow-9a70ab8813048db1aacd3df5361dae42bf4ea31f",
+    sha256 = "972ec45352161e4308a1b203956eedfb56e22cc6ce4f4ec95f7b087aeb00559e",
+    strip_prefix = "tensorflow-2.3.0-rc0",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/9a70ab8813048db1aacd3df5361dae42bf4ea31f.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/v2.3.0-rc0.tar.gz",
     ],
 )
 

--- a/larq_compute_engine/mlir/ir/lce_ops.cc
+++ b/larq_compute_engine/mlir/ir/lce_ops.cc
@@ -17,7 +17,7 @@ static TfLiteFusedActivation ConvertTfLiteFusedActivationAttr(
   return llvm::StringSwitch<TfLiteFusedActivation>(str)
       .Case("NONE", kTfLiteActNone)
       .Case("RELU", kTfLiteActRelu)
-      .Case("RELU_N1_TO_1", kTfLiteActRelu1)
+      .Case("RELU_N1_TO_1", kTfLiteActReluN1To1)
       .Case("RELU6", kTfLiteActRelu6);
 }
 

--- a/larq_compute_engine/mlir/tf_tfl_passes.cc
+++ b/larq_compute_engine/mlir/tf_tfl_passes.cc
@@ -21,12 +21,6 @@ void AddQuantizationPasses(const mlir::TFL::QuantizationSpecs& quant_specs,
                            mlir::OpPassManager* pass_manager) {
   pass_manager->addPass(mlir::TFL::CreatePrepareQuantizePass(quant_specs));
   pass_manager->addPass(mlir::TFL::CreateLCEQuantizePass());
-  pass_manager->addPass(mlir::TFL::CreateQuantizePass());
-  bool emit_quant_adaptor_ops =
-      quant_specs.inference_type != quant_specs.inference_input_type;
-  pass_manager->addPass(
-      mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
-
   if (quant_specs.default_ranges.first.hasValue() ||
       quant_specs.default_ranges.second.hasValue()) {
     pass_manager->addPass(mlir::TFL::CreateDefaultQuantParamsPass(
@@ -34,10 +28,12 @@ void AddQuantizationPasses(const mlir::TFL::QuantizationSpecs& quant_specs,
         quant_specs.default_ranges.second.getValueOr(0.0),
         quant_specs.IsSignedInferenceType()));
     pass_manager->addPass(mlir::TFL::CreateLCEQuantizePass());
-    pass_manager->addPass(mlir::TFL::CreateQuantizePass());
-    pass_manager->addPass(
-        mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
   }
+  pass_manager->addPass(mlir::TFL::CreateQuantizePass());
+  bool emit_quant_adaptor_ops =
+      quant_specs.inference_type != quant_specs.inference_input_type;
+  pass_manager->addPass(
+      mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
 }
 
 void AddTFToLCETFLConversionPasses(
@@ -48,8 +44,10 @@ void AddTFToLCETFLConversionPasses(
   standard_pipeline_options.enable_inliner = false;
   standard_pipeline_options.form_clusters = false;
   mlir::TF::CreateTFStandardPipeline(*pass_manager, standard_pipeline_options);
+  pass_manager->addPass(mlir::TF::CreateDeviceIndexSelectorPass());
 
   pass_manager->addPass(mlir::TF::CreateTFShapeInferencePass());
+  pass_manager->addPass(mlir::TF::CreateTFFunctionalControlFlowToRegions());
 
   // The conversion pipeline has to follow the following orders:
   // 1) Saved model related optimization like decompose resource ops
@@ -81,6 +79,8 @@ void AddTFToLCETFLConversionPasses(
 
   // Add a shape inference pass to optimize away the unnecessary casts.
   pass_manager->addPass(mlir::TF::CreateTFShapeInferencePass());
+
+  pass_manager->addPass(mlir::TF::CreateTFRegionControlFlowToFunctional());
 
   // Legalize while early to allow further constant folding.
   // TODO(jpienaar): This may not actually matter as we do canonicalization


### PR DESCRIPTION
## What do these changes do?
This PR upgrades our TensorFlow dependency to 2.3.0rc0.

## How Has This Been Tested?
Let's see what CI thinks.