### PR TITLE
Fix int8 outputtransform

### DIFF
--- a/larq_compute_engine/core/bconv2d_output_transform.h
+++ b/larq_compute_engine/core/bconv2d_output_transform.h
@@ -71,39 +71,22 @@ struct OutputTransform<AccumScalar, std::int32_t> {
 };
 
 // Output transformation for 8-bit quantization
-//
-// We use the following preprocessor flag which can be set in build scripts:
-// LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
-//
-// For devices that have an FPU, we can gain accuracy by doing a part
-// of the output transform in float, and then converting back to 8-bit.
-//
-// To not use the FPU, this flag should be disabled and the kernel will be
-// compiled without float ops in the output transform, at the cost of some
-// accuracy.
 
-#ifdef LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
 template <typename AccumScalar>
 struct OutputTransform<AccumScalar, std::int8_t>
     : OutputTransformBase<AccumScalar> {
   // These effective values are the post-activation multipliers and biases
-  // divided by output_scale
+  // divided by output_scale and including the output zero_point
   const float* effective_post_activation_multiplier = nullptr;
   const float* effective_post_activation_bias = nullptr;
-  std::int32_t output_zero_point = 0;
 
   std::int8_t Run(const AccumScalar accum, int out_channel) const {
     // First convert to full precision to do the linear transformation
     float result_fp = static_cast<float>(this->RunBase(accum));
-    if (effective_post_activation_multiplier) {
-      result_fp *= effective_post_activation_multiplier[out_channel];
-    }
-    if (effective_post_activation_bias) {
-      result_fp += effective_post_activation_bias[out_channel];
-    }
+    result_fp *= effective_post_activation_multiplier[out_channel];
+    result_fp += effective_post_activation_bias[out_channel];
     // Now round back to int32
     AccumScalar result = tflite::TfLiteRound(result_fp);
-    result += output_zero_point;
     // Clamp to int8 range
     result =
         std::min<std::int32_t>(result, std::numeric_limits<std::int8_t>::max());
@@ -112,36 +95,6 @@ struct OutputTransform<AccumScalar, std::int8_t>
     return static_cast<std::int8_t>(result);
   }
 };
-
-#else   // LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
-
-template <typename AccumScalar>
-struct OutputTransform<AccumScalar, std::int8_t>
-    : OutputTransformBase<AccumScalar> {
-  // output_multiplier and output_shift encode multiplication by
-  // (post_activation_multiplier[channel] / scale)
-  const std::int32_t* output_multiplier = nullptr;
-  const std::int32_t* output_shift = nullptr;
-  // output_effective_zero_point is addition by
-  // (output_zero_point + round(post_activation_bias[channel] / scale)
-  const std::int32_t* output_effective_zero_point = nullptr;
-
-  std::int8_t Run(const AccumScalar accum, int out_channel) const {
-    AccumScalar result = this->RunBase(accum);
-    // Multiply by (post_activation_multiplier[channel] / scale)
-    result = ::tflite::MultiplyByQuantizedMultiplier(
-        result, output_multiplier[out_channel], output_shift[out_channel]);
-    // Add post_activation_bias and output_zero_point
-    result += output_effective_zero_point[out_channel];
-    // Clamp to int8 range
-    result =
-        std::min<std::int32_t>(result, std::numeric_limits<std::int8_t>::max());
-    result = std::max<std::int32_t>(result,
-                                    std::numeric_limits<std::int8_t>::lowest());
-    return static_cast<std::int8_t>(result);
-  }
-};
-#endif  // LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
 
 }  // namespace core
 }  // namespace compute_engine

--- a/larq_compute_engine/tflite/kernels/bconv2d_output_transform_utils.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_output_transform_utils.h
@@ -62,19 +62,10 @@ void GetOutputTransform(
     TfLiteContext* context, TfLiteNode* node, TfLiteBConv2DParams* params,
     OutputTransform<AccumScalar, std::int8_t>& output_transform) {
   GetBaseParams(context, node, params, output_transform);
-#ifdef LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
   output_transform.effective_post_activation_multiplier =
       params->scaled_post_activation_multiplier.data();
   output_transform.effective_post_activation_bias =
       params->scaled_post_activation_bias.data();
-  output_transform.output_zero_point =
-      GetOutput(context, node, 0)->params.zero_point;
-#else
-  output_transform.output_multiplier = params->output_multiplier.data();
-  output_transform.output_shift = params->output_shift.data();
-  output_transform.output_effective_zero_point =
-      params->output_zero_point.data();
-#endif
 }
 
 }  // namespace bconv2d

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -51,18 +51,9 @@ typedef struct {
   std::int32_t output_activation_max;
 
   // This is only for int8 mode, its the post_activation_ values scaled by the
-  // output tensor scale. Until we have optimized code for writing bitpacked
-  // outputs, these are also used there.
+  // output tensor scale, and the bias includes the output zero-point.
   std::vector<float> scaled_post_activation_multiplier;
   std::vector<float> scaled_post_activation_bias;
-#ifndef LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT
-  // Quantizaion parameters, per output channel.
-  // Because we fuse the post_activation_add with the zero-point we now have
-  // preprocessed zero-points, and they are per-channel instead of per-tensor.
-  std::vector<std::int32_t> output_multiplier;
-  std::vector<std::int32_t> output_shift;
-  std::vector<std::int32_t> output_zero_point;
-#endif
   bool is_quantization_initialized = false;
 
   bool bitpack_before_im2col = false;


### PR DESCRIPTION
# What do these changes do?
We had a flag `LCE_RUN_OUTPUT_TRANSFORM_IN_FLOAT`. The non-float option was giving really bad results but this was not properly tested. This PR removes the non-float option and improves the end2end test.

For the unittests, it would make sense to actually compare the int8 `LceBconv2d` to `fake_quant + conv2d + fake_quant` instead of comparing it to int8 Conv2D, because that would match the Keras side much closer.
We can do that in this PR or in a separate PR, that is both fine with me.