### PR TITLE
Update the unittest error threshold

### DIFF
--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -419,7 +419,7 @@ void test_lce_op_output(const std::vector<TOutput>& lce_output_data,
                         const std::vector<int>& builtin_output_shape,
                         const std::vector<TOutput>& builtin_output_data,
                         std::int32_t zero_point) {
-  EXPECT_THAT(lce_output_data, ::testing::Pointwise(FloatNearPointwise(1e-4),
+  EXPECT_THAT(lce_output_data, ::testing::Pointwise(FloatNearPointwise(1e-3),
                                                     builtin_output_data));
 }
 


### PR DESCRIPTION
## What do these changes do?
Lately the ARM32 unittests have been failing more often with very small floating point mismatches. This commit slightly increases the tolerance.
