### PR TITLE
Use a 32-column C++ kernel layout when writing bitpacked output.

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -25,6 +25,23 @@ struct BinaryMulParams {
   using StandardCppKernelRhsLayout = FixedKernelLayout<Order::kColMajor, 1, 1>;
 };
 
+// A specialisation for the writing-bitpacked-output case, where the C++ LHS
+// kernel layout must have 32 columns (for bitpacking a word of channels).
+template <typename tAccumScalar>
+struct BinaryMulParams<tAccumScalar, std::int32_t> {
+  using AccumScalar = tAccumScalar;
+  using DstScalar = std::int32_t;
+
+  OutputTransform<AccumScalar, DstScalar> output_transform;
+
+  static constexpr LoopStructure kLoopStructure = LoopStructure::kAuto;
+  static constexpr LayoutSupport kLayoutSupport = LayoutSupport::kGeneral;
+  static constexpr ZeroPointSupport kZeroPointSupport =
+      ZeroPointSupport::kGeneral;
+  using StandardCppKernelLhsLayout = FixedKernelLayout<Order::kColMajor, 1, 32>;
+  using StandardCppKernelRhsLayout = FixedKernelLayout<Order::kColMajor, 1, 1>;
+};
+
 template <int LhsCols, int RhsCols, class T>
 struct BinaryKernelParams {
   const T* lhs_base_ptr;


### PR DESCRIPTION
This is much cleaner than the previous solution (which rounded the rows up/down and so did duplicate computation), and fixes some failures in the 'big' kernel tests on Aarch64.

## How Has This Been Tested?

The 'big' kernel tests now consistently pass for Aarch64, whereas previously they were flaky on master when writing bitpacked output with 2-threaded inference and large input sizes.

## Benchmark Results
N/A

## Related issue number
N/A
