### PR TITLE
Add `make_unsigned` to `unpack_matrix` type

### DIFF
--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -427,7 +427,8 @@ template <typename TBitpacked, typename TUnpacked>
 inline void unpack_matrix(const TBitpacked* input_data,
                           const std::size_t num_rows,
                           const std::size_t num_cols, TUnpacked* output_data) {
-  constexpr std::size_t bitwidth = std::numeric_limits<TBitpacked>::digits;
+  constexpr std::size_t bitwidth = std::numeric_limits<
+      typename std::make_unsigned<TBitpacked>::type>::digits;
 
   const TBitpacked* in_ptr = input_data;
   TUnpacked* out_ptr = output_data;


### PR DESCRIPTION
## What do these changes do?
Calling `unpack_matrix` with a signed integer type would yield wrong results. This fix forces the type to be unsigned.
