### PR TITLE
Add Android AAR build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,35 @@ jobs:
           name: Benchmark-Binaries
           path: benchmark-binaries
 
+  android-aar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2.1.1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/lce_android
+          key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
+      - name: Configure Bazel
+        run: ./configure.sh <<< $'n\n'
+        shell: bash
+      - name: Install pip dependencies
+        run: pip install numpy six --no-cache-dir
+      - name: Download and install Android NDK/SDK
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./third_party/install_android.sh
+      - name: Build LCE AAR
+        run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh
+      - uses: actions/upload-artifact@v2.1.1
+        with:
+          name: Android-AAR
+          path: lce-lite-*.aar
+
   macos-release-wheel:
     name: Build release wheels for macOS
     runs-on: macos-latest


### PR DESCRIPTION
## What do these changes do?
This PR adds builds of the Android AAR package to the release workflow.

## How Has This Been Tested?
I ran a test build [here](https://github.com/larq/compute-engine/runs/942161437?check_suite_focus=true).

## Related issue number
This doesn't fully address #317 as the PR doesn't upload the final package to Bintray yet, but at least it now get's build on CI so we can manually upload to Bintray.
