### PR TITLE
Prebuild AArch32 benchmark binary for new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
         run: |
           bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=aarch64
           cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_aarch64
+      - name: Build Benchmark utility for AArch32
+        run: |
+          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=rpi3
+          cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_aarch32
       - name: Build Benchmark utility for Android
         run: |
           bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=android_arm64


### PR DESCRIPTION
## What do these changes do?
This PR prebuilds an AArch32 version of our benchmark binary for new releases since #432 added optimized kernels for AArch32.

## How Has This Been Tested?
A [test build successfully completed here](https://github.com/larq/compute-engine/actions/runs/194649302).
