### PR TITLE
add extra braces around padding_buffer

### DIFF
--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -378,7 +378,7 @@ inline void packbits_array(const TIn* input_array, const std::size_t n,
   // enough zeros to fill the bitwidth. This function assumes enough memory for
   // padding is already allocatd in the output array `bitpacked_array`.
   if (elements_left != 0) {
-    std::array<TIn, bitwidth> padding_buffer = {0};
+    std::array<TIn, bitwidth> padding_buffer = {{0}};
     memcpy(padding_buffer.data(), in, elements_left * sizeof(TIn));
     for (size_t i = elements_left; i < bitwidth; ++i)
       padding_buffer[i] = zero_point;


### PR DESCRIPTION
add extra braces to avoid the warning:
 warning: suggest braces around initialization of subobject [-Wmissing-braces]
    std::array<TIn, bitwidth> padding_buffer = {0};


<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
Removed warning from build

## How Has This Been Tested?
It still builds

## Benchmark Results
NA

## Related issue number
NA
