### PR TITLE
Standardise on 32-bit bitpacking. Closes #446.

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -3,24 +3,22 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "utils",
+    name = "types",
     hdrs = [
         "types.h",
     ],
 )
 
-# BUILDING BGEMM
 cc_library(
     name = "bgemm_functor",
     hdrs = [
         "bgemm_functor.h",
     ],
     deps = [
-        ":utils",
+        ":types",
     ],
 )
 
-# BUILDING PACKBITS
 cc_library(
     name = "packbits",
     hdrs = ["packbits.h"] + select({
@@ -33,7 +31,7 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        ":utils",
+        ":types",
         "@flatbuffers",
     ],
 )
@@ -50,13 +48,6 @@ cc_library(
 cc_library(
     name = "padding_functor",
     hdrs = ["padding_functor.h"],
-)
-
-cc_library(
-    name = "packbits_aarch64",
-    hdrs = [
-        "packbits_aarch64.h",
-    ],
 )
 
 cc_library(
@@ -78,6 +69,7 @@ cc_library(
         "bconv2d_output_transform.h",
     ],
     deps = [
+        ":types",
         "@org_tensorflow//tensorflow/lite/kernels/internal:common",
         "@org_tensorflow//tensorflow/lite/kernels/internal:cppmath",
     ],
@@ -115,6 +107,7 @@ cc_library(
     ],
     deps = [
         ":bgemm_kernels_arm",
+        ":packbits",
         "//larq_compute_engine/core:bgemm_functor",
         "@ruy//ruy/profiler:instrumentation",
     ],
@@ -164,6 +157,7 @@ cc_library(
         "bmaxpool.h",
     ],
     deps = [
+        ":types",
         "@org_tensorflow//tensorflow/lite/kernels/internal:common",
         "@org_tensorflow//tensorflow/lite/kernels/internal:types",
     ],

--- a/larq_compute_engine/core/bgemm_impl.h
+++ b/larq_compute_engine/core/bgemm_impl.h
@@ -20,21 +20,19 @@ namespace compute_engine {
 namespace tflite {
 
 #ifndef TFLITE_WITH_RUY
-template <typename LhsScalar, typename RhsScalar, typename AccumScalar,
-          typename DstScalar>
+template <typename AccumScalar, typename DstScalar>
 struct BGemmImpl : BGemmImplRef<LhsScalar, RhsScalar, AccumScalar, DstScalar> {
 };
 #else
-template <typename LhsScalar, typename RhsScalar, typename AccumScalar,
-          typename DstScalar>
-struct BGemmImpl
-    : BGemmImplUsingRuy<LhsScalar, RhsScalar, AccumScalar, DstScalar> {};
+template <typename AccumScalar, typename DstScalar>
+struct BGemmImpl : BGemmImplUsingRuy<AccumScalar, DstScalar> {};
 #endif
 
-template <typename LhsScalar, typename RhsScalar, typename AccumScalar,
-          typename DstScalar>
-void BGemm(const MatrixParams<LhsScalar>& lhs_params, const LhsScalar* lhs_data,
-           const MatrixParams<RhsScalar>& rhs_params, const RhsScalar* rhs_data,
+template <typename AccumScalar, typename DstScalar>
+void BGemm(const MatrixParams<TBitpacked>& lhs_params,
+           const TBitpacked* lhs_data,
+           const MatrixParams<TBitpacked>& rhs_params,
+           const TBitpacked* rhs_data,
            const MatrixParams<DstScalar>& dst_params, DstScalar* dst_data,
            const OutputTransform<AccumScalar, DstScalar>& params,
            CpuBackendContext* context) {
@@ -48,9 +46,9 @@ void BGemm(const MatrixParams<LhsScalar>& lhs_params, const LhsScalar* lhs_data,
   //   }
   // }
   ruy::profiler::ScopeLabel label2("BGemm/GeneralBGEMM");
-  BGemmImpl<LhsScalar, RhsScalar, AccumScalar, DstScalar>::Run(
-      lhs_params, lhs_data, rhs_params, rhs_data, dst_params, dst_data, params,
-      context);
+  BGemmImpl<AccumScalar, DstScalar>::Run(lhs_params, lhs_data, rhs_params,
+                                         rhs_data, dst_params, dst_data, params,
+                                         context);
 }
 
 }  // namespace tflite

--- a/larq_compute_engine/core/bgemm_kernels_x86.h
+++ b/larq_compute_engine/core/bgemm_kernels_x86.h
@@ -1,6 +1,7 @@
 #ifndef COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_X86_H_
 #define COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_X86_H_
 
+#include "larq_compute_engine/core/types.h"
 #include "ruy/common.h"
 #include "ruy/kernel_common.h"
 #include "ruy/mat.h"
@@ -13,97 +14,67 @@
 
 using namespace ruy;
 
+using compute_engine::core::TBitpacked;
+
 #if RUY_PLATFORM_X86
 
-template <typename LhsScalar, typename RhsScalar, typename DstScalar,
-          typename MulParamsType>
-struct BgemmKernel<ruy::Path::kAvx2, LhsScalar, RhsScalar, DstScalar,
-                   MulParamsType> {
+template <typename DstScalar, typename MulParamsType>
+struct BgemmKernel<ruy::Path::kAvx2, DstScalar, MulParamsType> {
   Tuning tuning = Tuning::kAuto;
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+  void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
            int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
-    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
-                  "Inputs to binary kernel should have the same type.");
-    static_assert(
-        // std::is_unsigned<LhsScalar>::value &&
-        std::is_integral<LhsScalar>::value,
-        "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
     TFLITE_DCHECK(false);
   }
 };
 
-template <typename LhsScalar, typename RhsScalar, typename DstScalar,
-          typename MulParamsType>
-struct BgemmKernel<ruy::Path::kAvx512, LhsScalar, RhsScalar, DstScalar,
-                   MulParamsType> {
+template <typename DstScalar, typename MulParamsType>
+struct BgemmKernel<ruy::Path::kAvx512, DstScalar, MulParamsType> {
   Tuning tuning = Tuning::kAuto;
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+  void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
            int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
-    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
-                  "Inputs to binary kernel should have the same type.");
-    static_assert(
-        // std::is_unsigned<LhsScalar>::value &&
-        std::is_integral<LhsScalar>::value,
-        "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
     TFLITE_DCHECK(false);
   }
 };
 
-template <typename LhsScalar, typename RhsScalar, typename DstScalar,
-          typename MulParamsType>
-struct BgemmKernel<ruy::Path::kAvxVnni, LhsScalar, RhsScalar, DstScalar,
-                   MulParamsType> {
+template <typename DstScalar, typename MulParamsType>
+struct BgemmKernel<ruy::Path::kAvxVnni, DstScalar, MulParamsType> {
   Tuning tuning = Tuning::kAuto;
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 16>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+  void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
            int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
-    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
-                  "Inputs to binary kernel should have the same type.");
-    static_assert(
-        // std::is_unsigned<LhsScalar>::value &&
-        std::is_integral<LhsScalar>::value,
-        "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
-    // TODO: not implemented -> fallback to standard cpp
+    TFLITE_DCHECK(false);
   }
 };
 
-template <typename LhsScalar, typename RhsScalar, typename DstScalar,
-          typename MulParamsType>
-struct BgemmKernel<Path::kSse42, LhsScalar, RhsScalar, DstScalar,
-                   MulParamsType> {
+template <typename DstScalar, typename MulParamsType>
+struct BgemmKernel<Path::kSse42, DstScalar, MulParamsType> {
   Tuning tuning = Tuning::kAuto;
   using LhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   using RhsLayout = FixedKernelLayout<Order::kRowMajor, 1, 8>;
   explicit BgemmKernel(Tuning tuning_) : tuning(tuning_) {}
-  void Run(const ruy::PMat<LhsScalar>& lhs, const ruy::PMat<RhsScalar>& rhs,
+  void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const MulParamsType& mul_params, int start_row, int start_col,
            int end_row, int end_col, ruy::Mat<DstScalar>* dst) const {
-    static_assert(std::is_same<LhsScalar, RhsScalar>::value,
-                  "Inputs to binary kernel should have the same type.");
-    static_assert(
-        // std::is_unsigned<LhsScalar>::value &&
-        std::is_integral<LhsScalar>::value,
-        "Input to binary kernel should be of type unsigned integral.");
     static_assert(std::is_signed<DstScalar>::value,
                   "Output of binary kernel should be of a signed type.");
-    // TODO: not implemented -> fallback to standard cpp
+    TFLITE_DCHECK(false);
   }
 };
 

--- a/larq_compute_engine/core/bmaxpool.h
+++ b/larq_compute_engine/core/bmaxpool.h
@@ -1,6 +1,7 @@
 #ifndef COMPUTE_ENGINE_CORE_BMAXPOOL_H_
 #define COMPUTE_ENGINE_CORE_BMAXPOOL_H_
 
+#include "larq_compute_engine/core/types.h"
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/padding.h"
@@ -10,6 +11,8 @@ using namespace tflite;
 namespace compute_engine {
 namespace ce = compute_engine;
 namespace ref {
+
+using ce::core::TBitpacked;
 
 struct BMaxPoolParams {
   std::int32_t filter_height{0};
@@ -21,7 +24,6 @@ struct BMaxPoolParams {
 };
 
 // Effectively takes the AND of everything in the filter region
-template <typename TBitpacked>
 void BMaxPool(const BMaxPoolParams& params, const RuntimeShape& input_shape,
               const TBitpacked* input_data, const RuntimeShape& output_shape,
               TBitpacked* output_data) {

--- a/larq_compute_engine/core/packbits.h
+++ b/larq_compute_engine/core/packbits.h
@@ -18,85 +18,29 @@ namespace compute_engine {
 namespace core {
 
 // Utility functions
-constexpr int GetPackedSize(int unpacked_elements, int bitwidth) {
-  return (unpacked_elements + bitwidth - 1) / bitwidth;
-}
 
-constexpr int GetPackedMatrixSize(int rows, int cols, int bitwidth) {
-  return rows * GetPackedSize(cols, bitwidth);
-}
-
-template <typename TBitpacked>
 constexpr int GetPackedSize(int unpacked_elements) {
-  return GetPackedSize(
-      unpacked_elements,
-      std::numeric_limits<
-          typename std::make_unsigned<TBitpacked>::type>::digits);
+  return (unpacked_elements + bitpacking_bitwidth - 1) / bitpacking_bitwidth;
 }
 
-template <typename TBitpacked>
 constexpr int GetPackedMatrixSize(int rows, int cols) {
-  return GetPackedMatrixSize(
-      rows, cols,
-      std::numeric_limits<
-          typename std::make_unsigned<TBitpacked>::type>::digits);
+  return rows * GetPackedSize(cols);
 }
 
-template <class TIn, class TOut>
-inline void pack(const TIn* fptr, TOut* buf) {
-  constexpr std::size_t bitwidth = std::numeric_limits<TOut>::digits;
-  *buf = 0;
-  for (size_t i = 0; i < bitwidth; ++i) {
-    if (fptr[i] < 0) *buf |= (TOut(1) << i);
-  }
-}
-
-template <class TIn, class TOut>
-inline void pack_quantized(const TIn* in, TOut* out,
+template <class TIn>
+inline void pack_quantized(const TIn* in, TBitpacked* out,
                            const std::int32_t zero_point) {
-  constexpr std::size_t bitwidth = std::numeric_limits<TOut>::digits;
   *out = 0;
-  for (size_t i = 0; i < bitwidth; ++i) {
+  for (size_t i = 0; i < bitpacking_bitwidth; ++i) {
     // Note: uint8 to int32 will set the top 24 bits to 0
     //        int8 to int32 will set the top 24 bits to the int8 sign bit
-    if (static_cast<std::int32_t>(in[i]) < zero_point) *out |= (TOut(1) << i);
+    if (static_cast<std::int32_t>(in[i]) < zero_point)
+      *out |= (TBitpacked(1) << i);
   }
 }
 
 template <class T>
-inline void pack(const T* fptr, std::uint8_t* buf) {
-  struct bf {
-    unsigned int b0 : 1;
-    unsigned int b1 : 1;
-    unsigned int b2 : 1;
-    unsigned int b3 : 1;
-    unsigned int b4 : 1;
-    unsigned int b5 : 1;
-    unsigned int b6 : 1;
-    unsigned int b7 : 1;
-  };
-
-  union bf_u8 {
-    bf t;
-    std::uint8_t u8;
-  };
-
-  // TODO: use the bit sign instead of comparision operator
-  // static_cast<const float>(1 << sizeof(a)*8-1);
-  bf_u8 u;
-  u.t.b0 = fptr[0] < 0;
-  u.t.b1 = fptr[1] < 0;
-  u.t.b2 = fptr[2] < 0;
-  u.t.b3 = fptr[3] < 0;
-  u.t.b4 = fptr[4] < 0;
-  u.t.b5 = fptr[5] < 0;
-  u.t.b6 = fptr[6] < 0;
-  u.t.b7 = fptr[7] < 0;
-  *buf = u.u8;
-}
-
-template <class T>
-inline void pack(const T* fptr, std::uint32_t* buf) {
+inline void pack(const T* fptr, TBitpacked* buf) {
   struct bf {
     unsigned int b0 : 1;
     unsigned int b1 : 1;
@@ -132,194 +76,52 @@ inline void pack(const T* fptr, std::uint32_t* buf) {
     unsigned int b31 : 1;
   };
 
-  union bf_u32 {
+  union bf_i32 {
     bf t;
-    std::uint32_t u32;
+    TBitpacked i32;
   };
 
   // TODO: use the bit sign instead of comparision operator
   // static_cast<const float>(1 << sizeof(a)*8-1);
-  bf_u32 u;
-  u.t.b0 = fptr[0] < 0;
-  u.t.b1 = fptr[1] < 0;
-  u.t.b2 = fptr[2] < 0;
-  u.t.b3 = fptr[3] < 0;
-  u.t.b4 = fptr[4] < 0;
-  u.t.b5 = fptr[5] < 0;
-  u.t.b6 = fptr[6] < 0;
-  u.t.b7 = fptr[7] < 0;
-  u.t.b8 = fptr[8] < 0;
-  u.t.b9 = fptr[9] < 0;
-  u.t.b10 = fptr[10] < 0;
-  u.t.b11 = fptr[11] < 0;
-  u.t.b12 = fptr[12] < 0;
-  u.t.b13 = fptr[13] < 0;
-  u.t.b14 = fptr[14] < 0;
-  u.t.b15 = fptr[15] < 0;
-  u.t.b16 = fptr[16] < 0;
-  u.t.b17 = fptr[17] < 0;
-  u.t.b18 = fptr[18] < 0;
-  u.t.b19 = fptr[19] < 0;
-  u.t.b20 = fptr[20] < 0;
-  u.t.b21 = fptr[21] < 0;
-  u.t.b22 = fptr[22] < 0;
-  u.t.b23 = fptr[23] < 0;
-  u.t.b24 = fptr[24] < 0;
-  u.t.b25 = fptr[25] < 0;
-  u.t.b26 = fptr[26] < 0;
-  u.t.b27 = fptr[27] < 0;
-  u.t.b28 = fptr[28] < 0;
-  u.t.b29 = fptr[29] < 0;
-  u.t.b30 = fptr[30] < 0;
-  u.t.b31 = fptr[31] < 0;
-  *buf = u.u32;
-}
-
-template <class T>
-inline void pack(const T* fptr, std::uint64_t* buf) {
-  struct bf {
-    unsigned int b0 : 1;
-    unsigned int b1 : 1;
-    unsigned int b2 : 1;
-    unsigned int b3 : 1;
-    unsigned int b4 : 1;
-    unsigned int b5 : 1;
-    unsigned int b6 : 1;
-    unsigned int b7 : 1;
-    unsigned int b8 : 1;
-    unsigned int b9 : 1;
-    unsigned int b10 : 1;
-    unsigned int b11 : 1;
-    unsigned int b12 : 1;
-    unsigned int b13 : 1;
-    unsigned int b14 : 1;
-    unsigned int b15 : 1;
-    unsigned int b16 : 1;
-    unsigned int b17 : 1;
-    unsigned int b18 : 1;
-    unsigned int b19 : 1;
-    unsigned int b20 : 1;
-    unsigned int b21 : 1;
-    unsigned int b22 : 1;
-    unsigned int b23 : 1;
-    unsigned int b24 : 1;
-    unsigned int b25 : 1;
-    unsigned int b26 : 1;
-    unsigned int b27 : 1;
-    unsigned int b28 : 1;
-    unsigned int b29 : 1;
-    unsigned int b30 : 1;
-    unsigned int b31 : 1;
-    unsigned int b32 : 1;
-    unsigned int b33 : 1;
-    unsigned int b34 : 1;
-    unsigned int b35 : 1;
-    unsigned int b36 : 1;
-    unsigned int b37 : 1;
-    unsigned int b38 : 1;
-    unsigned int b39 : 1;
-    unsigned int b40 : 1;
-    unsigned int b41 : 1;
-    unsigned int b42 : 1;
-    unsigned int b43 : 1;
-    unsigned int b44 : 1;
-    unsigned int b45 : 1;
-    unsigned int b46 : 1;
-    unsigned int b47 : 1;
-    unsigned int b48 : 1;
-    unsigned int b49 : 1;
-    unsigned int b50 : 1;
-    unsigned int b51 : 1;
-    unsigned int b52 : 1;
-    unsigned int b53 : 1;
-    unsigned int b54 : 1;
-    unsigned int b55 : 1;
-    unsigned int b56 : 1;
-    unsigned int b57 : 1;
-    unsigned int b58 : 1;
-    unsigned int b59 : 1;
-    unsigned int b60 : 1;
-    unsigned int b61 : 1;
-    unsigned int b62 : 1;
-    unsigned int b63 : 1;
-  };
-
-  union bf_u64 {
-    bf t;
-    std::uint64_t u64;
-  };
-
-  bf_u64 u;
-  u.t.b0 = fptr[0] < 0;
-  u.t.b1 = fptr[1] < 0;
-  u.t.b2 = fptr[2] < 0;
-  u.t.b3 = fptr[3] < 0;
-  u.t.b4 = fptr[4] < 0;
-  u.t.b5 = fptr[5] < 0;
-  u.t.b6 = fptr[6] < 0;
-  u.t.b7 = fptr[7] < 0;
-  u.t.b8 = fptr[8] < 0;
-  u.t.b9 = fptr[9] < 0;
-  u.t.b10 = fptr[10] < 0;
-  u.t.b11 = fptr[11] < 0;
-  u.t.b12 = fptr[12] < 0;
-  u.t.b13 = fptr[13] < 0;
-  u.t.b14 = fptr[14] < 0;
-  u.t.b15 = fptr[15] < 0;
-  u.t.b16 = fptr[16] < 0;
-  u.t.b17 = fptr[17] < 0;
-  u.t.b18 = fptr[18] < 0;
-  u.t.b19 = fptr[19] < 0;
-  u.t.b20 = fptr[20] < 0;
-  u.t.b21 = fptr[21] < 0;
-  u.t.b22 = fptr[22] < 0;
-  u.t.b23 = fptr[23] < 0;
-  u.t.b24 = fptr[24] < 0;
-  u.t.b25 = fptr[25] < 0;
-  u.t.b26 = fptr[26] < 0;
-  u.t.b27 = fptr[27] < 0;
-  u.t.b28 = fptr[28] < 0;
-  u.t.b29 = fptr[29] < 0;
-  u.t.b30 = fptr[30] < 0;
-  u.t.b31 = fptr[31] < 0;
-  u.t.b32 = fptr[32] < 0;
-  u.t.b33 = fptr[33] < 0;
-  u.t.b34 = fptr[34] < 0;
-  u.t.b35 = fptr[35] < 0;
-  u.t.b36 = fptr[36] < 0;
-  u.t.b37 = fptr[37] < 0;
-  u.t.b38 = fptr[38] < 0;
-  u.t.b39 = fptr[39] < 0;
-  u.t.b40 = fptr[40] < 0;
-  u.t.b41 = fptr[41] < 0;
-  u.t.b42 = fptr[42] < 0;
-  u.t.b43 = fptr[43] < 0;
-  u.t.b44 = fptr[44] < 0;
-  u.t.b45 = fptr[45] < 0;
-  u.t.b46 = fptr[46] < 0;
-  u.t.b47 = fptr[47] < 0;
-  u.t.b48 = fptr[48] < 0;
-  u.t.b49 = fptr[49] < 0;
-  u.t.b50 = fptr[50] < 0;
-  u.t.b51 = fptr[51] < 0;
-  u.t.b52 = fptr[52] < 0;
-  u.t.b53 = fptr[53] < 0;
-  u.t.b54 = fptr[54] < 0;
-  u.t.b55 = fptr[55] < 0;
-  u.t.b56 = fptr[56] < 0;
-  u.t.b57 = fptr[57] < 0;
-  u.t.b58 = fptr[58] < 0;
-  u.t.b59 = fptr[59] < 0;
-  u.t.b60 = fptr[60] < 0;
-  u.t.b61 = fptr[61] < 0;
-  u.t.b62 = fptr[62] < 0;
-  u.t.b63 = fptr[63] < 0;
-  *buf = u.u64;
+  bf_i32 i;
+  i.t.b0 = fptr[0] < 0;
+  i.t.b1 = fptr[1] < 0;
+  i.t.b2 = fptr[2] < 0;
+  i.t.b3 = fptr[3] < 0;
+  i.t.b4 = fptr[4] < 0;
+  i.t.b5 = fptr[5] < 0;
+  i.t.b6 = fptr[6] < 0;
+  i.t.b7 = fptr[7] < 0;
+  i.t.b8 = fptr[8] < 0;
+  i.t.b9 = fptr[9] < 0;
+  i.t.b10 = fptr[10] < 0;
+  i.t.b11 = fptr[11] < 0;
+  i.t.b12 = fptr[12] < 0;
+  i.t.b13 = fptr[13] < 0;
+  i.t.b14 = fptr[14] < 0;
+  i.t.b15 = fptr[15] < 0;
+  i.t.b16 = fptr[16] < 0;
+  i.t.b17 = fptr[17] < 0;
+  i.t.b18 = fptr[18] < 0;
+  i.t.b19 = fptr[19] < 0;
+  i.t.b20 = fptr[20] < 0;
+  i.t.b21 = fptr[21] < 0;
+  i.t.b22 = fptr[22] < 0;
+  i.t.b23 = fptr[23] < 0;
+  i.t.b24 = fptr[24] < 0;
+  i.t.b25 = fptr[25] < 0;
+  i.t.b26 = fptr[26] < 0;
+  i.t.b27 = fptr[27] < 0;
+  i.t.b28 = fptr[28] < 0;
+  i.t.b29 = fptr[29] < 0;
+  i.t.b30 = fptr[30] < 0;
+  i.t.b31 = fptr[31] < 0;
+  *buf = i.i32;
 }
 
 // Helper function
-template <class TIn, class TOut>
-inline void pack_bitfield(const TIn* in, TOut* out,
+template <class TIn>
+inline void pack_bitfield(const TIn* in, TBitpacked* out,
                           const std::int32_t zero_point) {
   // Note: The expressions in these if-statements are known at compile-time so
   // they are all optimied away
@@ -330,84 +132,70 @@ inline void pack_bitfield(const TIn* in, TOut* out,
     pack(in, out);
 }
 
-template <class TIn, class TOut>
+template <class TIn>
 inline void packbits_array(const TIn* input_array, const std::size_t n,
-                           TOut* bitpacked_array,
+                           TBitpacked* bitpacked_array,
                            const std::int32_t zero_point) {
-  constexpr std::size_t bitwidth = std::numeric_limits<TOut>::digits;
-
-  int num_packed_elems = n / bitwidth;
-  int elements_left = n - bitwidth * num_packed_elems;
+  int num_packed_elems = n / bitpacking_bitwidth;
+  int elements_left = n - bitpacking_bitwidth * num_packed_elems;
 
   const TIn* in = input_array;
-  TOut* out = bitpacked_array;
+  TBitpacked* out = bitpacked_array;
 
 #ifdef __aarch64__
   if (FLATBUFFERS_LITTLEENDIAN && std::is_same<TIn, float>::value &&
-      std::is_same<TOut, std::uint64_t>::value && zero_point == 0) {
-    packbits_aarch64_64(reinterpret_cast<const float*>(in), num_packed_elems,
-                        reinterpret_cast<std::uint64_t*>(out));
-    in += bitwidth * num_packed_elems;
-    out += num_packed_elems;
-  } else {
-    while (num_packed_elems--) {
-      pack_bitfield(in, out++, zero_point);
-      in += bitwidth;
-    }
-  }
-#else
-  while (num_packed_elems--) {
-    pack_bitfield(in, out++, zero_point);
-    in += bitwidth;
+      zero_point == 0) {
+    const int num_4x32_blocks = num_packed_elems / 4;
+    packbits_aarch64_4x32(reinterpret_cast<const float*>(in), num_4x32_blocks,
+                          out);
+    in += bitpacking_bitwidth * 4 * num_4x32_blocks;
+    out += 4 * num_4x32_blocks;
+    num_packed_elems %= 4;
   }
 #endif
+  while (num_packed_elems--) {
+    pack_bitfield(in, out++, zero_point);
+    in += bitpacking_bitwidth;
+  }
 
   // If padding is needed, copy the remaining elements to a buffer and add
-  // enough zeros to fill the bitwidth. This function assumes enough memory for
-  // padding is already allocated in the output array `bitpacked_array`.
+  // enough zeros to fill the bitpacking_bitwidth. This function assumes enough
+  // memory for padding is already allocated in the output array
+  // `bitpacked_array`.
   if (elements_left != 0) {
-    std::array<TIn, bitwidth> padding_buffer = {{0}};
+    std::array<TIn, bitpacking_bitwidth> padding_buffer = {{0}};
     memcpy(padding_buffer.data(), in, elements_left * sizeof(TIn));
-    for (size_t i = elements_left; i < bitwidth; ++i)
+    for (size_t i = elements_left; i < bitpacking_bitwidth; ++i)
       padding_buffer[i] = zero_point;
     pack_bitfield(padding_buffer.data(), out, zero_point);
   }
 }
 
 // Bitpacks each row of a row-major matrix
-template <class TIn, class TOut_>
+template <class TIn>
 inline void packbits_matrix(const TIn* input, const std::size_t input_num_rows,
-                            const std::size_t input_num_cols, TOut_* output,
+                            const std::size_t input_num_cols,
+                            TBitpacked* output,
                             const std::int32_t zero_point = 0) {
-  // Force the types to be unsigned so that the function can be called on signed
-  // types as well
-  using TOut = typename std::make_unsigned<TOut_>::type;
-
-  constexpr std::size_t bitwidth = std::numeric_limits<TOut>::digits;
-
-  const TIn* input_ptr = input;
-  TOut* output_ptr = reinterpret_cast<TOut*>(output);
-
-  if (input_num_cols % bitwidth == 0) {
+  if (input_num_cols % bitpacking_bitwidth == 0) {
     // If each row can be bitpacked without any padding, then we can treat
     // the matrix as one flat array and bitpack it all in one go.
-    packbits_array(input_ptr, input_num_cols * input_num_rows, output_ptr,
-                   zero_point);
+    packbits_array(input, input_num_cols * input_num_rows, output, zero_point);
   } else {
     // Calculate the size of the bitpacked rows
-    const std::size_t output_num_cols = GetPackedSize<TOut>(input_num_cols);
+    const std::size_t output_num_cols = GetPackedSize(input_num_cols);
 
     // Iterate through each row of the input matrix and bitpack the row into the
     // corresponding memory location of the output matrix
     for (size_t row_index = 0; row_index < input_num_rows; ++row_index) {
-      packbits_array(input_ptr, input_num_cols, output_ptr, zero_point);
-      input_ptr += input_num_cols;
-      output_ptr += output_num_cols;
+      packbits_array(input, input_num_cols, output, zero_point);
+      input += input_num_cols;
+      output += output_num_cols;
     }
   }
 }
 
-template <typename TBitpacked, typename TUnpacked>
+template <typename TUnpacked>
 void unpack_bitfield(const TBitpacked in, TUnpacked*& out,
                      std::size_t num_elements) {
   for (size_t i = 0; i < num_elements; ++i) {
@@ -419,21 +207,18 @@ void unpack_bitfield(const TBitpacked in, TUnpacked*& out,
 // Every row is bitpacked as TBitpacked, with canonical order
 // The argument `num_cols` is the *unpacked* number of cols!
 // Enough output memory is assumed.
-template <typename TBitpacked, typename TUnpacked>
+template <typename TUnpacked>
 inline void unpack_matrix(const TBitpacked* input_data,
                           const std::size_t num_rows,
                           const std::size_t num_cols, TUnpacked* output_data) {
-  constexpr std::size_t bitwidth = std::numeric_limits<
-      typename std::make_unsigned<TBitpacked>::type>::digits;
-
   const TBitpacked* in_ptr = input_data;
   TUnpacked* out_ptr = output_data;
   for (size_t row_index = 0; row_index < num_rows; ++row_index) {
-    int num_full_blocks = num_cols / bitwidth;
-    int elements_left = num_cols - bitwidth * num_full_blocks;
+    int num_full_blocks = num_cols / bitpacking_bitwidth;
+    int elements_left = num_cols - bitpacking_bitwidth * num_full_blocks;
 
     while (num_full_blocks--) {
-      unpack_bitfield(*in_ptr++, out_ptr, bitwidth);
+      unpack_bitfield(*in_ptr++, out_ptr, bitpacking_bitwidth);
     }
 
     if (elements_left != 0) {

--- a/larq_compute_engine/core/packbits_utils.h
+++ b/larq_compute_engine/core/packbits_utils.h
@@ -10,20 +10,17 @@ namespace compute_engine {
 namespace ce = compute_engine;
 namespace core {
 
-template <typename TBitpacked>
-int GetPackedTensorSize(const RuntimeShape& shape) {
-  constexpr auto bitwidth = std::numeric_limits<
-      typename std::make_unsigned<TBitpacked>::type>::digits;
+inline int GetPackedTensorSize(const RuntimeShape& shape) {
   const int dims = shape.DimensionsCount();
   // Pack the tensor along the last dimension
   const int rows = FlatSizeSkipDim(shape, dims - 1);
   const int cols = shape.Dims(dims - 1);
-  return ce::core::GetPackedMatrixSize(rows, cols, bitwidth);
+  return ce::core::GetPackedMatrixSize(rows, cols);
 }
 
 // Convenience function for bitpacking a tensor along its last dimension
 // and updating the tensor shape
-template <class T, class TBitpacked>
+template <class T>
 inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
                             const std::int32_t zero_point,
                             RuntimeShape& out_shape, TBitpacked* out_data) {
@@ -35,17 +32,14 @@ inline void packbits_tensor(const RuntimeShape& in_shape, const T* in_data,
   ce::core::packbits_matrix(in_data, rows, cols, out_data, zero_point);
 
   out_shape.ReplaceWith(dims, in_shape.DimsData());
-  out_shape.SetDim(dims - 1, GetPackedSize<TBitpacked>(cols));
+  out_shape.SetDim(dims - 1, GetPackedSize(cols));
 }
 
 // Convenience function for going from a shape to the packed shape
-template <class TBitpacked>
-RuntimeShape packed_shape(const RuntimeShape& in_shape) {
-  constexpr auto bitwidth = std::numeric_limits<TBitpacked>::digits;
+inline RuntimeShape packed_shape(const RuntimeShape& in_shape) {
   const int dims = in_shape.DimensionsCount();
   RuntimeShape out_shape(in_shape);
-  out_shape.SetDim(dims - 1,
-                   (in_shape.Dims(dims - 1) + bitwidth - 1) / bitwidth);
+  out_shape.SetDim(dims - 1, GetPackedSize(in_shape.Dims(dims - 1)));
   return out_shape;
 }
 

--- a/larq_compute_engine/core/tests/BUILD
+++ b/larq_compute_engine/core/tests/BUILD
@@ -6,7 +6,6 @@ cc_test(
     name = "bgemm_tests",
     size = "small",
     srcs = ["bgemm_tests.cc"],
-    copts = ["-Iext/gtest/include"],
     deps = [
         "//larq_compute_engine/core:bgemm_functor",
         "@com_google_googletest//:gtest_main",
@@ -17,9 +16,16 @@ cc_test(
     name = "packbits_tests",
     size = "small",
     srcs = ["packbits_tests.cc"],
-    copts = ["-Iext/gtest/include"],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:windows": [],
+        "//conditions:default": [
+            "-lm",
+            "-lrt",
+        ],
+    }),
     deps = [
         "//larq_compute_engine/core:packbits",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -38,7 +44,6 @@ cc_test(
     name = "packbits_aarch64_tests",
     size = "small",
     srcs = ["packbits_aarch64_tests.cc"],
-    copts = ["-Iexternal/gtest/include"],
     deps = [
         "//larq_compute_engine/core:packbits",
         "@com_google_googletest//:gtest_main",

--- a/larq_compute_engine/core/tests/bgemm_tests.cc
+++ b/larq_compute_engine/core/tests/bgemm_tests.cc
@@ -8,20 +8,20 @@ namespace compute_engine {
 namespace testing {
 
 namespace ce = compute_engine;
+using ce::core::bitpacking_bitwidth;
 using ce::core::Layout;
+using ce::core::TBitpacked;
 
-template <class TIn, class TOut>
-void test_binary_inner_prod() {
-  const auto a = static_cast<TIn>(0b11101110);
-  const auto b = static_cast<TIn>(0b11111101);
-  // a and b are off by three bits so POP_CNT(a XOR b) = 3
-  const auto expected =
-      static_cast<TOut>(std::numeric_limits<TIn>::digits - 2 * 3);
-  auto c = ce::core::compute_binary_inner_prod<TIn, TOut>(a, b);
+TEST(BGemmTests, BinaryInnerProd) {
+  const auto a = static_cast<TBitpacked>(0b01101110000111111101011001101000);
+  const auto b = static_cast<TBitpacked>(0b01100110000110111001011011101001);
+  // a and b are off by five bits so POP_CNT(a XOR b) = 5
+  const auto expected = static_cast<std::int32_t>(bitpacking_bitwidth - 2 * 5);
+  auto c = ce::core::compute_binary_inner_prod(a, b);
   EXPECT_EQ(c, expected);
 }
 
-template <class TIn, class TOut, class TBgemmFunctor, int m, int n, int k>
+template <class TBgemmFunctor, int m, int n, int k>
 void test_bgemm() {
   const int lda = k;
   const int ldb = n;
@@ -31,89 +31,43 @@ void test_bgemm() {
   const int b_size = k * n;
   const int c_size = m * n;
 
-  std::array<TIn, a_size> a;
+  std::array<TBitpacked, a_size> a;
   a.fill(1);
 
-  std::array<TIn, b_size> b;
+  std::array<TBitpacked, b_size> b;
   b.fill(1);
 
   // each row of matrix "a" and column of "b" contains k same values so
   // a[i, k] XOR b[k, j] = 0 and therefore
-  // c[i, j] = k * (std::numeric_limits<TIn>::digits - 2 * POP_CNT(0))
-  TOut expected_value = k * std::numeric_limits<TIn>::digits;
-  std::array<TOut, c_size> expected;
+  // c[i, j] = k * (bitpacking_bitwidth - 2 * POP_CNT(0))
+  std::int32_t expected_value = k * bitpacking_bitwidth;
+  std::array<std::int32_t, c_size> expected;
   expected.fill(expected_value);
 
-  std::array<TOut, c_size> c;
+  std::array<std::int32_t, c_size> c;
   TBgemmFunctor bgemm_functor;
   bgemm_functor(m, n, k, a.data(), lda, b.data(), ldb, c.data(), ldc);
   EXPECT_THAT(c, ::testing::ElementsAreArray(expected));
 }
 
-TEST(BGemmTests, BinaryInnerProdUInt8) {
-  using TIn = std::uint8_t;
-  using TOut = std::int32_t;
-  test_binary_inner_prod<TIn, TOut>();
-}
-
-TEST(BGemmTests, BinaryInnerProdUInt32) {
-  using TIn = std::uint32_t;
-  using TOut = std::int32_t;
-  test_binary_inner_prod<TIn, TOut>();
-}
-
-TEST(BGemmTests, BinaryInnerProdUInt64) {
-  using TIn = std::uint64_t;
-  using TOut = std::int32_t;
-  test_binary_inner_prod<TIn, TOut>();
-}
-
-TEST(BGemmTests, BGemmTestUInt8) {
-  using TIn = std::uint8_t;
-  using TOut = std::int32_t;
+TEST(BGemmTests, BGemmTestRowMajor) {
   using BGemmFunctor =
-      ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
-                                      Layout::RowMajor, TOut>;
+      ce::core::ReferenceBGemmFunctor<Layout::RowMajor, Layout::RowMajor,
+                                      std::int32_t>;
   const int m = 20;
   const int k = 200;
   const int n = 30;
-  test_bgemm<TIn, TOut, BGemmFunctor, m, n, k>();
+  test_bgemm<BGemmFunctor, m, n, k>();
 }
 
-TEST(BGemmTests, BGemmTestUInt32) {
-  using TIn = std::uint32_t;
-  using TOut = std::int32_t;
+TEST(BGemmTests, BGemmTestColMajor) {
   using BGemmFunctor =
-      ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
-                                      Layout::RowMajor, TOut>;
+      ce::core::ReferenceBGemmFunctor<Layout::RowMajor, Layout::ColMajor,
+                                      std::int32_t>;
   const int m = 20;
   const int k = 200;
   const int n = 30;
-  test_bgemm<TIn, TOut, BGemmFunctor, m, n, k>();
-}
-
-TEST(BGemmTests, BGemmTestUInt64) {
-  using TIn = std::uint64_t;
-  using TOut = std::int32_t;
-  using BGemmFunctor =
-      ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
-                                      Layout::RowMajor, TOut>;
-  const int m = 20;
-  const int k = 200;
-  const int n = 30;
-  test_bgemm<TIn, TOut, BGemmFunctor, m, n, k>();
-}
-
-TEST(BGemmTests, BGemmTestUInt64ColMajor) {
-  using TIn = std::uint64_t;
-  using TOut = std::int32_t;
-  using BGemmFunctor =
-      ce::core::ReferenceBGemmFunctor<TIn, Layout::RowMajor, TIn,
-                                      Layout::ColMajor, TOut>;
-  const int m = 20;
-  const int k = 200;
-  const int n = 30;
-  test_bgemm<TIn, TOut, BGemmFunctor, m, n, k>();
+  test_bgemm<BGemmFunctor, m, n, k>();
 }
 
 }  // end namespace testing

--- a/larq_compute_engine/core/tests/packbits_aarch64_tests.cc
+++ b/larq_compute_engine/core/tests/packbits_aarch64_tests.cc
@@ -6,19 +6,19 @@
 
 #include "larq_compute_engine/core/packbits.h"
 #include "larq_compute_engine/core/packbits_aarch64.h"
+#include "larq_compute_engine/core/types.h"
 
 namespace compute_engine {
 namespace testing {
 
 using namespace compute_engine::core;
 
-template <void (*packing_func)(const float*, std::size_t, std::uint64_t*),
-          std::size_t block_size, std::size_t num_blocks>
-void test_bitpacking() {
-  constexpr std::size_t n = block_size * num_blocks;
+void test_bitpacking(int num_4x32_blocks) {
+  const int num_blocks = 4 * num_4x32_blocks;
+  const int n = 32 * num_blocks;
 
   float input[n];
-  std::uint64_t output[num_blocks];
+  TBitpacked output[num_blocks];
   for (auto i = 0; i < n; ++i) {
     // Try to get the position of bit i by packing the one-hot vector e_i
     for (auto j = 0; j < n; ++j) {
@@ -28,18 +28,19 @@ void test_bitpacking() {
         input[j] = 1.2345f;
     }
     // Run bitpacking
-    packing_func(input, num_blocks, output);
+    packbits_aarch64_4x32(input, num_blocks, output);
     // See where in the output the bit has popped up
     int bit_index = -1;
     int bits_found = 0;
     for (auto j = 0; j < num_blocks; ++j) {
-      for (auto k = 0; k < block_size; ++k) {
+      for (auto k = 0; k < 32; ++k) {
         if (output[j] & (1uL << k)) {
-          bit_index = k + j * block_size;
+          bit_index = k + j * 32;
           bits_found++;
         }
       }
     }
+
     // We should have exactly one enabled bit...
     EXPECT_EQ(bits_found, 1);
     // ...and it should be in the i^th position.
@@ -47,17 +48,11 @@ void test_bitpacking() {
   }
 }
 
-TEST(BitpackingAarch64, 1x64) { test_bitpacking<packbits_aarch64_64, 64, 1>(); }
-TEST(BitpackingAarch64, 2x64) { test_bitpacking<packbits_aarch64_64, 64, 2>(); }
-TEST(BitpackingAarch64, 3x64) { test_bitpacking<packbits_aarch64_64, 64, 3>(); }
-TEST(BitpackingAarch64, 4x64) { test_bitpacking<packbits_aarch64_64, 64, 4>(); }
-TEST(BitpackingAarch64, 8x64) { test_bitpacking<packbits_aarch64_64, 64, 8>(); }
-TEST(BitpackingAarch64, 17x64) {
-  test_bitpacking<packbits_aarch64_64, 64, 17>();
-}
-TEST(BitpackingAarch64, 23x64) {
-  test_bitpacking<packbits_aarch64_64, 64, 23>();
-}
+TEST(BitpackingAarch64, 1x4x32) { test_bitpacking(1); }
+TEST(BitpackingAarch64, 2x4x32) { test_bitpacking(2); }
+TEST(BitpackingAarch64, 3x4x32) { test_bitpacking(3); }
+TEST(BitpackingAarch64, 11x4x32) { test_bitpacking(11); }
+TEST(BitpackingAarch64, 17x4x32) { test_bitpacking(17); }
 
 }  // end namespace testing
 }  // end namespace compute_engine

--- a/larq_compute_engine/core/types.h
+++ b/larq_compute_engine/core/types.h
@@ -1,8 +1,17 @@
 #ifndef COMPUTE_ENGINE_CORE_TYPES_H_
 #define COMPUTE_ENGINE_CORE_TYPES_H_
 
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
 namespace compute_engine {
 namespace core {
+
+// Define these once here, so they can be included everywhere.
+using TBitpacked = std::int32_t;
+constexpr std::size_t bitpacking_bitwidth =
+    std::numeric_limits<typename std::make_unsigned<TBitpacked>::type>::digits;
 
 // defines the memory layout of the filter values
 enum class FilterFormat { Unknown, HWIO, OHWI, OHWI_PACKED };

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -176,6 +176,7 @@ cc_library(
     ],
     deps = [
         ":larq_compute_engine",
+        "//larq_compute_engine/core:types",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
@@ -195,6 +196,7 @@ cc_library(
     deps = [
         ":larq_compute_engine",
         "//larq_compute_engine/core:packbits",
+        "//larq_compute_engine/core:types",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -31,7 +31,7 @@ cc_library(
         "bconv2d_params.h",
     ],
     deps = [
-        "//larq_compute_engine/core:utils",
+        "//larq_compute_engine/core:types",
     ],
 )
 
@@ -43,6 +43,7 @@ cc_library(
     deps = [
         ":bconv2d_params",
         "//larq_compute_engine/core:bconv2d_output_transform",
+        "//larq_compute_engine/core:types",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
     ],
 )
@@ -64,6 +65,7 @@ cc_library(
         ":bconv2d_params",
         "//larq_compute_engine/core:bconv2d_impl_ref",
         "//larq_compute_engine/core:bmaxpool",
+        "//larq_compute_engine/core:packbits",
         "@flatbuffers",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/c:c_api_internal",

--- a/larq_compute_engine/tflite/kernels/bconv2d_output_transform_utils.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_output_transform_utils.h
@@ -1,8 +1,9 @@
 #ifndef LARQ_COMPUTE_ENGINE_TFLITE_KERNELS_BCONV2D_OUTPUT_TRANSFORM_SETUP
 #define LARQ_COMPUTE_ENGINE_TFLITE_KERNELS_BCONV2D_OUTPUT_TRANSFORM_SETUP
 
-#include "bconv2d_params.h"
 #include "larq_compute_engine/core/bconv2d_output_transform.h"
+#include "larq_compute_engine/core/types.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_params.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 
@@ -47,11 +48,11 @@ void GetOutputTransform(TfLiteContext* context, TfLiteNode* node,
       GetTensorData<float>(post_activation_bias);
 }
 
-// Fill the OutputTransform values for bitpacked int32 outputs
+// Fill the OutputTransform values for bitpacked outputs
 template <typename AccumScalar>
 void GetOutputTransform(
     TfLiteContext* context, TfLiteNode* node, TfLiteBConv2DParams* params,
-    OutputTransform<AccumScalar, std::int32_t>& output_transform) {
+    OutputTransform<AccumScalar, TBitpacked>& output_transform) {
   const auto* thresholds = GetInput(context, node, 4);
   output_transform.thresholds = GetTensorData<AccumScalar>(thresholds);
 }

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -77,7 +77,6 @@ typedef struct {
   std::vector<std::uint8_t> filter_packed;
   bool is_filter_repacked = false;
 
-  int bitpacking_bitwidth;
   bool read_bitpacked_input = false;
   bool write_bitpacked_output = false;
 

--- a/larq_compute_engine/tflite/kernels/bmaxpool.cc
+++ b/larq_compute_engine/tflite/kernels/bmaxpool.cc
@@ -17,7 +17,7 @@ namespace compute_engine {
 namespace tflite {
 namespace bmaxpool {
 
-using TBitpacked = std::uint32_t;
+using ce::core::TBitpacked;
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   auto* poolparams = new ce::ref::BMaxPoolParams{};
@@ -55,7 +55,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   int channels_out = 0;
   if (input->type == kTfLiteFloat32 || input->type == kTfLiteInt8) {
-    channels_out = ce::core::GetPackedSize<TBitpacked>(input->dims->data[3]);
+    channels_out = ce::core::GetPackedSize(input->dims->data[3]);
   } else {
     TF_LITE_ENSURE_EQ(context, input->type, kTfLiteInt32);
     channels_out = input->dims->data[3];

--- a/larq_compute_engine/tflite/tests/BUILD
+++ b/larq_compute_engine/tflite/tests/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "utils.h",
     ],
     deps = [
+        "//larq_compute_engine/core:types",
         "@org_tensorflow//tensorflow/lite/kernels/internal:types",
     ],
 )

--- a/larq_compute_engine/tflite/tests/bconv2d_int8_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_int8_test.cc
@@ -7,9 +7,9 @@ namespace compute_engine {
 namespace tflite {
 namespace testing {
 
-TEST(BConv2DTests, Int8ErrorTest) {
+TEST(BConv2DTests, Int8ErrorDeathTest) {
   LceTensor<std::int8_t> input_tensor({1, 16, 16, 64});
-  LceTensor<std::int32_t> packed_filter_tensor({128, 3, 3, 64});
+  LceTensor<TBitpacked> packed_filter_tensor({128, 3, 3, 64});
   LceTensor<std::int8_t> post_tensor({128});
   LceTensor<std::int32_t> threshold_tensor;
   LceTensor<std::int8_t> output_tensor;
@@ -20,11 +20,11 @@ TEST(BConv2DTests, Int8ErrorTest) {
 
   EXPECT_DEATH(
       {
-        Int8_BConv2DOpModel m_lce(
-            compute_engine::tflite::Register_BCONV_2D_64_OPT, input_tensor,
-            packed_filter_tensor, output_tensor, post_tensor, post_tensor,
-            threshold_tensor, 64, 1, 1, Padding_SAME, 0,
-            ActivationFunctionType_NONE, 1, 1, 1);
+        Int8_BConv2DOpModel m_lce(compute_engine::tflite::Register_BCONV_2D_OPT,
+                                  input_tensor, packed_filter_tensor,
+                                  output_tensor, post_tensor, post_tensor,
+                                  threshold_tensor, 64, 1, 1, Padding_SAME, 0,
+                                  ActivationFunctionType_NONE, 1, 1, 1);
       },
       "8-bit quantization is only supported with valid or one-padding.");
 }
@@ -32,7 +32,7 @@ TEST(BConv2DTests, Int8ErrorTest) {
 TEST(BConv2DTests, Int8PostTest) {
   using T = std::int8_t;
   LceTensor<T> input_tensor({1, 2, 2, 2});
-  LceTensor<std::int32_t> packed_filter_tensor({4, 2, 2, 2});
+  LceTensor<TBitpacked> packed_filter_tensor({4, 2, 2, 2});
   LceTensor<T> post_tensor({4});
   LceTensor<std::int32_t> threshold_tensor;
   LceTensor<T> output_tensor;
@@ -47,11 +47,11 @@ TEST(BConv2DTests, Int8PostTest) {
   output_tensor.scale = 1.0f / 32.0f;
   output_tensor.zero_point = 0;
 
-  BConv2DOpModel<T, T, T> m_lce(
-      compute_engine::tflite::Register_BCONV_2D_64_OPT, input_tensor,
-      packed_filter_tensor, output_tensor, post_tensor, post_tensor,
-      threshold_tensor, 2, 1, 1, Padding_VALID, 0, ActivationFunctionType_NONE,
-      1, 1, 1);
+  BConv2DOpModel<T, T, T> m_lce(compute_engine::tflite::Register_BCONV_2D_OPT,
+                                input_tensor, packed_filter_tensor,
+                                output_tensor, post_tensor, post_tensor,
+                                threshold_tensor, 2, 1, 1, Padding_VALID, 0,
+                                ActivationFunctionType_NONE, 1, 1, 1);
 
   m_lce.SetInput({
       1, 1,   // batch = 0, y = 0, x = 0

--- a/larq_compute_engine/tflite/tests/bconv2d_op_model.h
+++ b/larq_compute_engine/tflite/tests/bconv2d_op_model.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "flatbuffers/flexbuffers.h"  // TF:flatbuffers
+#include "larq_compute_engine/core/types.h"
 #include "larq_compute_engine/tflite/tests/utils.h"
 #include "tensorflow/lite/kernels/test_util.h"
 
@@ -12,15 +13,11 @@ using namespace tflite;
 namespace compute_engine {
 namespace tflite {
 
-TfLiteRegistration* Register_BCONV_2D_64_OPT();
+TfLiteRegistration* Register_BCONV_2D_OPT();
 
 namespace testing {
 
-// Use the same bitwidth as the MLIR converter
-// Since tflite does not have an unsigned 32-bit int type
-// we have to use the signed type here or it will throw errors.
-using PackedFilterType = std::int32_t;
-constexpr std::size_t packed_bitwidth = 32;
+using compute_engine::core::TBitpacked;
 
 typedef TfLiteRegistration* (*register_function)(void);
 
@@ -79,7 +76,7 @@ class BConv2DOpModel : public BaseBConv2DOpModel {
  public:
   using BaseBConv2DOpModel::BaseBConv2DOpModel;
 
-  void SetFilter(const std::vector<PackedFilterType>& f) {
+  void SetFilter(const std::vector<TBitpacked>& f) {
     PopulateTensor(filter_, f);
   }
 

--- a/larq_compute_engine/tflite/tests/bmaxpool_test.cc
+++ b/larq_compute_engine/tflite/tests/bmaxpool_test.cc
@@ -2,6 +2,7 @@
 
 #include "flatbuffers/flexbuffers.h"  // TF:flatbuffers
 #include "larq_compute_engine/core/packbits_utils.h"
+#include "larq_compute_engine/core/types.h"
 #include "larq_compute_engine/tflite/tests/utils.h"
 #include "tensorflow/lite/kernels/test_util.h"
 
@@ -50,9 +51,6 @@ class PoolingOpModel : public BasePoolingOpModel {
   std::vector<T> GetOutput() { return ExtractVector<T>(output_); }
   std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
 };
-
-// We cannot use `uint32` here because the tflite tenor type requires int32
-using TBitpacked = std::int32_t;
 
 typedef TfLiteRegistration* (*register_function)(void);
 
@@ -157,7 +155,7 @@ class BMaxPoolOpTest : public ::testing::TestWithParam<TestParamTuple> {};
 TEST_P(BMaxPoolOpTest, FloatAndBinaryInput) {
   TestParam params(GetParam());
 
-  int packed_input_depth = GetPackedSize<TBitpacked>(params.input_depth);
+  int packed_input_depth = GetPackedSize(params.input_depth);
 
   LceTensor<float> input_tensor({params.input_batch_count, params.input_height,
                                  params.input_width, params.input_depth});
@@ -212,7 +210,7 @@ TEST_P(BMaxPoolOpTest, FloatAndBinaryInput) {
   // Bitpack the tflite output
   RuntimeShape out_shape = GetShape(m_builtin.GetOutputShape());
   std::vector<TBitpacked> builtin_output_data_bp(
-      GetPackedTensorSize<TBitpacked>(out_shape));
+      GetPackedTensorSize(out_shape));
   RuntimeShape packed_out_shape;
   packbits_tensor(out_shape, m_builtin.GetOutput().data(), 0, packed_out_shape,
                   builtin_output_data_bp.data());
@@ -229,7 +227,7 @@ TEST_P(BMaxPoolOpTest, FloatAndBinaryInput) {
 TEST_P(BMaxPoolOpTest, Int8Input) {
   TestParam params(GetParam());
 
-  int packed_input_depth = GetPackedSize<TBitpacked>(params.input_depth);
+  int packed_input_depth = GetPackedSize(params.input_depth);
 
   LceTensor<std::int8_t> input_tensor({params.input_batch_count,
                                        params.input_height, params.input_width,
@@ -279,7 +277,7 @@ TEST_P(BMaxPoolOpTest, Int8Input) {
   // Bitpack the tflite output
   RuntimeShape out_shape = GetShape(m_builtin.GetOutputShape());
   std::vector<TBitpacked> builtin_output_data_bp(
-      GetPackedTensorSize<TBitpacked>(out_shape));
+      GetPackedTensorSize(out_shape));
   RuntimeShape packed_out_shape;
   packbits_tensor(out_shape, m_builtin.GetOutput().data(),
                   output_tensor.zero_point, packed_out_shape,

--- a/larq_compute_engine/tflite/tests/utils.h
+++ b/larq_compute_engine/tflite/tests/utils.h
@@ -5,10 +5,13 @@
 #include <random>
 #include <string>
 
+#include "larq_compute_engine/core/types.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/test_util.h"
 
 namespace tflite {
+
+using compute_engine::core::TBitpacked;
 
 constexpr int Padding_ONE = Padding_MAX + 1;
 
@@ -38,6 +41,8 @@ TfLitePadding GetTfLitePadding(enum Padding padding) {
       return kTfLitePaddingValid;
     case Padding_SAME:
       return kTfLitePaddingSame;
+    default:
+      return kTfLitePaddingUnknown;
   };
 }
 
@@ -48,6 +53,8 @@ TfLiteFusedActivation GetTfLiteActivation(
   } else if (activation == ActivationFunctionType_NONE) {
     return kTfLiteActNone;
   }
+  TFLITE_DCHECK(false);
+  return kTfLiteActNone;
 }
 
 // Helper for determining the type for the builtin convolution that we are
@@ -61,17 +68,17 @@ struct GetBuiltinType<float, float> {
 };
 
 template <>
-struct GetBuiltinType<std::int32_t, float> {
+struct GetBuiltinType<TBitpacked, float> {
   using type = float;
 };
 
 template <>
-struct GetBuiltinType<float, std::int32_t> {
+struct GetBuiltinType<float, TBitpacked> {
   using type = float;
 };
 
 template <>
-struct GetBuiltinType<std::int32_t, std::int32_t> {
+struct GetBuiltinType<TBitpacked, TBitpacked> {
   using type = float;
 };
 
@@ -81,12 +88,12 @@ struct GetBuiltinType<std::int8_t, std::int8_t> {
 };
 
 template <>
-struct GetBuiltinType<std::int8_t, std::int32_t> {
+struct GetBuiltinType<std::int8_t, TBitpacked> {
   using type = std::int8_t;
 };
 
 template <>
-struct GetBuiltinType<std::int32_t, std::int8_t> {
+struct GetBuiltinType<TBitpacked, std::int8_t> {
   using type = std::int8_t;
 };
 


### PR DESCRIPTION
## What do these changes do?

In LCE at the moment we support two different bitpacking types: uint32 and uint64. We use uint64 wherever possible, and uint32 otherwise. This used to make sense because we previously used a special optimised non-canonical 64-bit bitpacking procedure that was very fast on Aarch64. However, #443 removed non-canonical bitpacking (without performance loss), which laid the groundwork for switching completely from 64-bit bitpacking to 32-bit bitpacking. For the motivation for standardising on 32-bit bitpacking, see #446.

I'm very sorry for the size of this PR - it touches almost every file in the repo - but at least it removes twice as much code as it adds!

## Detailed changes

Concretely, this PR standardises on int32 - *not* uint32 - bitpacking. This is because TFLite doesn't have an unsigned 32-bit tensor type, but does have a signed 32-bit tensor type. Aligning with the TFLite tensor type makes some things such as bitpacked activations easier, and as we only perform bitwise operations on the bitpacked data, the sign of the datatype doesn't matter.

One nice benefit is that we now have only two opt registrations: `BCONV_2D_REF` and `BCONV_2D_OPT`.

Most of the code that's removed is function/struct templating that was previously necessary to support multiple bitpacking types. It was previously common to have a templated `TBitpacked` type parameter; this PR removes such templating, and instead defines a single, global `TBitpacked` in `types.h`, that is then imported anywhere the type definition is needed. This approach means that it should still be possible to change the bitpacking type in the future without too much trouble.

Additionally, a lot of code has been either simplified or stripped out if no longer relevant. This includes:
* The bitpacking code itself has been heavily simplified, including the bitpacking tests (which have mostly been re-written).
* Functions in `bconv2d.cc` that select the bitpacking type have been removed.
* Lots of assertions in the various kernel implementations that the LHS and RHS types had to be the same, et cetera (without datatype templating this doesn't make sense) have been removed.
* Code for handling 32-bit bitpacked data with uint64 optimised kernels has been removed.
* The optimised assembly kernels have been modified to accept int32 rather than uint64 inputs (this change is relatively minor; it mostly involves adjusting matrix depth calculations).
* Perhaps surprisingly, the `bgemm_functor` code (used in our reference kernel) and associated tests have also been heavily simplified, because there were previously function overloads for many different datatypes, which is now unnecessary.

## How Has This Been Tested?

The 'big' kernel tests that don't run on CI pass locally for Aarch64 and Arm32. The bitpacking tests have been re-written, as have the bgemm functor tests.

## Benchmark Results

This PR itself introduces a performance regression, because although our bitpacking and bgemm are as fast as ever, the Ruy 'packing' step is slower when the datatype is int32 (as opposed to uint64).

However, this PR should be viewed in conjunction with #462, which builds upon this PR to introduce optimised Ruy packing for int32 datatypes and in fact improves benchmark performance. Full benchmark results are in that PR (comparing against the master branch prior to this PR being merged).

## Related issue number

Closes #446.