### PR TITLE
Improve performance with optimised Ruy matrix packing.

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -118,6 +118,7 @@ cc_library(
     hdrs = [
         "bgemm_impl_ruy.h",
         "bgemm_trmul_params.h",
+        "ruy_pack.h",
     ],
     deps = [
         ":bgemm_kernels_ruy",

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -10,6 +10,7 @@
 #include "ruy/profiler/instrumentation.h"
 #include "tensorflow/lite/kernels/cpu_backend_context.h"
 #include "tensorflow/lite/kernels/cpu_backend_gemm_params.h"
+#include "tensorflow/lite/kernels/cpu_backend_gemm_ruy.h"
 
 using namespace tflite;
 using namespace tflite::cpu_backend_gemm;
@@ -38,17 +39,16 @@ struct BGemmImplUsingRuy {
 
     // Set up the matrix layouts and mul_params.
     ruy::Matrix<TBitpacked> lhs;
-    ruy::MakeSimpleLayout(lhs_params.rows, lhs_params.cols,
-                          ruy::Order::kRowMajor, lhs.mutable_layout());
     ruy::Matrix<TBitpacked> rhs;
-    ruy::MakeSimpleLayout(rhs_params.rows, rhs_params.cols,
-                          ruy::Order::kColMajor, rhs.mutable_layout());
     ruy::Matrix<DstScalar> dst;
-    ruy::MakeSimpleLayout(dst_params.rows, dst_params.cols,
-                          ruy::Order::kColMajor, dst.mutable_layout());
-    lhs.set_data(lhs_data);
-    rhs.set_data(rhs_data);
-    dst.set_data(dst_data);
+    // We allow these matrices to be cached. Note that this doesn't force them
+    // to be cached; it means that the `cache_policy` of the MatrixParams will
+    // be respected.
+    cpu_backend_gemm::detail::MakeRuyMatrix(lhs_params, lhs_data, &lhs,
+                                            /*use_caching=*/true);
+    cpu_backend_gemm::detail::MakeRuyMatrix(rhs_params, rhs_data, &rhs,
+                                            /*use_caching=*/true);
+    cpu_backend_gemm::detail::MakeRuyMatrix(dst_params, dst_data, &dst);
 
     // We have to make this a `const` matrix because otherwise gcc will try to
     // use the non-const versions of `matrix.data()`
@@ -63,13 +63,8 @@ struct BGemmImplUsingRuy {
 
     constexpr auto BGemmCompiledPaths = ruy::kAllPaths;
 
-    // avoid the reference path for production code
     ruy::Path bgemm_runtime_path = ruy_ctx->SelectPath(ruy::kAllPaths);
 
-    // fallback to standard cpp kernel for all architectures that are not
-    // supported yet.
-    // TODO: this needs to be modified as soon as architecture-specific
-    // optimized kernels are added.
 #if RUY_PLATFORM_ARM
     if (bgemm_runtime_path == ruy::Path::kNeonDotprod)
       bgemm_runtime_path = ruy::Path::kNeon;
@@ -79,12 +74,12 @@ struct BGemmImplUsingRuy {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
 #endif
 
-    // For writing bitpacked output, fallback to the standard C++ kernel.
+    // For now, writing bitpacked output only has a C++ implementation.
     if (std::is_same<DstScalar, TBitpacked>::value) {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
     }
 
-    // For now, int8 only has a C++ implementation.
+    // For now, int8 output only has a C++ implementation.
     if (std::is_same<DstScalar, std::int8_t>::value) {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
     }

--- a/larq_compute_engine/core/bgemm_trmul_params.h
+++ b/larq_compute_engine/core/bgemm_trmul_params.h
@@ -1,10 +1,10 @@
 #ifndef COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_TRMUL_PARAMS_H_
 #define COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_TRMUL_PARAMS_H_
 
-#include "bgemm_kernels_ruy.h"
+#include "larq_compute_engine/core/bgemm_kernels_ruy.h"
+#include "larq_compute_engine/core/ruy_pack.h"
 #include "ruy/dispatch.h"
 #include "ruy/mul_params.h"
-#include "ruy/pack_common.h"
 #include "ruy/path.h"
 #include "ruy/trmul_params.h"
 
@@ -35,21 +35,20 @@ void PopulateBinaryTrMulParams(ruy::TrMulParams* params) {
     return;
   }
 
-  using PackedTBitpacked = ruy::PackedType<ThePath, TBitpacked>;
   using Kernel = BgemmKernel<ThePath, DstScalar, MulParamsType>;
   using LhsKernelLayout = typename Kernel::LhsLayout;
   using RhsKernelLayout = typename Kernel::RhsLayout;
 
   params->path = ThePath;
 
-  CreatePackedMatrix<TBitpacked, PackedTBitpacked>(
+  CreatePackedMatrix<TBitpacked, TBitpacked>(
       Side::kLhs, ToKernelLayout<LhsKernelLayout>(), params);
-  CreatePackedMatrix<TBitpacked, PackedTBitpacked>(
+  CreatePackedMatrix<TBitpacked, TBitpacked>(
       Side::kRhs, ToKernelLayout<RhsKernelLayout>(), params);
   params->run_pack[Side::kLhs] =
-      &RunPack<ThePath, LhsKernelLayout, TBitpacked, PackedTBitpacked>;
+      &compute_engine::tflite::RunPack<ThePath, LhsKernelLayout>;
   params->run_pack[Side::kRhs] =
-      &RunPack<ThePath, RhsKernelLayout, TBitpacked, PackedTBitpacked>;
+      &compute_engine::tflite::RunPack<ThePath, RhsKernelLayout>;
   params->run_kernel = &RunBgemmKernel<ThePath, DstScalar, MulParamsType>;
 }
 

--- a/larq_compute_engine/core/ruy_pack.h
+++ b/larq_compute_engine/core/ruy_pack.h
@@ -1,0 +1,136 @@
+/*
+ * Ruy performs 'packing' of the LHS and RHS matrices before the GEMM operation,
+ * which involves re-arranging the matrices in memory to enable linear memory
+ * access patterns for the optimised assembly GEMM kernels. For more detail on
+ * the motivation for packing, see the the gemmlowp docs:
+ * https://github.com/google/gemmlowp/blob/master/doc/packing.md.
+ *
+ * Packing is part of the inference 'critical path' because although the packed
+ * weights matrix can be cached, the packed input activations cannot be. Ruy
+ * therefore includes optimised packing routines. However, these are specific to
+ * the datatypes (float and/or int8) and kernel-layouts used in the built-in Ruy
+ * kernels, which don't match those of our optimised LCE kernels. This means
+ * that if we rely on the Ruy packing code we end up falling back to the slow
+ * reference implementation that copies each element one-by-one.
+ *
+ * In our optimised LCE kernels, the LHS matrix is the weights and the RHS is
+ * the input activations. As the packed weights can be computed once then
+ * cached, we only care about optimising for packing the RHS. In all our
+ * optimised kernels, the RHS has a 4x4 column-major kernel layout; we therefore
+ * extend the Ruy packing with an optimised (but portable, C++) packing routine
+ * for 4x4 column-major kernel layouts.
+ */
+
+#include "larq_compute_engine/core/types.h"
+#include "ruy/pack_common.h"
+
+namespace compute_engine {
+namespace tflite {
+
+using compute_engine::core::TBitpacked;
+using namespace ruy;
+
+template <Path ThePath, typename FixedKernelLayout>
+struct LceRuyPackImpl
+    : PackImpl<ThePath, FixedKernelLayout, TBitpacked, TBitpacked, TBitpacked> {
+};
+
+template <Path ThePath>
+struct LceRuyPackImpl<ThePath, FixedKernelLayout<Order::kColMajor, 4, 4>> {
+  // This method is derived Ruy's 16x4 column-major int8 packing routine:
+  // https://github.com/google/ruy/blob/c9f5f9cecde3d6314df6e7d91517356bf07135eb/ruy/pack_arm.h#L122-L197
+  static void Run(Tuning, const Mat<TBitpacked>& src_matrix,
+                  PMat<TBitpacked>* packed_matrix, int start_col, int end_col) {
+    profiler::ScopeLabel label("Pack (ColMajor, 4x4)");
+
+    // Ruy supports collecting column sums during the packing process, which we
+    // have no need for.
+    RUY_DCHECK_EQ(packed_matrix->sums, nullptr);
+
+    // Likewise, Ruy supports arbitrary zero points, but we only use true-zero.
+    RUY_DCHECK_EQ(src_matrix.zero_point, 0);
+
+    RUY_DCHECK(IsColMajor(src_matrix.layout));
+    RUY_DCHECK(IsColMajor(packed_matrix->layout));
+    RUY_DCHECK_EQ(start_col % 4, 0);
+
+    TBitpacked zerobuf[4];
+    memset(zerobuf, 0, sizeof(zerobuf));
+
+    const int src_stride = src_matrix.layout.stride;
+
+    for (int block_col = start_col; block_col < end_col; block_col += 4) {
+      const TBitpacked* src_ptr0 =
+          src_matrix.data.get() + src_stride * block_col;
+      const TBitpacked* src_ptr1 = src_ptr0 + src_stride;
+      const TBitpacked* src_ptr2 = src_ptr1 + src_stride;
+      const TBitpacked* src_ptr3 = src_ptr2 + src_stride;
+      int src_inc0 = 4;
+      int src_inc1 = 4;
+      int src_inc2 = 4;
+      int src_inc3 = 4;
+      if (block_col >= src_matrix.layout.cols - 3) {
+        if (block_col >= src_matrix.layout.cols - 0) {
+          src_ptr0 = zerobuf;
+          src_inc0 = 0;
+        }
+        if (block_col >= src_matrix.layout.cols - 1) {
+          src_ptr1 = zerobuf;
+          src_inc1 = 0;
+        }
+        if (block_col >= src_matrix.layout.cols - 2) {
+          src_ptr2 = zerobuf;
+          src_inc2 = 0;
+        }
+        src_ptr3 = zerobuf;
+        src_inc3 = 0;
+      }
+      TBitpacked* packed_ptr =
+          packed_matrix->data + packed_matrix->layout.stride * block_col;
+      constexpr std::size_t packed_stride = 4;
+      constexpr std::size_t packed_stride_bytes = sizeof(TBitpacked) * 4;
+      for (int block_row = 0; block_row < src_matrix.layout.rows - 3;
+           block_row += 4) {
+        memcpy(packed_ptr, src_ptr0, packed_stride_bytes);
+        src_ptr0 += src_inc0;
+        memcpy(packed_ptr + packed_stride, src_ptr1, packed_stride_bytes);
+        src_ptr1 += src_inc1;
+        memcpy(packed_ptr + 2 * packed_stride, src_ptr2, packed_stride_bytes);
+        src_ptr2 += src_inc2;
+        memcpy(packed_ptr + 3 * packed_stride, src_ptr3, packed_stride_bytes);
+        src_ptr3 += src_inc3;
+        packed_ptr += 4 * packed_stride;
+      }
+      if (src_matrix.layout.rows % 4 != 0) {
+        const std::size_t non_zero_rows = src_matrix.layout.rows % 4;
+        const std::size_t non_zero_size = sizeof(TBitpacked) * non_zero_rows;
+        const std::size_t zero_size = packed_stride_bytes - non_zero_size;
+        memcpy(packed_ptr, src_ptr0, non_zero_size);
+        memset(packed_ptr + non_zero_rows, 0, zero_size);
+        packed_ptr += packed_stride;
+        memcpy(packed_ptr, src_ptr1, non_zero_size);
+        memset(packed_ptr + non_zero_rows, 0, zero_size);
+        packed_ptr += packed_stride;
+        memcpy(packed_ptr, src_ptr2, non_zero_size);
+        memset(packed_ptr + non_zero_rows, 0, zero_size);
+        packed_ptr += packed_stride;
+        memcpy(packed_ptr, src_ptr3, non_zero_size);
+        memset(packed_ptr + non_zero_rows, 0, zero_size);
+      }
+    }
+  }
+};
+
+// Derived from the function of the same name in Ruy:
+// https://github.com/google/ruy/blob/c9f5f9cecde3d6314df6e7d91517356bf07135eb/ruy/pack.h#L130-L140
+template <Path ThePath, typename FixedKernelLayout>
+void RunPack(Tuning tuning, const EMat& src_matrix, PEMat* packed_matrix,
+             int start_col, int end_col) {
+  Mat<TBitpacked> src = UneraseType<TBitpacked>(src_matrix);
+  PMat<TBitpacked> packed = UneraseType<TBitpacked>(*packed_matrix);
+  LceRuyPackImpl<ThePath, FixedKernelLayout>::Run(tuning, src, &packed,
+                                                  start_col, end_col);
+}
+
+}  // namespace tflite
+}  // namespace compute_engine

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -185,11 +185,16 @@ inline void BConv2D(
   lhs_params.order = cpu_backend_gemm::Order::kRowMajor;
   lhs_params.rows = n;
   lhs_params.cols = k;
+  // The LHS is the weights, which are static, so caching is prefered.
+  lhs_params.cache_policy = cpu_backend_gemm::CachePolicy::kAlwaysCache;
 
   cpu_backend_gemm::MatrixParams<TBitpacked> rhs_params;
   rhs_params.order = cpu_backend_gemm::Order::kColMajor;
   rhs_params.rows = k;
   rhs_params.cols = m;
+  // The RHS is the input activations, which change every inference, so there's
+  // no advantage from caching.
+  rhs_params.cache_policy = cpu_backend_gemm::CachePolicy::kNeverCache;
 
   cpu_backend_gemm::MatrixParams<DstScalar> dst_params;
   dst_params.order = cpu_backend_gemm::Order::kColMajor;


### PR DESCRIPTION
## What do these changes do?

This PR introduces an optimised Ruy 'packing' routine for 4x4 column-major kernel layouts. This is the kernel layout that is used for the RHS (input activations) matrix in all our optimised assembly kernels, and the Ruy packing for this layout currently falls back to slow reference code. The new packing routine therefore boosts Aarch64 and Arm32 performance.

This PR also enables caching of the packed LHS (weights) matrix. This is done by enabling the `use_caching` flag within our op, and setting the Ruy cache-policy to 'always cache' for the LHS matrix. Note that the RHS matrix would not benefit from caching because it is not static and changes every inference.

This PR should be viewed (and reviewed) in conjunction with #461, upon which it is re-based. Only the final commit is relevant.

## How Has This Been Tested?

CI.

## Benchmark Results

I have benchmarked and this PR and the baseline on my Android phone (a OnePlus 6) and a Raspberry Pi 4B. I used the LCE benchmark utility with `num_runs=250` and report the average and the standard-deviation.

It's important to note that the baseline used here is current master, prior to #461 (specifically, this commit: 30e9b02eceb).

#### OnePlus 6 (1 thread)

| Model         |    Baseline   |       PR      | Change |
|---------------|:-------------:|:-------------:|:------:|
| QuickNet      | 16.45 +- 0.05 | 14.58 +- 0.06 | -11.4% |
| QuickNetLarge | 24.03 +- 0.08 | 21.73 +- 0.08 | -9.6%  |
| QuickNetXL    | 42.03 +- 0.10 | 37.82 +- 0.08 | -10.0% |

#### OnePlus 6 (4 threads)

| Model         |    Baseline   |       PR      | Change |
|---------------|:-------------:|:-------------:|:------:|
| QuickNet      | 6.91 +- 0.23  | 6.39 +- 0.31  | -7.5%  |
| QuickNetLarge | 10.05 +- 0.38 | 9.47 +- 0.33  | -5.8%  |
| QuickNetXL    | 17.06 +- 0.38 | 16.05 +- 0.39 | -5.9%  |

#### Raspberry Pi 4B (1 thread)

| Model         |    Baseline   |       PR      | Change |
|---------------|:-------------:|:-------------:|:------:|
| QuickNet      | 31.68 +- 0.05 | 30.45 +- 0.05 | -3.9%  |
| QuickNetLarge | 48.25 +- 0.49 | 46.49 +- 0.08 | -3.6%  |
| QuickNetXL    | 83.76 +- 0.12 | 80.47 +- 0.19 | -3.9%  |

#### Raspberry Pi 4B (4 threads)

| Model         |    Baseline   |       PR      | Change |
|---------------|:-------------:|:-------------:|:------:|
| QuickNet      | 15.45 +- 0.05 | 14.94 +- 0.07 | -3.3%  |
| QuickNetLarge | 23.00 +- 0.07 | 22.20 +- 0.06 | -3.5%  |
| QuickNetXL    | 36.92 +- 0.11 | 35.41 +- 0.08 | -4.1%  |

There is a strong performance improvement. It is more pronounced on the OnePlus 6 than the Raspberry Pi, but significant on both. It's more than I was expecting!

For reference, the speed-up seems to be fairly evenly split between the new optimised packing routine and the LHS caching.

## Related issue number

N/A.