### PR TITLE
Change custom option enums to match flatbuffer schema

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -111,7 +111,7 @@ cc_library(
         "@flatbuffers",
         "@llvm-project//mlir:QuantOps",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
-        "@org_tensorflow//tensorflow/lite/c:common",
+        "@org_tensorflow//tensorflow/lite/schema:schema_fbs",
     ],
     alwayslink = 1,
 )

--- a/larq_compute_engine/mlir/ir/lce_ops.cc
+++ b/larq_compute_engine/mlir/ir/lce_ops.cc
@@ -1,24 +1,24 @@
 #include "larq_compute_engine/mlir/ir/lce_ops.h"
 
 #include "flatbuffers/flexbuffers.h"
-#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/schema/schema_generated.h"
 
 namespace mlir {
 namespace TF {
 
-static TfLitePadding ConvertTfLitePaddingAttr(llvm::StringRef str) {
-  return llvm::StringSwitch<TfLitePadding>(str)
-      .Case("SAME", kTfLitePaddingSame)
-      .Case("VALID", kTfLitePaddingValid);
+static tflite::Padding ConvertPaddingAttr(llvm::StringRef str) {
+  return llvm::StringSwitch<tflite::Padding>(str)
+      .Case("SAME", tflite::Padding_SAME)
+      .Case("VALID", tflite::Padding_VALID);
 }
 
-static TfLiteFusedActivation ConvertTfLiteFusedActivationAttr(
+static tflite::ActivationFunctionType ConvertActivationAttr(
     llvm::StringRef str) {
-  return llvm::StringSwitch<TfLiteFusedActivation>(str)
-      .Case("NONE", kTfLiteActNone)
-      .Case("RELU", kTfLiteActRelu)
-      .Case("RELU_N1_TO_1", kTfLiteActReluN1To1)
-      .Case("RELU6", kTfLiteActRelu6);
+  return llvm::StringSwitch<tflite::ActivationFunctionType>(str)
+      .Case("NONE", tflite::ActivationFunctionType_NONE)
+      .Case("RELU", tflite::ActivationFunctionType_RELU)
+      .Case("RELU_N1_TO_1", tflite::ActivationFunctionType_RELU_N1_TO_1)
+      .Case("RELU6", tflite::ActivationFunctionType_RELU6);
 }
 
 #define GET_OP_CLASSES
@@ -33,9 +33,9 @@ std::vector<uint8_t> Bconv2dOp::buildCustomOptions() {
     fbb.Int("dilation_height_factor", dilation_height_factor().getSExtValue());
     fbb.Int("dilation_width_factor", dilation_width_factor().getSExtValue());
     fbb.Int("fused_activation_function",
-            (int)ConvertTfLiteFusedActivationAttr(fused_activation_function()));
+            (int)ConvertActivationAttr(fused_activation_function()));
     fbb.Int("pad_values", pad_values().getSExtValue());
-    fbb.Int("padding", (int)ConvertTfLitePaddingAttr(padding()));
+    fbb.Int("padding", (int)ConvertPaddingAttr(padding()));
     fbb.Int("stride_height", stride_height().getSExtValue());
     fbb.Int("stride_width", stride_width().getSExtValue());
   });
@@ -46,7 +46,7 @@ std::vector<uint8_t> Bconv2dOp::buildCustomOptions() {
 std::vector<uint8_t> BMaxPool2dOp::buildCustomOptions() {
   flexbuffers::Builder fbb;
   fbb.Map([&]() {
-    fbb.Int("padding", (int)ConvertTfLitePaddingAttr(padding()));
+    fbb.Int("padding", (int)ConvertPaddingAttr(padding()));
     fbb.Int("stride_width", stride_width().getSExtValue());
     fbb.Int("stride_height", stride_height().getSExtValue());
     fbb.Int("filter_width", filter_width().getSExtValue());

--- a/larq_compute_engine/mlir/tests/BUILD
+++ b/larq_compute_engine/mlir/tests/BUILD
@@ -23,6 +23,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@flatbuffers",
         "@llvm-project//mlir:IR",
-        "@org_tensorflow//tensorflow/lite/c:common",
+        "@org_tensorflow//tensorflow/lite/schema:schema_fbs",
     ],
 )

--- a/larq_compute_engine/mlir/tests/lce_ops_options_test.cc
+++ b/larq_compute_engine/mlir/tests/lce_ops_options_test.cc
@@ -4,9 +4,10 @@
 #include "larq_compute_engine/mlir/ir/lce_ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OperationSupport.h"
-#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/schema/schema_generated.h"
 
 using namespace mlir;
+using namespace tflite;
 
 IntegerAttr getIntegerAttr(Builder builder, int value) {
   return builder.getIntegerAttr(builder.getIntegerType(32), value);
@@ -47,9 +48,9 @@ TEST(LCEOpsSerializationTest, BConv2dTest) {
   ASSERT_EQ(m["stride_height"].AsInt32(), 1);
   ASSERT_EQ(m["stride_width"].AsInt32(), 2);
   ASSERT_EQ(m["pad_values"].AsInt32(), 1);
-  ASSERT_EQ((TfLiteFusedActivation)m["fused_activation_function"].AsInt32(),
-            kTfLiteActRelu);
-  ASSERT_EQ((TfLitePadding)m["padding"].AsInt32(), kTfLitePaddingSame);
+  ASSERT_EQ((ActivationFunctionType)m["fused_activation_function"].AsInt32(),
+            ActivationFunctionType_RELU);
+  ASSERT_EQ((Padding)m["padding"].AsInt32(), Padding_SAME);
 }
 
 TEST(LCEOpsSerializationTest, BMaxPool2dTest) {
@@ -68,7 +69,7 @@ TEST(LCEOpsSerializationTest, BMaxPool2dTest) {
   std::vector<uint8_t> v = cast<TF::BMaxPool2dOp>(op).buildCustomOptions();
   const flexbuffers::Map& m = flexbuffers::GetRoot(v).AsMap();
 
-  ASSERT_EQ((TfLitePadding)m["padding"].AsInt32(), kTfLitePaddingSame);
+  ASSERT_EQ((Padding)m["padding"].AsInt32(), Padding_SAME);
   ASSERT_EQ(m["stride_width"].AsInt32(), 2);
   ASSERT_EQ(m["stride_height"].AsInt32(), 1);
   ASSERT_EQ(m["filter_width"].AsInt32(), 3);

--- a/larq_compute_engine/mlir/tests/legalize-lce.mlir
+++ b/larq_compute_engine/mlir/tests/legalize-lce.mlir
@@ -5,7 +5,7 @@ func @legalize_bconv2d(%arg0: tensor<256x32x32x3xf32>, %arg1: tensor<16x3x3x3xf3
   %0 = "lq.Bconv2d"(%arg0, %arg1, %arg2, %arg3, %arg4) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
   return %0 : tensor<256x30x30x16xf32>
 
-  // CHECK: %0 = "tfl.custom"(%arg0, %arg1, %arg2, %arg3, %arg4) {custom_code = "LceBconv2d", custom_option = opaque<"lq", "0x6368616E6E656C735F696E0064696C6174696F6E5F6865696768745F666163746F720064696C6174696F6E5F77696474685F666163746F720066757365645F61637469766174696F6E5F66756E6374696F6E007061645F76616C7565730070616464696E67007374726964655F686569676874007374726964655F776964746800088277614C3329221508010803010100000201010404040404040404102401"> : tensor<160xi8>} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
+  // CHECK: %0 = "tfl.custom"(%arg0, %arg1, %arg2, %arg3, %arg4) {custom_code = "LceBconv2d", custom_option = opaque<"lq", "0x6368616E6E656C735F696E0064696C6174696F6E5F6865696768745F666163746F720064696C6174696F6E5F77696474685F666163746F720066757365645F61637469766174696F6E5F66756E6374696F6E007061645F76616C7565730070616464696E67007374726964655F686569676874007374726964655F776964746800088277614C3329221508010803010100000101010404040404040404102401"> : tensor<160xi8>} : (tensor<256x32x32x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x30x30x16xf32>
   // CHECK-NEXT: return %0
 }
 
@@ -14,7 +14,7 @@ func @legalize_bmax_pool2d(%arg0: tensor<256x32x32x3xi32>) -> tensor<256x16x16x3
   %0 = "lq.BMaxPool2d"(%arg0) {filter_height = 2 : i32, filter_width = 2 : i32, padding = "SAME", stride_height = 2 : i32, stride_width = 2 : i32} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
   return %0 : tensor<256x16x16x3xi32>
 
-  // CHECK: %0 = "tfl.custom"(%arg0) {custom_code = "LceBMaxPool2d", custom_option = opaque<"lq", "0x70616464696E67007374726964655F7769647468007374726964655F6865696768740066696C7465725F77696474680066696C7465725F68656967687400050F1D412D3B050105020201020204040404040A2401"> : tensor<84xi8>} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
+  // CHECK: %0 = "tfl.custom"(%arg0) {custom_code = "LceBMaxPool2d", custom_option = opaque<"lq", "0x70616464696E67007374726964655F7769647468007374726964655F6865696768740066696C7465725F77696474680066696C7465725F68656967687400050F1D412D3B050105020200020204040404040A2401"> : tensor<84xi8>} : (tensor<256x32x32x3xi32>) -> tensor<256x16x16x3xi32>
   // CHECK-NEXT: return %0
 }
 

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -49,6 +49,20 @@ cc_library(
 )
 
 cc_library(
+    name = "utils",
+    srcs = [
+        "utils.cc",
+    ],
+    hdrs = [
+        "utils.h",
+    ],
+    deps = [
+        "@org_tensorflow//tensorflow/lite/c:common",
+        "@org_tensorflow//tensorflow/lite/schema:schema_fbs",
+    ],
+)
+
+cc_library(
     name = "lce_op_kernels",
     srcs = [
         "bconv2d.cc",
@@ -63,6 +77,7 @@ cc_library(
         ":bconv2d_impl",
         ":bconv2d_output_transform_utils",
         ":bconv2d_params",
+        ":utils",
         "//larq_compute_engine/core:bconv2d_impl_ref",
         "//larq_compute_engine/core:bitpack",
         "//larq_compute_engine/core:bmaxpool",

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -1,14 +1,15 @@
 #include <cmath>
 #include <cstdint>
 
-#include "bconv2d_impl.h"
-#include "bconv2d_output_transform_utils.h"
-#include "bconv2d_params.h"
-#include "flatbuffers/flexbuffers.h"  // TF:flatbuffers
+#include "flatbuffers/flexbuffers.h"
 #include "larq_compute_engine/core/bconv2d_impl_ref.h"
 #include "larq_compute_engine/core/bitpack.h"
 #include "larq_compute_engine/core/padding_functor.h"
 #include "larq_compute_engine/core/types.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_impl.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_output_transform_utils.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_params.h"
+#include "larq_compute_engine/tflite/kernels/utils.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api_internal.h"
 #include "tensorflow/lite/kernels/cpu_backend_context.h"
@@ -86,9 +87,9 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
   conv_params->dilation_height_factor = m["dilation_height_factor"].AsInt32();
   conv_params->dilation_width_factor = m["dilation_width_factor"].AsInt32();
 
-  conv_params->padding_type = (TfLitePadding)m["padding"].AsInt32();
-  conv_params->fused_activation_function =
-      (TfLiteFusedActivation)m["fused_activation_function"].AsInt32();
+  conv_params->padding_type = ConvertPadding((Padding)m["padding"].AsInt32());
+  conv_params->fused_activation_function = ConvertActivation(
+      (ActivationFunctionType)m["fused_activation_function"].AsInt32());
 
   conv_params->pad_value =
       m["pad_values"].IsNull() ? 0 : m["pad_values"].AsInt32();

--- a/larq_compute_engine/tflite/kernels/bmaxpool.cc
+++ b/larq_compute_engine/tflite/kernels/bmaxpool.cc
@@ -3,6 +3,7 @@
 
 #include "flatbuffers/flexbuffers.h"  // TF:flatbuffers
 #include "larq_compute_engine/core/bitpack_utils.h"
+#include "larq_compute_engine/tflite/kernels/utils.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api_internal.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
@@ -29,7 +30,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   poolparams->filter_width = m["filter_width"].AsInt32();
   poolparams->stride_height = m["stride_height"].AsInt32();
   poolparams->stride_width = m["stride_width"].AsInt32();
-  poolparams->padding_type = (TfLitePadding)m["padding"].AsInt32();
+  poolparams->padding_type = ConvertPadding((Padding)m["padding"].AsInt32());
 
   return poolparams;
 }

--- a/larq_compute_engine/tflite/kernels/utils.cc
+++ b/larq_compute_engine/tflite/kernels/utils.cc
@@ -1,0 +1,30 @@
+#include "larq_compute_engine/tflite/kernels/utils.h"
+
+namespace tflite {
+
+TfLiteFusedActivation ConvertActivation(ActivationFunctionType activation) {
+  switch (activation) {
+    case ActivationFunctionType_NONE:
+      return kTfLiteActNone;
+    case ActivationFunctionType_RELU:
+      return kTfLiteActRelu;
+    case ActivationFunctionType_RELU_N1_TO_1:
+      return kTfLiteActReluN1To1;
+    case ActivationFunctionType_RELU6:
+      return kTfLiteActRelu6;
+    default:
+      return kTfLiteActNone;
+  }
+}
+
+TfLitePadding ConvertPadding(Padding padding) {
+  switch (padding) {
+    case Padding_SAME:
+      return kTfLitePaddingSame;
+    case Padding_VALID:
+      return kTfLitePaddingValid;
+  }
+  return kTfLitePaddingUnknown;
+}
+
+}  // namespace tflite

--- a/larq_compute_engine/tflite/kernels/utils.h
+++ b/larq_compute_engine/tflite/kernels/utils.h
@@ -1,0 +1,17 @@
+#ifndef COMPUTE_ENGINE_TFLITE_KERNEL_UTILS_H
+#define COMPUTE_ENGINE_TFLITE_KERNEL_UTILS_H
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+
+// Converts the flatbuffer activation to what is used at runtime.
+TfLiteFusedActivation ConvertActivation(ActivationFunctionType activation);
+
+// Converts the flatbuffer padding enum to what is used at runtime.
+TfLitePadding ConvertPadding(Padding padding);
+
+}  // namespace tflite
+
+#endif  // COMPUTE_ENGINE_TFLITE_KERNEL_UTILS_H

--- a/larq_compute_engine/tflite/tests/bconv2d_op_model.h
+++ b/larq_compute_engine/tflite/tests/bconv2d_op_model.h
@@ -50,10 +50,9 @@ class BaseBConv2DOpModel : public SingleOpModel {
       fbb.Int("stride_width", stride_width);
       fbb.Int("dilation_height_factor", dilation_height_factor);
       fbb.Int("dilation_width_factor", dilation_width_factor);
-      fbb.Int("padding", (int)GetTfLitePadding(padding));
+      fbb.Int("padding", (int)padding);
       fbb.Int("pad_values", pad_values);
-      fbb.Int("fused_activation_function",
-              (int)GetTfLiteActivation(activation));
+      fbb.Int("fused_activation_function", (int)activation);
     });
     fbb.Finish();
     SetCustomOp("LceBconv2d", fbb.GetBuffer(), registration);

--- a/larq_compute_engine/tflite/tests/bmaxpool_test.cc
+++ b/larq_compute_engine/tflite/tests/bmaxpool_test.cc
@@ -70,7 +70,7 @@ class BaseBMaxPoolOpModel : public SingleOpModel {
       fbb.Int("stride_width", stride_width);
       fbb.Int("filter_height", filter_height);
       fbb.Int("filter_width", filter_width);
-      fbb.Int("padding", (int)GetTfLitePadding(padding));
+      fbb.Int("padding", (int)padding);
     });
     fbb.Finish();
     SetCustomOp("LceBMaxPool2d", fbb.GetBuffer(), registration);

--- a/larq_compute_engine/tflite/tests/utils.h
+++ b/larq_compute_engine/tflite/tests/utils.h
@@ -35,28 +35,6 @@ std::string getActivationString(const enum ActivationFunctionType activation) {
   return "UNKOWN";
 }
 
-TfLitePadding GetTfLitePadding(enum Padding padding) {
-  switch (padding) {
-    case Padding_VALID:
-      return kTfLitePaddingValid;
-    case Padding_SAME:
-      return kTfLitePaddingSame;
-    default:
-      return kTfLitePaddingUnknown;
-  };
-}
-
-TfLiteFusedActivation GetTfLiteActivation(
-    const enum ActivationFunctionType activation) {
-  if (activation == ActivationFunctionType_RELU) {
-    return kTfLiteActRelu;
-  } else if (activation == ActivationFunctionType_NONE) {
-    return kTfLiteActNone;
-  }
-  TFLITE_DCHECK(false);
-  return kTfLiteActNone;
-}
-
 // Helper for determining the type for the builtin convolution that we are
 // comparing with
 template <typename TInput, typename TOutput>


### PR DESCRIPTION
## What do these changes do?
This changes activation and padding enums to match the enum used in the TFLite flatbuffer schema.

## How Has This Been Tested?
CI

## Related issue number
Closes #458
