### PR TITLE
Fix unittest linkopts for macos

### DIFF
--- a/larq_compute_engine/core/tests/BUILD
+++ b/larq_compute_engine/core/tests/BUILD
@@ -18,6 +18,9 @@ cc_test(
     srcs = ["bitpack_tests.cc"],
     linkopts = select({
         "@org_tensorflow//tensorflow:windows": [],
+        "@org_tensorflow//tensorflow:macos": [
+            "-lm",
+        ],
         "//conditions:default": [
             "-lm",
             "-lrt",


### PR DESCRIPTION
## What do these changes do?
This fixes build issue of unittests on macos

## How Has This Been Tested?
Ran unittest locally on macos