### PR TITLE
Simplify bconv test

### DIFF
--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -200,18 +200,18 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     }
   }
 
+  if (output->type == kTfLiteInt8 &&
+      conv_params->padding_type == kTfLitePaddingSame &&
+      conv_params->pad_value != 1) {
+    TF_LITE_KERNEL_LOG(
+        context,
+        "8-bit quantization is only supported with valid or one-padding");
+    return kTfLiteError;
+  }
+
   if (!conv_params->read_bitpacked_input) {
     TF_LITE_ENSURE(context,
                    input->type == kTfLiteInt8 || input->type == kTfLiteFloat32);
-
-    if (input->type == kTfLiteInt8 &&
-        conv_params->padding_type == kTfLitePaddingSame &&
-        conv_params->pad_value != 1) {
-      TF_LITE_KERNEL_LOG(
-          context,
-          "8-bit quantization is only supported with valid or one-padding");
-      return kTfLiteError;
-    }
 
     // TODO: more intelligent selection of the parameter `bitpack_before_im2col`
     //       based on benchmarking results (as in

--- a/larq_compute_engine/tflite/tests/bconv2d_int8_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_int8_test.cc
@@ -8,15 +8,17 @@ namespace tflite {
 namespace testing {
 
 TEST(BConv2DTests, Int8ErrorDeathTest) {
-  LceTensor<std::int8_t> input_tensor({1, 16, 16, 64});
+  LceTensor<TBitpacked> input_tensor({1, 16, 16, 2});
   LceTensor<TBitpacked> packed_filter_tensor({128, 3, 3, 64});
   LceTensor<std::int8_t> post_tensor({128});
   LceTensor<std::int32_t> threshold_tensor;
   LceTensor<std::int8_t> output_tensor;
 
+  output_tensor.scale = 1.0f;
+  output_tensor.zero_point = 0;
+
   // Required for the macro
-  typedef BConv2DOpModel<std::int8_t, std::int8_t, std::int8_t>
-      Int8_BConv2DOpModel;
+  typedef BConv2DOpModel<std::int8_t, std::int8_t> Int8_BConv2DOpModel;
 
   EXPECT_DEATH(
       {
@@ -31,8 +33,8 @@ TEST(BConv2DTests, Int8ErrorDeathTest) {
 
 TEST(BConv2DTests, Int8PostTest) {
   using T = std::int8_t;
-  LceTensor<T> input_tensor({1, 2, 2, 2});
-  LceTensor<TBitpacked> packed_filter_tensor({4, 2, 2, 2});
+  LceTensor<TBitpacked> input_tensor({1, 2, 2, 1});
+  LceTensor<TBitpacked> packed_filter_tensor({4, 2, 2, 1});
   LceTensor<T> post_tensor({4});
   LceTensor<std::int32_t> threshold_tensor;
   LceTensor<T> output_tensor;
@@ -47,37 +49,37 @@ TEST(BConv2DTests, Int8PostTest) {
   output_tensor.scale = 1.0f / 32.0f;
   output_tensor.zero_point = 0;
 
-  BConv2DOpModel<T, T, T> m_lce(compute_engine::tflite::Register_BCONV_2D_OPT,
-                                input_tensor, packed_filter_tensor,
-                                output_tensor, post_tensor, post_tensor,
-                                threshold_tensor, 2, 1, 1, Padding_VALID, 0,
-                                ActivationFunctionType_NONE, 1, 1, 1);
+  BConv2DOpModel<T, T> m_lce(compute_engine::tflite::Register_BCONV_2D_OPT,
+                             input_tensor, packed_filter_tensor, output_tensor,
+                             post_tensor, post_tensor, threshold_tensor, 2, 1,
+                             1, Padding_VALID, 0, ActivationFunctionType_NONE,
+                             1, 1, 1);
 
   m_lce.SetInput({
-      1, 1,   // batch = 0, y = 0, x = 0
-      1, -1,  // batch = 0, y = 0, x = 1
-      1, 1,   // batch = 0, y = 1, x = 0
-      1, -1   // batch = 0, y = 1, x = 1
+      0,  // batch = 0, y = 0, x = 0
+      1,  // batch = 0, y = 0, x = 1
+      0,  // batch = 0, y = 1, x = 0
+      1   // batch = 0, y = 1, x = 1
   });
   // Bitpacked filter. Since we're only testing post_ stuff here, its easiest to
   // set all filter values to +1, which means bitpacked 0
   m_lce.SetFilter({
-      0, 0,  // out channel = 0, y = 0, x = 0
-      0, 0,  // out channel = 0, y = 0, x = 1
-      0, 0,  // out channel = 0, y = 1, x = 0
-      0, 0,  // out channel = 0, y = 1, x = 1
-      0, 0,  // out channel = 1, y = 0, x = 0
-      0, 0,  // out channel = 1, y = 0, x = 1
-      0, 0,  // out channel = 1, y = 1, x = 0
-      0, 0,  // out channel = 1, y = 1, x = 1
-      0, 0,  // out channel = 2, y = 0, x = 0
-      0, 0,  // out channel = 2, y = 0, x = 1
-      0, 0,  // out channel = 2, y = 1, x = 0
-      0, 0,  // out channel = 2, y = 1, x = 1
-      0, 0,  // out channel = 3, y = 0, x = 0
-      0, 0,  // out channel = 3, y = 0, x = 1
-      0, 0,  // out channel = 3, y = 1, x = 0
-      0, 0   // out channel = 3, y = 1, x = 1
+      0,  // out channel = 0, y = 0, x = 0
+      0,  // out channel = 0, y = 0, x = 1
+      0,  // out channel = 0, y = 1, x = 0
+      0,  // out channel = 0, y = 1, x = 1
+      0,  // out channel = 1, y = 0, x = 0
+      0,  // out channel = 1, y = 0, x = 1
+      0,  // out channel = 1, y = 1, x = 0
+      0,  // out channel = 1, y = 1, x = 1
+      0,  // out channel = 2, y = 0, x = 0
+      0,  // out channel = 2, y = 0, x = 1
+      0,  // out channel = 2, y = 1, x = 0
+      0,  // out channel = 2, y = 1, x = 1
+      0,  // out channel = 3, y = 0, x = 0
+      0,  // out channel = 3, y = 0, x = 1
+      0,  // out channel = 3, y = 1, x = 0
+      0   // out channel = 3, y = 1, x = 1
   });
 
   // The real post values will be (x - 5) / 16

--- a/larq_compute_engine/tflite/tests/bconv2d_op_model.h
+++ b/larq_compute_engine/tflite/tests/bconv2d_op_model.h
@@ -70,7 +70,7 @@ class BaseBConv2DOpModel : public SingleOpModel {
   int thresholds_;
 };
 
-template <typename TInput, typename PostType, typename TOutput>
+template <typename PostType, typename TOutput>
 class BConv2DOpModel : public BaseBConv2DOpModel {
  public:
   using BaseBConv2DOpModel::BaseBConv2DOpModel;
@@ -79,7 +79,7 @@ class BConv2DOpModel : public BaseBConv2DOpModel {
     PopulateTensor(filter_, f);
   }
 
-  void SetInput(const std::vector<TInput>& data) {
+  void SetInput(const std::vector<TBitpacked>& data) {
     PopulateTensor(input_, data);
   }
 

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -726,8 +726,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 // The BigTest suite will be skipped in the qemu CI runs as they take more than
 // an hour.
-// This test does not include zero-padding because it will be skipped in most
-// configurations
 INSTANTIATE_TEST_SUITE_P(
     BigTest, BConv2DOpTest,
     ::testing::Combine(
@@ -743,40 +741,12 @@ INSTANTIATE_TEST_SUITE_P(
         Values(std::array<int, 2>{1, 1},
                std::array<int, 2>{2, 3}),  // strides height/width
         Values(std::array<int, 2>{1, 1},
-               std::array<int, 2>{3, 2}),    // dilation height/width
-        Values(Padding_VALID, Padding_ONE),  // padding
+               std::array<int, 2>{3, 2}),  // dilation height/width
+        Values(Padding_VALID, Padding_SAME, Padding_ONE),  // padding
         Values(ActivationFunctionType_NONE,
                ActivationFunctionType_RELU),  // activation function
         Values(1, 2),                         // number of threads
         ValuesIn(BConv2DOpTest::GetKernelsTuples(*kKernelMap))),
-    TestParam::TestNameSuffix);
-
-// This is the same test as above but now only with zero-padding.
-// Since zero-padding is not supported in combination with ReLu or with the
-// reference implementation (or bitpacked output or int8 output), we only use
-// ActivationFunctionType_NONE and the OPT implementation here,
-// to avoid all the 'SKIPPED' tests.
-INSTANTIATE_TEST_SUITE_P(
-    BigTestSamePadding, BConv2DOpTest,
-    ::testing::Combine(
-        Values(std::array<int, 4>{1, 7, 7, 1}, std::array<int, 4>{1, 8, 5, 1},
-               std::array<int, 4>{1, 7, 7, 64}, std::array<int, 4>{1, 8, 5, 64},
-               std::array<int, 4>{1, 7, 7, 130},
-               std::array<int, 4>{1, 8, 5, 130}),  // input shape [BHWI]
-        Values(std::array<int, 3>{1, 1, 1}, std::array<int, 3>{3, 3, 1},
-               std::array<int, 3>{2, 3, 1}, std::array<int, 3>{1, 1, 4},
-               std::array<int, 3>{3, 3, 4}, std::array<int, 3>{2, 3, 4},
-               std::array<int, 3>{1, 1, 64}, std::array<int, 3>{3, 3, 64},
-               std::array<int, 3>{2, 3, 64}),  // filter shape [HWO]
-        Values(std::array<int, 2>{1, 1},
-               std::array<int, 2>{2, 3}),  // strides height/width
-        Values(std::array<int, 2>{1, 1},
-               std::array<int, 2>{3, 2}),     // dilation height/width
-        Values(Padding_SAME),                 // padding
-        Values(ActivationFunctionType_NONE),  // activation function
-        Values(1, 2),                         // number of threads
-        Values(std::pair<std::string, register_function>{
-            "BConv2DOPT", compute_engine::tflite::Register_BCONV_2D_OPT})),
     TestParam::TestNameSuffix);
 
 TEST(BConv2DTests, ReluErrorDeathTest) {

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -368,27 +368,6 @@ MATCHER_P(FloatNearPointwise, tol, "Out of range") {
           std::get<0>(arg) < std::get<1>(arg) + tol);
 }
 
-// 8-bit quantized or float input
-template <typename TInput, typename PostType, typename TOutput>
-void set_lce_op_input(
-    const RuntimeShape& input_shape,
-    std::vector<typename GetBuiltinType<TInput, TOutput>::type> input_data,
-    std::int32_t zero_point, BConv2DOpModel<TInput, PostType, TOutput>& m_lce) {
-  m_lce.SetInput(input_data);
-}
-
-// TBitpacked input
-template <typename TData, typename PostType, typename TOutput>
-void set_lce_op_input(const RuntimeShape& input_shape,
-                      std::vector<TData> input_data, std::int32_t zero_point,
-                      BConv2DOpModel<TBitpacked, PostType, TOutput>& m_lce) {
-  std::vector<TBitpacked> input_data_bp(core::GetPackedTensorSize(input_shape));
-  RuntimeShape output_shape;
-  core::bitpack_tensor(input_shape, input_data.data(), zero_point, output_shape,
-                       input_data_bp.data());
-  m_lce.SetInput(input_data_bp);
-}
-
 // Output test for writing bitpacked output
 template <typename BuiltinType>
 void test_lce_op_output(const std::vector<TBitpacked>& lce_output_data,
@@ -422,18 +401,14 @@ void test_lce_op_output(const std::vector<TOutput>& lce_output_data,
                                                     builtin_output_data));
 }
 
-template <typename TInput, typename TOutput>
+template <typename TOutput>
 void runTest(const TestParam& param) {
-  static_assert(std::is_same<TInput, float>::value ||
-                    std::is_same<TInput, std::int8_t>::value ||
-                    std::is_same<TInput, TBitpacked>::value,
-                "The LCE op input type must be float or int8 or TBitpacked.");
   static_assert(std::is_same<TOutput, float>::value ||
                     std::is_same<TOutput, std::int8_t>::value ||
                     std::is_same<TOutput, TBitpacked>::value,
                 "The LCE op output type must be float or int8 or TBitpacked.");
 
-  using BuiltinType = typename GetBuiltinType<TInput, TOutput>::type;
+  using BuiltinType = typename GetBuiltinType<TOutput>::type;
   using BuiltinBiasType = typename GetBiasType<BuiltinType>::type;
   using PostType = typename GetPostType<BuiltinType>::type;
 
@@ -452,15 +427,12 @@ void runTest(const TestParam& param) {
   const Padding padding = param.padding;
   const ActivationFunctionType activation = param.activation;
   const int num_threads = param.num_threads;
-  constexpr bool read_bitpacked_input = std::is_same<TInput, TBitpacked>::value;
   constexpr bool write_bitpacked_output =
       std::is_same<TOutput, TBitpacked>::value;
-  constexpr bool quantized_model = (std::is_same<TInput, std::int8_t>::value ||
-                                    std::is_same<TOutput, std::int8_t>::value);
+  constexpr bool int8_output = std::is_same<TOutput, std::int8_t>::value;
 
   // 8-bit quantization if and only if the builtin type is int8
-  static_assert(quantized_model ==
-                std::is_same<BuiltinType, std::int8_t>::value);
+  static_assert(int8_output == std::is_same<BuiltinType, std::int8_t>::value);
 
   const Padding builtin_padding =
       (padding == Padding_ONE ? Padding_VALID : padding);
@@ -468,14 +440,16 @@ void runTest(const TestParam& param) {
       (padding == Padding_ONE ? Padding_SAME : padding);
   const int pad_values = (padding == Padding_ONE ? 1 : 0);
 
+  const int packed_channels = core::GetPackedSize(input_depth);
+
   const int input_num_elem =
       input_batch_count * input_height * input_width * input_depth;
+  const int packed_input_num_elem =
+      input_batch_count * input_height * input_width * packed_channels;
 
   const int filters_num_elem =
       filter_height * filter_width * input_depth * filter_count;
-
-  const int packed_channels = core::GetPackedSize(input_depth);
-  const int packed_num_elem =
+  const int packed_filters_num_elem =
       filter_count * filter_height * filter_width * packed_channels;
 
   // the reference implementation only support one-padding
@@ -498,6 +472,9 @@ void runTest(const TestParam& param) {
   LceTensor<BuiltinType> padded_input_tensor(
       {input_batch_count, input_height, input_width, input_depth});
 
+  LceTensor<TBitpacked> packed_input_tensor(
+      {input_batch_count, input_height, input_width, packed_channels});
+
   LceTensor<BuiltinType> filter_tensor(
       {filter_count, filter_height, filter_width, input_depth});
 
@@ -513,34 +490,23 @@ void runTest(const TestParam& param) {
   LceTensor<TOutput> output_tensor;
   LceTensor<BuiltinType> builtin_output_tensor;
 
-  if (quantized_model) {
-    // Note: it can still be that we have bitpacked input or output
-
+  if (int8_output) {
+    // When the output is int8, the builtin op also has int8 input
     input_tensor.GenerateQuantizationParams(gen);
-    // Use the same quantization parameters for the builtin op
+    // Use the same quantization parameters for the padded tensor
     padded_input_tensor.SetQuantizationParams(input_tensor);
     filter_tensor.GenerateQuantizationParamsPerChannel(gen);
     builtin_output_tensor.GenerateQuantizationParams(gen);
 
-    if (!write_bitpacked_output)
-      output_tensor.SetQuantizationParams(builtin_output_tensor);
+    output_tensor.SetQuantizationParams(builtin_output_tensor);
 
     if (std::is_same<PostType, std::int8_t>::value) {
       post_tensor.GenerateQuantizationParams(gen);
     }
-
-    // In TF 2.1, Relu is broken on int8 Conv2D.
-    // They fixed it in this commit, which is in TF 2.2
-    // https://github.com/tensorflow/tensorflow/commit/25adce3551d145f615f77eafd08159451e5be0c8
-    // Until this branch is rebased on TF 2.2,
-    // we skip the Relu int8 test
-    if (activation == ActivationFunctionType_RELU) {
-      GTEST_SKIP();
-      return;
-    }
   }
 
   std::vector<BuiltinType> input_data, padded_input_data, filters_data;
+  std::vector<TBitpacked> packed_input_data;
   std::vector<PostType> post_activation_multiplier_data,
       post_activation_bias_data;
   std::vector<std::int32_t> threshold_data;
@@ -550,7 +516,8 @@ void runTest(const TestParam& param) {
 
   input_data.resize(input_num_elem);
   filters_data.resize(filters_num_elem);
-  packed_filters_data.resize(packed_num_elem);
+  packed_filters_data.resize(packed_filters_num_elem);
+  packed_input_data.resize(packed_input_num_elem);
   bias_data.resize(
       filter_count,
       0);  // bias always has zero_point = 0, scale = input * filter
@@ -563,7 +530,7 @@ void runTest(const TestParam& param) {
   filter_tensor.GenerateSigns(gen, std::begin(filters_data),
                               std::end(filters_data));
 
-  if (quantized_model) {
+  if (int8_output) {
     // Set the post_activation_ step to identity, to make sure
     // the Conv2D and BConv2D kernel are clamping at the same point.
     // We have a separate test for non-identity post_activation_
@@ -571,7 +538,9 @@ void runTest(const TestParam& param) {
       post_activation_multiplier_data[i] = post_tensor.Quantize(1);
       post_activation_bias_data[i] = post_tensor.Quantize(0);
     }
-  } else {  // Bitpacked input or float input
+
+  } else {  // Bitpacked output or float output
+
     auto float_generator = [&gen]() {
       return std::uniform_real_distribution<>(0.01, 1.5)(gen);
     };
@@ -580,16 +549,19 @@ void runTest(const TestParam& param) {
                   std::end(post_activation_multiplier_data), float_generator);
     std::generate(std::begin(post_activation_bias_data),
                   std::end(post_activation_bias_data), float_generator);
+
+    if (write_bitpacked_output) {
+      ComputeThresholds(input_depth, filter_height, filter_width,
+                        post_activation_multiplier_data,
+                        post_activation_bias_data, activation, threshold_data);
+    }
   }
 
-  if (write_bitpacked_output) {
-    ComputeThresholds(input_depth, filter_height, filter_width,
-                      post_activation_multiplier_data,
-                      post_activation_bias_data, activation, threshold_data);
-  }
-
-  // Bitpack filters
+  // Bitpack input and filters
   using namespace compute_engine::core;
+  bitpack_matrix(input_data.data(),
+                 input_batch_count * input_height * input_width, input_depth,
+                 packed_input_data.data(), input_tensor.zero_point);
   bitpack_matrix(filters_data.data(),
                  filter_count * filter_height * filter_width, input_depth,
                  packed_filters_data.data());
@@ -704,22 +676,14 @@ void runTest(const TestParam& param) {
    -------------*/
 
   // Create LCE op.
-
-  // For reading bitpacked input, the input tensor is bitpacked
-  if (read_bitpacked_input) {
-    input_tensor.shape[3] = GetPackedSize(input_depth);
-    input_tensor.type = TensorType_INT32;
-  }
-
-  BConv2DOpModel<TInput, PostType, TOutput> m_lce(
-      registration, input_tensor, packed_filter_tensor, output_tensor,
+  BConv2DOpModel<PostType, TOutput> m_lce(
+      registration, packed_input_tensor, packed_filter_tensor, output_tensor,
       post_tensor, post_tensor, threshold_tensor, input_depth, stride_width,
       stride_height, bconv_padding, pad_values, activation,
       dilation_width_factor, dilation_height_factor, num_threads);
 
   // Set op parameters.
-  set_lce_op_input({input_batch_count, input_height, input_width, input_depth},
-                   input_data, input_tensor.zero_point, m_lce);
+  m_lce.SetInput(packed_input_data);
   m_lce.SetFilter(packed_filters_data);
   if (write_bitpacked_output) {
     m_lce.SetThresholds(threshold_data);
@@ -734,38 +698,11 @@ void runTest(const TestParam& param) {
                      builtin_output, builtin_output_tensor.zero_point);
 }
 
-// Three input types: int8, TBitpacked (int32), float
-// Three output types: int8, TBitpacked (int32), float
-// Thats 9 combinations, but float -> int8 and int8 -> float are never used so
-// that leaves 7 combinations.
+TEST_P(BConv2DOpTest, Bitpacked) { runTest<TBitpacked>(TestParam(GetParam())); }
 
-TEST_P(BConv2DOpTest, ReadFloatWriteFloat) {
-  runTest<float, float>(TestParam(GetParam()));
-}
+TEST_P(BConv2DOpTest, Float) { runTest<float>(TestParam(GetParam())); }
 
-TEST_P(BConv2DOpTest, ReadBPWriteBP) {
-  runTest<TBitpacked, TBitpacked>(TestParam(GetParam()));
-}
-
-TEST_P(BConv2DOpTest, ReadFloatWriteBP) {
-  runTest<float, TBitpacked>(TestParam(GetParam()));
-}
-
-TEST_P(BConv2DOpTest, ReadBPWriteFloat) {
-  runTest<TBitpacked, float>(TestParam(GetParam()));
-}
-
-TEST_P(BConv2DOpTest, ReadInt8WriteInt8) {
-  runTest<std::int8_t, std::int8_t>(TestParam(GetParam()));
-}
-
-TEST_P(BConv2DOpTest, ReadBPWriteInt8) {
-  runTest<TBitpacked, std::int8_t>(TestParam(GetParam()));
-}
-
-TEST_P(BConv2DOpTest, ReadInt8WriteBP) {
-  runTest<std::int8_t, TBitpacked>(TestParam(GetParam()));
-}
+TEST_P(BConv2DOpTest, Int8) { runTest<std::int8_t>(TestParam(GetParam())); }
 
 using ::testing::Values;
 using ::testing::ValuesIn;
@@ -833,7 +770,7 @@ INSTANTIATE_TEST_SUITE_P(
     TestParam::TestNameSuffix);
 
 TEST(BConv2DTests, ReluErrorDeathTest) {
-  LceTensor<float> input_tensor({1, 16, 16, 64});
+  LceTensor<TBitpacked> input_tensor({1, 16, 16, 2});
   LceTensor<TBitpacked> packed_filter_tensor({128, 3, 3, 64});
   LceTensor<float> post_tensor({128});
   LceTensor<std::int32_t> threshold_tensor({128});
@@ -842,8 +779,8 @@ TEST(BConv2DTests, ReluErrorDeathTest) {
 
   // We have to use typedefs or else the template invocation in the type
   // confuses the pre-processor (EXPECT_DEATH is a macro).
-  typedef BConv2DOpModel<float, float, float> FP_BConv2DOpModel;
-  typedef BConv2DOpModel<float, float, TBitpacked> Bitpacked_BConv2DOpModel;
+  typedef BConv2DOpModel<float, float> FP_BConv2DOpModel;
+  typedef BConv2DOpModel<float, TBitpacked> Bitpacked_BConv2DOpModel;
 
   // Test if fused ReLu throws an error in combination with zero-padding
   EXPECT_DEATH(

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -726,6 +726,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 // The BigTest suite will be skipped in the qemu CI runs as they take more than
 // an hour.
+// This test does not include zero-padding because it will be skipped in most
+// configurations
 INSTANTIATE_TEST_SUITE_P(
     BigTest, BConv2DOpTest,
     ::testing::Combine(
@@ -741,12 +743,40 @@ INSTANTIATE_TEST_SUITE_P(
         Values(std::array<int, 2>{1, 1},
                std::array<int, 2>{2, 3}),  // strides height/width
         Values(std::array<int, 2>{1, 1},
-               std::array<int, 2>{3, 2}),  // dilation height/width
-        Values(Padding_VALID, Padding_SAME, Padding_ONE),  // padding
+               std::array<int, 2>{3, 2}),    // dilation height/width
+        Values(Padding_VALID, Padding_ONE),  // padding
         Values(ActivationFunctionType_NONE,
                ActivationFunctionType_RELU),  // activation function
         Values(1, 2),                         // number of threads
         ValuesIn(BConv2DOpTest::GetKernelsTuples(*kKernelMap))),
+    TestParam::TestNameSuffix);
+
+// This is the same test as above but now only with zero-padding.
+// Since zero-padding is not supported in combination with ReLu or with the
+// reference implementation (or bitpacked output or int8 output), we only use
+// ActivationFunctionType_NONE and the OPT implementation here,
+// to avoid all the 'SKIPPED' tests.
+INSTANTIATE_TEST_SUITE_P(
+    BigTestSamePadding, BConv2DOpTest,
+    ::testing::Combine(
+        Values(std::array<int, 4>{1, 7, 7, 1}, std::array<int, 4>{1, 8, 5, 1},
+               std::array<int, 4>{1, 7, 7, 64}, std::array<int, 4>{1, 8, 5, 64},
+               std::array<int, 4>{1, 7, 7, 130},
+               std::array<int, 4>{1, 8, 5, 130}),  // input shape [BHWI]
+        Values(std::array<int, 3>{1, 1, 1}, std::array<int, 3>{3, 3, 1},
+               std::array<int, 3>{2, 3, 1}, std::array<int, 3>{1, 1, 4},
+               std::array<int, 3>{3, 3, 4}, std::array<int, 3>{2, 3, 4},
+               std::array<int, 3>{1, 1, 64}, std::array<int, 3>{3, 3, 64},
+               std::array<int, 3>{2, 3, 64}),  // filter shape [HWO]
+        Values(std::array<int, 2>{1, 1},
+               std::array<int, 2>{2, 3}),  // strides height/width
+        Values(std::array<int, 2>{1, 1},
+               std::array<int, 2>{3, 2}),     // dilation height/width
+        Values(Padding_SAME),                 // padding
+        Values(ActivationFunctionType_NONE),  // activation function
+        Values(1, 2),                         // number of threads
+        Values(std::pair<std::string, register_function>{
+            "BConv2DOPT", compute_engine::tflite::Register_BCONV_2D_OPT})),
     TestParam::TestNameSuffix);
 
 TEST(BConv2DTests, ReluErrorDeathTest) {

--- a/larq_compute_engine/tflite/tests/utils.h
+++ b/larq_compute_engine/tflite/tests/utils.h
@@ -37,41 +37,21 @@ std::string getActivationString(const enum ActivationFunctionType activation) {
 
 // Helper for determining the type for the builtin convolution that we are
 // comparing with
-template <typename TInput, typename TOutput>
+template <typename TOutput>
 struct GetBuiltinType {};
 
 template <>
-struct GetBuiltinType<float, float> {
+struct GetBuiltinType<float> {
   using type = float;
 };
 
 template <>
-struct GetBuiltinType<TBitpacked, float> {
+struct GetBuiltinType<TBitpacked> {
   using type = float;
 };
 
 template <>
-struct GetBuiltinType<float, TBitpacked> {
-  using type = float;
-};
-
-template <>
-struct GetBuiltinType<TBitpacked, TBitpacked> {
-  using type = float;
-};
-
-template <>
-struct GetBuiltinType<std::int8_t, std::int8_t> {
-  using type = std::int8_t;
-};
-
-template <>
-struct GetBuiltinType<std::int8_t, TBitpacked> {
-  using type = std::int8_t;
-};
-
-template <>
-struct GetBuiltinType<TBitpacked, std::int8_t> {
+struct GetBuiltinType<std::int8_t> {
   using type = std::int8_t;
 };
 

--- a/larq_compute_engine/tflite/tests/utils.h
+++ b/larq_compute_engine/tflite/tests/utils.h
@@ -35,56 +35,6 @@ std::string getActivationString(const enum ActivationFunctionType activation) {
   return "UNKOWN";
 }
 
-// Helper for determining the type for the builtin convolution that we are
-// comparing with
-template <typename TOutput>
-struct GetBuiltinType {};
-
-template <>
-struct GetBuiltinType<float> {
-  using type = float;
-};
-
-template <>
-struct GetBuiltinType<TBitpacked> {
-  using type = float;
-};
-
-template <>
-struct GetBuiltinType<std::int8_t> {
-  using type = std::int8_t;
-};
-
-// Helper for builtin bias type from the builtin data type
-template <typename T>
-struct GetBiasType {};
-
-template <>
-struct GetBiasType<float> {
-  using type = float;
-};
-
-template <>
-struct GetBiasType<std::int8_t> {
-  using type = std::int32_t;
-};
-
-// Helper for determining the post_activation_ type
-template <typename BuiltinType>
-struct GetPostType {};
-
-template <>
-struct GetPostType<float> {
-  using type = float;
-};
-
-template <>
-struct GetPostType<std::int8_t> {
-  // The converter currently uses float, the kernel supports both
-  using type = float;
-  // using type = std::int8_t;
-};
-
 // Useful struct, in particular for int8 quantization
 template <typename T>
 struct LceTensor : public TensorData {


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This updates the unittests to only use bitpacked input, to be merged into #457.

It further simplifies the tests by making the builtin op always use float in/output instead of sometimes float and sometimes int8.