### PR TITLE
Remove int8/float input support from bconv

### DIFF
--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -44,8 +44,8 @@ inline void BConv2D(const ConvParams& params,
                                                     details>& output_transform,
                     const RuntimeShape& output_shape, DstScalar* output_data,
                     const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
-                    bool bitpack_before_im2col, void* padding_buffer,
-                    const int pad_value, void* cpu_backend_context) {
+                    void* padding_buffer, const int pad_value,
+                    void* cpu_backend_context) {
   static_assert(std::is_same<DstScalar, float>::value ||
                     std::is_same<DstScalar, TBitpacked>::value ||
                     std::is_same<DstScalar, std::int8_t>::value,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -83,8 +83,6 @@ cc_library(
         "//larq_compute_engine/core:bmaxpool",
         "@flatbuffers",
         "@org_tensorflow//tensorflow/lite:framework",
-        "@org_tensorflow//tensorflow/lite/c:c_api_internal",
-        "@org_tensorflow//tensorflow/lite/kernels:op_macros",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
     ],

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -3,7 +3,6 @@
 
 #include "flatbuffers/flexbuffers.h"
 #include "larq_compute_engine/core/bconv2d_impl_ref.h"
-#include "larq_compute_engine/core/bitpack.h"
 #include "larq_compute_engine/core/padding_functor.h"
 #include "larq_compute_engine/core/types.h"
 #include "larq_compute_engine/tflite/kernels/bconv2d_impl.h"
@@ -11,12 +10,10 @@
 #include "larq_compute_engine/tflite/kernels/bconv2d_params.h"
 #include "larq_compute_engine/tflite/kernels/utils.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
-#include "tensorflow/lite/c/c_api_internal.h"
 #include "tensorflow/lite/kernels/cpu_backend_context.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
-#include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/kernels/padding.h"
 
 using namespace tflite;
@@ -27,8 +24,6 @@ namespace compute_engine {
 namespace tflite {
 namespace bconv2d {
 
-using ce::core::bitpacking_bitwidth;
-using ce::core::Layout;
 using ce::core::TBitpacked;
 
 enum class KernelType {

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -179,7 +179,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
     // In case that our network is not 8-bit quantized, we do require float
     // values
-    if (input->type == kTfLiteFloat32 || output->type == kTfLiteFloat32) {
+    if (output->type == kTfLiteFloat32) {
       TF_LITE_ENSURE_EQ(context, post_activation_multiplier->type,
                         kTfLiteFloat32);
       TF_LITE_ENSURE_EQ(context, post_activation_bias->type, kTfLiteFloat32);
@@ -241,11 +241,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                            &conv_params->output_activation_min,
                            &conv_params->output_activation_max);
 
-  if (input->type == kTfLiteInt8) {
-    // 8-bit quantized input and output
-    TF_LITE_ENSURE_EQ(context, input->quantization.type,
-                      kTfLiteAffineQuantization);
-  }
   if (output->type == kTfLiteInt8) {
     TF_LITE_ENSURE_EQ(context, output->quantization.type,
                       kTfLiteAffineQuantization);

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -558,16 +558,6 @@ void EvalRef(TfLiteContext* context, TfLiteNode* node,
     params->is_quantization_initialized = true;
   }
 
-  auto input_shape = GetTensorShape(input);
-  const auto packed_filter_shape = GetTensorShape(packed_filter);
-
-  // Bitpack the input data, unless we're reading bitpacked input.
-  auto input_data = GetTensorData<TBitpacked>(input);
-  RuntimeShape packed_input_shape;
-  packed_input_shape.ReplaceWith(4, input_shape.DimsData());
-  const TBitpacked* packed_input_data =
-      reinterpret_cast<const TBitpacked*>(input_data);
-
   // Using the standard TF Lite ConvParams struct.
   // This requires extra step of converting the TfLiteBConv2DParams
   // but unifies the interface with the default TF lite API for CONV params
@@ -580,12 +570,12 @@ void EvalRef(TfLiteContext* context, TfLiteNode* node,
 
   TfLiteTensor* im2col = nullptr;
   ce::ref::BConv2D<std::int32_t, DstScalar>(
-      op_params, packed_input_shape, packed_input_data, packed_filter_shape,
-      GetTensorData<TBitpacked>(packed_filter), output_transform,
-      GetTensorShape(output), GetTensorData<DstScalar>(output),
-      GetTensorShape(im2col), GetTensorData<TBitpacked>(im2col),
-      nullptr /*padding buffer*/, params->pad_value,
-      nullptr /*cpu backend context*/);
+      op_params, GetTensorShape(input), GetTensorData<TBitpacked>(input),
+      GetTensorShape(packed_filter), GetTensorData<TBitpacked>(packed_filter),
+      output_transform, GetTensorShape(output),
+      GetTensorData<DstScalar>(output), GetTensorShape(im2col),
+      GetTensorData<TBitpacked>(im2col), nullptr /*padding buffer*/,
+      params->pad_value, nullptr /*cpu backend context*/);
 }
 
 template <KernelType kernel_type, typename DstScalar>

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -78,14 +78,14 @@ const float* GetPostActivationMultiplier(
   return output_transform.post_activation_multiplier;
 }
 
-template <typename SrcScalar, typename AccumScalar, typename DstScalar>
+template <typename AccumScalar, typename DstScalar>
 inline void BConv2D(
     const ConvParams& params, const RuntimeShape& input_shape,
-    const SrcScalar* input_data, TBitpacked* packed_input_data,
+    const TBitpacked* input_data, TBitpacked* packed_input_data,
     const RuntimeShape& filter_shape, const TBitpacked* packed_filter_data,
     const OutputTransform<AccumScalar, DstScalar>& output_transform,
     const RuntimeShape& output_shape, DstScalar* output_data,
-    const RuntimeShape& im2col_shape, SrcScalar* im2col_data,
+    const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
     const float* padding_buffer, const int pad_value,
     const bool read_bitpacked_input, CpuBackendContext* cpu_backend_context) {
   TF_LITE_ASSERT_EQ(input_shape.DimensionsCount(), 4);

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -76,7 +76,6 @@ typedef struct {
   std::vector<std::uint8_t> filter_packed;
   bool is_filter_repacked = false;
 
-  bool read_bitpacked_input = false;
   bool write_bitpacked_output = false;
 
   bool conv_params_initialized = false;

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -56,7 +56,6 @@ typedef struct {
   std::vector<float> scaled_post_activation_bias;
   bool is_quantization_initialized = false;
 
-  bool bitpack_before_im2col = false;
   bool need_im2col = false;
   // IDs are the arbitrary identifiers used by TF Lite to identify and access
   // memory buffers. They are unique in the entire TF Lite context.


### PR DESCRIPTION
## What do these changes do?
This PR removes support for floating point and integer input in the bconv op.

## How Has This Been Tested?
CI

## Related issue number
To be merged into #457

Closed #290 and closes #110 in favour of #447
