### PR TITLE
Add profiler scopes for bitpacking functions and quantization/maxpool ops.

### DIFF
--- a/larq_compute_engine/core/BUILD
+++ b/larq_compute_engine/core/BUILD
@@ -33,6 +33,8 @@ cc_library(
     deps = [
         ":types",
         "@flatbuffers",
+        "@org_tensorflow//tensorflow/lite/kernels/internal:types",
+        "@ruy//ruy/profiler:instrumentation",
     ],
 )
 
@@ -41,7 +43,6 @@ cc_library(
     hdrs = ["bitpack_utils.h"],
     deps = [
         ":bitpack",
-        "@ruy//ruy/profiler:instrumentation",
     ],
 )
 

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -111,7 +111,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, TBitpacked, Spec> {
 
     const int depth = lhs.layout.rows;
     const int dst_stride_bitpacked =
-        ce::core::GetPackedSize(dst->layout.stride);
+        ce::core::GetBitpackedSize(dst->layout.stride);
 
     // The destination is column major and we need to bitpack along the row
     // (channels) axis so we need to loop over column index then row index.

--- a/larq_compute_engine/core/bitpack_aarch64.h
+++ b/larq_compute_engine/core/bitpack_aarch64.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "larq_compute_engine/core/types.h"
+#include "ruy/profiler/instrumentation.h"
 
 namespace compute_engine {
 namespace core {
@@ -18,6 +19,8 @@ inline void bitpack_aarch64_4x32(const float* input, std::size_t num_blocks,
   static_assert(sizeof(TBitpacked) == 4,
                 "Correctness of this function relies on the size of TBitpacked "
                 "being 4 bytes.");
+
+  ruy::profiler::ScopeLabel label("Bitpack 4x32 floats (optimised)");
 
   if (num_blocks < 1) return;
 

--- a/larq_compute_engine/core/bitpack_utils.h
+++ b/larq_compute_engine/core/bitpack_utils.h
@@ -10,12 +10,12 @@ namespace compute_engine {
 namespace ce = compute_engine;
 namespace core {
 
-inline int GetPackedTensorSize(const RuntimeShape& shape) {
+inline int GetBitpackedTensorSize(const RuntimeShape& shape) {
   const int dims = shape.DimensionsCount();
   // Pack the tensor along the last dimension
   const int rows = FlatSizeSkipDim(shape, dims - 1);
   const int cols = shape.Dims(dims - 1);
-  return ce::core::GetPackedMatrixSize(rows, cols);
+  return ce::core::GetBitpackedMatrixSize(rows, cols);
 }
 
 // Convenience function for bitpacking a tensor along its last dimension
@@ -36,7 +36,7 @@ inline void bitpack_tensor(const RuntimeShape& in_shape, const T* in_data,
 inline RuntimeShape packed_shape(const RuntimeShape& in_shape) {
   const int dims = in_shape.DimensionsCount();
   RuntimeShape out_shape(in_shape);
-  out_shape.SetDim(dims - 1, GetPackedSize(in_shape.Dims(dims - 1)));
+  out_shape.SetDim(dims - 1, GetBitpackedSize(in_shape.Dims(dims - 1)));
   return out_shape;
 }
 

--- a/larq_compute_engine/core/padding_functor.h
+++ b/larq_compute_engine/core/padding_functor.h
@@ -109,7 +109,7 @@ class PaddingFunctor {
             for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
               // Sum over input channels
               int popcount = 0;
-              int packed_channels = GetPackedSize(input_channels);
+              int packed_channels = GetBitpackedSize(input_channels);
               for (int in_c = 0; in_c < packed_channels; ++in_c) {
                 int filter_idx;
                 // filter_data has shape

--- a/larq_compute_engine/core/tests/bitpack_tests.cc
+++ b/larq_compute_engine/core/tests/bitpack_tests.cc
@@ -26,14 +26,14 @@ void runBitpackingTest(const int num_rows, const int num_cols,
     GTEST_SKIP();
   }
 
-  const int num_packed_cols = ce::core::GetPackedSize(num_cols);
+  const int num_packed_cols = ce::core::GetBitpackedSize(num_cols);
 
   std::random_device rd;
   std::mt19937 gen(rd());
 
   std::vector<TIn> input_matrix(num_rows * num_cols);
   std::vector<TBitpacked> output_matrix(
-      ce::core::GetPackedMatrixSize(num_rows, num_cols));
+      ce::core::GetBitpackedMatrixSize(num_rows, num_cols));
 
   // Generate some random data for the input.
   std::generate(std::begin(input_matrix), std::end(input_matrix), [&gen]() {

--- a/larq_compute_engine/mlir/ir/lce_ops.cc
+++ b/larq_compute_engine/mlir/ir/lce_ops.cc
@@ -63,7 +63,7 @@ void QuantizeOp::build(OpBuilder& builder, OperationState& state, Value x) {
   const auto existing_shape = x.getType().cast<ShapedType>().getShape();
   const auto channels = existing_shape[existing_shape.size() - 1];
   std::vector<int64_t> shape = existing_shape.drop_back();
-  shape.push_back(compute_engine::core::GetPackedSize(channels));
+  shape.push_back(compute_engine::core::GetBitpackedSize(channels));
   state.addTypes(RankedTensorType::get(shape, builder.getIntegerType(32)));
 }
 

--- a/larq_compute_engine/mlir/transforms/bitpack_weights.cc
+++ b/larq_compute_engine/mlir/transforms/bitpack_weights.cc
@@ -31,7 +31,8 @@ DenseElementsAttr Bitpack(PatternRewriter& builder, Attribute x) {
   auto shape = x.getType().cast<ShapedType>().getShape();
   int num_rows = shape[0] * shape[1] * shape[2];
   int unpacked_channels = shape[3];
-  int packed_channels = compute_engine::core::GetPackedSize(unpacked_channels);
+  int packed_channels =
+      compute_engine::core::GetBitpackedSize(unpacked_channels);
 
   std::vector<TBitpacked> new_values(num_rows * packed_channels);
   std::vector<float> old_values(num_rows * unpacked_channels);

--- a/larq_compute_engine/mlir/transforms/optimize.cc
+++ b/larq_compute_engine/mlir/transforms/optimize.cc
@@ -193,7 +193,7 @@ llvm::Optional<RankedTensorType> maybeGetBitpackedType(
   if (existing_shape.size() != 4) return llvm::None;
 
   const auto packed_channels =
-      compute_engine::core::GetPackedSize(existing_shape[3]);
+      compute_engine::core::GetBitpackedSize(existing_shape[3]);
   return RankedTensorType::get({existing_shape[0], existing_shape[1],
                                 existing_shape[2], packed_channels},
                                rewriter.getIntegerType(32));

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -81,6 +81,7 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
+        "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,
 )

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -238,7 +238,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   output_shape->data[2] = out_width;
   if (conv_params->write_bitpacked_output) {
     // If we write bitpacked output, we use 32-bit bitpacking
-    output_shape->data[3] = ce::core::GetPackedSize(conv_params->channels_out);
+    output_shape->data[3] =
+        ce::core::GetBitpackedSize(conv_params->channels_out);
   } else {
     output_shape->data[3] = conv_params->channels_out;
   }
@@ -285,7 +286,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     }
 
     // Resize the im2col tensor
-    int channels_in = ce::core::GetPackedSize(conv_params->channels_in);
+    int channels_in = ce::core::GetBitpackedSize(conv_params->channels_in);
 
     // determine the im2col buffer size
     TfLiteIntArray* im2col_size = TfLiteIntArrayCopy(output_shape);

--- a/larq_compute_engine/tflite/kernels/bmaxpool.cc
+++ b/larq_compute_engine/tflite/kernels/bmaxpool.cc
@@ -3,6 +3,7 @@
 
 #include "flatbuffers/flexbuffers.h"
 #include "larq_compute_engine/tflite/kernels/utils.h"
+#include "ruy/profiler/instrumentation.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
@@ -72,6 +73,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  ruy::profiler::ScopeLabel label("Binary MaxPool");
+
   ce::ref::BMaxPoolParams* poolparams =
       reinterpret_cast<ce::ref::BMaxPoolParams*>(node->user_data);
 

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -369,7 +369,7 @@ void test_lce_op_output(const std::vector<TBitpacked>& lce_output_data,
   RuntimeShape out_shape;
   out_shape.BuildFrom(builtin_output_shape);
   std::vector<TBitpacked> builtin_output_data_bp(
-      core::GetPackedTensorSize(out_shape));
+      core::GetBitpackedTensorSize(out_shape));
   core::bitpack_tensor(out_shape, builtin_output_data.data(), 0,
                        builtin_output_data_bp.data());
 
@@ -444,7 +444,7 @@ void runTest(const TestParam& param) {
       (padding == Padding_ONE ? Padding_SAME : padding);
   const int pad_values = (padding == Padding_ONE ? 1 : 0);
 
-  const int packed_channels = core::GetPackedSize(input_depth);
+  const int packed_channels = core::GetBitpackedSize(input_depth);
 
   const int input_num_elem =
       input_batch_count * input_height * input_width * input_depth;

--- a/larq_compute_engine/tflite/tests/bmaxpool_test.cc
+++ b/larq_compute_engine/tflite/tests/bmaxpool_test.cc
@@ -142,7 +142,7 @@ class BMaxPoolOpTest : public ::testing::TestWithParam<TestParamTuple> {};
 TEST_P(BMaxPoolOpTest, BinaryInput) {
   TestParam params(GetParam());
 
-  int packed_input_depth = GetPackedSize(params.input_depth);
+  int packed_input_depth = GetBitpackedSize(params.input_depth);
 
   LceTensor<float> input_tensor({params.input_batch_count, params.input_height,
                                  params.input_width, params.input_depth});
@@ -188,7 +188,7 @@ TEST_P(BMaxPoolOpTest, BinaryInput) {
   // Bitpack the tflite output
   RuntimeShape out_shape = GetShape(m_builtin.GetOutputShape());
   std::vector<TBitpacked> builtin_output_data_bp(
-      GetPackedTensorSize(out_shape));
+      GetBitpackedTensorSize(out_shape));
   bitpack_tensor(out_shape, m_builtin.GetOutput().data(), 0,
                  builtin_output_data_bp.data());
 

--- a/larq_compute_engine/tflite/tests/quantization_test.cc
+++ b/larq_compute_engine/tflite/tests/quantization_test.cc
@@ -76,7 +76,7 @@ template <typename TUnpacked>
 void TestQuantization(const TestParamTuple& param) {
   std::array<int, 4> shape = ::testing::get<0>(param);
 
-  int packed_channels = GetPackedSize(shape[3]);
+  int packed_channels = GetBitpackedSize(shape[3]);
 
   LceTensor<TUnpacked> unpacked_tensor(
       {shape[0], shape[1], shape[2], shape[3]});


### PR DESCRIPTION
## What do these changes do?

This is a non-functional PR that adds [Ruy profiler](https://github.com/google/ruy/blob/4452e73747d162f86aadc614f3296420d0d345a9/ruy/profiler/README.md) scopes to the bitpacking (and unpacking) functions as well as the `LceQuantize` and `LceDequantize` ops.

## How Has This Been Tested?

CI.

## Benchmark Results

N/A.

## Related issue number

N/A.
