### PR TITLE
Remove output shape argument from bitpack_tensor

### DIFF
--- a/larq_compute_engine/core/bitpack_utils.h
+++ b/larq_compute_engine/core/bitpack_utils.h
@@ -23,16 +23,13 @@ inline int GetPackedTensorSize(const RuntimeShape& shape) {
 template <class T>
 inline void bitpack_tensor(const RuntimeShape& in_shape, const T* in_data,
                            const std::int32_t zero_point,
-                           RuntimeShape& out_shape, TBitpacked* out_data) {
+                           TBitpacked* out_data) {
   const int dims = in_shape.DimensionsCount();
   // Pack the tensor along the last dimension
   const int rows = FlatSizeSkipDim(in_shape, dims - 1);
   const int cols = in_shape.Dims(dims - 1);
 
   ce::core::bitpack_matrix(in_data, rows, cols, out_data, zero_point);
-
-  out_shape.ReplaceWith(dims, in_shape.DimsData());
-  out_shape.SetDim(dims - 1, GetPackedSize(cols));
 }
 
 // Convenience function for going from a shape to the packed shape

--- a/larq_compute_engine/tflite/kernels/quantization.cc
+++ b/larq_compute_engine/tflite/kernels/quantization.cc
@@ -72,16 +72,13 @@ TfLiteStatus QuantizeEval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteTensor* input = GetInput(context, node, 0);
   TfLiteTensor* output = GetOutput(context, node, 0);
 
-  RuntimeShape packed_input_shape;
   if (input->type == kTfLiteFloat32) {
     ce::core::bitpack_tensor(GetTensorShape(input), GetTensorData<float>(input),
-                             0, packed_input_shape,
-                             GetTensorData<TBitpacked>(output));
+                             0, GetTensorData<TBitpacked>(output));
   } else if (input->type == kTfLiteInt8) {
-    ce::core::bitpack_tensor(GetTensorShape(input),
-                             GetTensorData<std::int8_t>(input),
-                             input->params.zero_point, packed_input_shape,
-                             GetTensorData<TBitpacked>(output));
+    ce::core::bitpack_tensor(
+        GetTensorShape(input), GetTensorData<std::int8_t>(input),
+        input->params.zero_point, GetTensorData<TBitpacked>(output));
   } else {
     return kTfLiteError;
   }

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -370,8 +370,7 @@ void test_lce_op_output(const std::vector<TBitpacked>& lce_output_data,
   out_shape.BuildFrom(builtin_output_shape);
   std::vector<TBitpacked> builtin_output_data_bp(
       core::GetPackedTensorSize(out_shape));
-  RuntimeShape packed_shape;
-  core::bitpack_tensor(out_shape, builtin_output_data.data(), 0, packed_shape,
+  core::bitpack_tensor(out_shape, builtin_output_data.data(), 0,
                        builtin_output_data_bp.data());
 
   // We need the outputs here to be bit-exact, so don't allow for floating

--- a/larq_compute_engine/tflite/tests/bmaxpool_test.cc
+++ b/larq_compute_engine/tflite/tests/bmaxpool_test.cc
@@ -167,8 +167,7 @@ TEST_P(BMaxPoolOpTest, BinaryInput) {
   input_tensor.GenerateSigns(gen, std::begin(input_data), std::end(input_data));
 
   // Bitpack the input
-  bitpack_tensor(input_shape, input_data.data(), 0, packed_input_shape,
-                 input_data_bp.data());
+  bitpack_tensor(input_shape, input_data.data(), 0, input_data_bp.data());
 
   // Our op with binary input
   BMaxPoolOpModel m_lce_binary(params.registration, packed_input_tensor,
@@ -190,12 +189,11 @@ TEST_P(BMaxPoolOpTest, BinaryInput) {
   RuntimeShape out_shape = GetShape(m_builtin.GetOutputShape());
   std::vector<TBitpacked> builtin_output_data_bp(
       GetPackedTensorSize(out_shape));
-  RuntimeShape packed_out_shape;
-  bitpack_tensor(out_shape, m_builtin.GetOutput().data(), 0, packed_out_shape,
+  bitpack_tensor(out_shape, m_builtin.GetOutput().data(), 0,
                  builtin_output_data_bp.data());
 
   // Check our binary op
-  EXPECT_EQ(m_lce_binary.GetOutputShape(), GetShape(packed_out_shape));
+  EXPECT_EQ(m_lce_binary.GetOutputShape(), GetShape(packed_shape(out_shape)));
   EXPECT_EQ(m_lce_binary.GetOutput(), builtin_output_data_bp);
 }
 


### PR DESCRIPTION
## What do these changes do?
This PR removes the output shape argument from `core::bitpack_tensor` as it was never used inside the code.

## How Has This Been Tested?
This is a non functional change covered by the current unittests

## Benchmark Results
I didn't benchmark the changes, but I don't expect that it will have a measurable runtime impact.
