### PR TITLE
Directly pass packed filer shape to bconv kernel

### DIFF
--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -14,8 +14,6 @@ cc_library(
     ],
     deps = [
         "//larq_compute_engine/core:bgemm_impl",
-        "//larq_compute_engine/core:bitpack",
-        "//larq_compute_engine/core:bitpack_utils",
         "//larq_compute_engine/core:padding_functor",
         "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_context",
         "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_gemm",
@@ -77,6 +75,7 @@ cc_library(
         ":utils",
         "//larq_compute_engine/core:bconv2d_impl_ref",
         "//larq_compute_engine/core:bitpack",
+        "//larq_compute_engine/core:bitpack_utils",
         "//larq_compute_engine/core:bmaxpool",
         "@flatbuffers",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -458,7 +458,7 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
   OutputTransform<AccumScalar, DstScalar> output_transform;
   GetOutputTransform(context, node, params, output_transform);
 
-  // `BConv2D` wants the *unpacked* filter and output shape.
+  // `BConv2D` wants the *unpacked* output shape.
   auto unpacked_output_shape = GetTensorShape(output);
   unpacked_output_shape.SetDim(3, params->channels_out);
 

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -459,8 +459,6 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
   GetOutputTransform(context, node, params, output_transform);
 
   // `BConv2D` wants the *unpacked* filter and output shape.
-  auto unpacked_filter_shape = GetTensorShape(filter);
-  unpacked_filter_shape.SetDim(3, params->channels_in);
   auto unpacked_output_shape = GetTensorShape(output);
   unpacked_output_shape.SetDim(3, params->channels_out);
 
@@ -471,7 +469,7 @@ void EvalOpt(TfLiteContext* context, TfLiteNode* node,
   // write bitpacked output directly.
   BConv2D<AccumScalar, DstScalar>(
       op_params, GetTensorShape(input), GetTensorData<TBitpacked>(input),
-      unpacked_filter_shape, GetTensorData<TBitpacked>(filter),
+      GetTensorShape(filter), GetTensorData<TBitpacked>(filter),
       output_transform, unpacked_output_shape, GetTensorData<DstScalar>(output),
       GetTensorShape(im2col), GetTensorData<TBitpacked>(im2col),
       params->padding_buffer.data(), params->pad_value,

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -2,8 +2,6 @@
 #define COMPUTE_EGNINE_TFLITE_KERNELS_BCONV_2D_IMPL_H_
 
 #include "larq_compute_engine/core/bgemm_impl.h"
-#include "larq_compute_engine/core/bitpack.h"
-#include "larq_compute_engine/core/bitpack_utils.h"
 #include "larq_compute_engine/core/padding_functor.h"
 #include "ruy/profiler/instrumentation.h"
 #include "tensorflow/lite/kernels/cpu_backend_context.h"

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -122,13 +122,10 @@ inline void BConv2D(
   int m = 0;
   int k = 0;
 
-  // The filter tensor was already bitpacked. Only get the new shape.
-  RuntimeShape packed_filter_shape = ce::core::packed_shape(filter_shape);
-
   // We're already bitpacked, so im2col `zero_byte` is 0.
   RuntimeShape result_shape;
 
-  im2col(params, input_shape, input_data, packed_filter_shape, output_shape,
+  im2col(params, input_shape, input_data, filter_shape, output_shape,
          im2col_shape, im2col_data, result_shape, &rhs_data, 0);
 
   k = result_shape.Dims(3);


### PR DESCRIPTION
## What do these changes do?
This PR changes the BConv kernel to directly pass the packed filter size to the kernel implementation which removes an unnecessary shape conversion.

## How Has This Been Tested?
This is a non functional change covered by the current unittests

## Benchmark Results
I didn't benchmark the changes, but I don't expect that it will have a measurable runtime impact.
