### PR TITLE
Use Bazel test_filter argument instead of action_env for tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
       - name: "TF Lite Arm32: Cross-compile and run unit tests in qemu"
-        run: bazelisk test larq_compute_engine/tests:cc_tests_arm32_qemu --config=rpi3 --test_output=all --action_env=GTEST_FILTER="-*BigTest*"
+        run: bazelisk test larq_compute_engine/tests:cc_tests_arm32_qemu --config=rpi3 --test_output=all --test_filter="-*BigTest*"
       - name: "TF Lite Aarch64: Cross-compile and run unit tests in qemu"
-        run: bazelisk test larq_compute_engine/tests:cc_tests_aarch64_qemu --config=aarch64 --test_output=all --action_env=GTEST_FILTER="-*BigTest*"
+        run: bazelisk test larq_compute_engine/tests:cc_tests_aarch64_qemu --config=aarch64 --test_output=all --test_filter="-*BigTest*"
       - name: "Benchmark utility: check it builds successfully"
         run: bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=aarch64 --compilation_mode=fastbuild
       - name: "ImageNet evaluation utility: check it builds successfully"


### PR DESCRIPTION
The `action_env` argument prevents Bazel cache sharing and forces re-compilation (between the case where you use the argument and where you don't). We can use the `test_filter` argument instead.

## How Has This Been Tested?

CI. 

Locally, using this argument lets me switch between running the 'big' kernel tests and the normal kernel tests without re-compilation, which was not the case before.

## Benchmark Results

N/A.

## Related issue number

N/A.
