### PR TITLE
Fuse part of the back-transformation into the multiplier and bias.

### DIFF
--- a/larq_compute_engine/core/bconv2d_impl_ref.h
+++ b/larq_compute_engine/core/bconv2d_impl_ref.h
@@ -35,17 +35,15 @@ using ce::core::TBitpacked;
 
 template <typename AccumScalar, typename DstScalar,
           ce::core::OutputTransformDetails details>
-inline void BConv2D(const ConvParams& params,
-                    const RuntimeShape& packed_input_shape,
-                    const TBitpacked* packed_input_data,
-                    const RuntimeShape& packed_filter_shape,
-                    const TBitpacked* packed_filter_data,
-                    const ce::core::OutputTransform<std::int32_t, DstScalar,
-                                                    details>& output_transform,
-                    const RuntimeShape& output_shape, DstScalar* output_data,
-                    const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
-                    void* padding_buffer, const int pad_value,
-                    void* cpu_backend_context) {
+inline void BConv2D(
+    const ConvParams& params, const RuntimeShape& packed_input_shape,
+    const TBitpacked* packed_input_data,
+    const RuntimeShape& packed_filter_shape,
+    const TBitpacked* packed_filter_data,
+    const ce::core::OutputTransform<DstScalar, details>& output_transform,
+    const RuntimeShape& output_shape, DstScalar* output_data,
+    const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
+    void* padding_buffer, const int pad_value, void* cpu_backend_context) {
   static_assert(std::is_same<DstScalar, float>::value ||
                     std::is_same<DstScalar, TBitpacked>::value ||
                     std::is_same<DstScalar, std::int8_t>::value,

--- a/larq_compute_engine/core/bgemm_impl.h
+++ b/larq_compute_engine/core/bgemm_impl.h
@@ -34,7 +34,7 @@ void BGemm(const MatrixParams<TBitpacked>& lhs_params,
            const MatrixParams<TBitpacked>& rhs_params,
            const TBitpacked* rhs_data,
            const MatrixParams<DstScalar>& dst_params, DstScalar* dst_data,
-           const OutputTransform<AccumScalar, DstScalar>& params,
+           const OutputTransform<DstScalar>& params,
            CpuBackendContext* context) {
   ruy::profiler::ScopeLabel label("BGemm");
   // TODO: special fast bgemm impl. for matrix-vector multiplication

--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -23,12 +23,14 @@ using compute_engine::core::TBitpacked;
 
 template <typename AccumScalar, typename DstScalar>
 struct BGemmImplUsingRuy {
-  static void Run(
-      const MatrixParams<TBitpacked>& lhs_params, const TBitpacked* lhs_data,
-      const MatrixParams<TBitpacked>& rhs_params, const TBitpacked* rhs_data,
-      const MatrixParams<DstScalar>& dst_params, DstScalar* dst_data,
-      const OutputTransform<AccumScalar, DstScalar>& output_transform,
-      CpuBackendContext* context) {
+  static void Run(const MatrixParams<TBitpacked>& lhs_params,
+                  const TBitpacked* lhs_data,
+                  const MatrixParams<TBitpacked>& rhs_params,
+                  const TBitpacked* rhs_data,
+                  const MatrixParams<DstScalar>& dst_params,
+                  DstScalar* dst_data,
+                  const OutputTransform<DstScalar>& output_transform,
+                  CpuBackendContext* context) {
     ruy::profiler::ScopeLabel label("BGemmRuy");
 
     static_assert(std::is_signed<DstScalar>::value,

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -18,7 +18,7 @@ struct BinaryMulParams {
   using AccumScalar = tAccumScalar;
   using DstScalar = tDstScalar;
 
-  OutputTransform<AccumScalar, DstScalar> output_transform;
+  OutputTransform<DstScalar> output_transform;
 
   static constexpr LoopStructure kLoopStructure = LoopStructure::kAuto;
   static constexpr LayoutSupport kLayoutSupport = LayoutSupport::kGeneral;
@@ -36,7 +36,7 @@ struct BinaryMulParams<tAccumScalar, TBitpacked> {
   using AccumScalar = tAccumScalar;
   using DstScalar = TBitpacked;
 
-  OutputTransform<AccumScalar, DstScalar> output_transform;
+  OutputTransform<DstScalar> output_transform;
 
   static constexpr LoopStructure kLoopStructure = LoopStructure::kAuto;
   static constexpr LayoutSupport kLayoutSupport = LayoutSupport::kGeneral;
@@ -69,7 +69,6 @@ struct BinaryKernelParams {
   std::int32_t depth;
   std::int32_t clamp_min;
   std::int32_t clamp_max;
-  std::int32_t backtransform_add;
   float dst_tmp_buf[LhsCols * RhsCols];
 };
 
@@ -90,10 +89,8 @@ inline void MakeBinaryKernelParams(
   params->dst_base_ptr =
       dst->data.get() + start_col * dst->layout.stride + start_row;
 
-  params->post_activation_multiplier =
-      spec.output_transform.post_activation_multiplier;
-  params->post_activation_bias = spec.output_transform.post_activation_bias;
-  params->backtransform_add = spec.output_transform.backtransform_add;
+  params->post_activation_multiplier = spec.output_transform.multiplier;
+  params->post_activation_bias = spec.output_transform.bias;
   params->start_row = start_row;
   params->start_col = start_col;
   params->last_row = end_row - LhsCols;

--- a/larq_compute_engine/core/bgemm_kernels_ruy.h
+++ b/larq_compute_engine/core/bgemm_kernels_ruy.h
@@ -34,8 +34,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, DstScalar, Spec> {
   void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const Spec& spec, int start_row, int start_col, int end_row,
            int end_col, ruy::Mat<DstScalar>* dst) const {
-    const OutputTransform<AccumScalar, DstScalar>& output_transform =
-        spec.output_transform;
+    const OutputTransform<DstScalar>& output_transform = spec.output_transform;
 
     int clamped_end_row = std::min(end_row, dst->layout.rows);
     int clamped_end_col = std::min(end_col, dst->layout.cols);
@@ -78,8 +77,7 @@ struct BgemmKernel<ruy::Path::kStandardCpp, TBitpacked, Spec> {
   void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const Spec& spec, int start_row, int start_col, int end_row,
            int end_col, ruy::Mat<TBitpacked>* dst) const {
-    const OutputTransform<AccumScalar, TBitpacked>& output_transform =
-        spec.output_transform;
+    const OutputTransform<TBitpacked>& output_transform = spec.output_transform;
 
     // We are writing bitpacked output (where we bitpack along the channel axis)
     // and so we need to operate on blocks of `bitwidth` channels at a time. As
@@ -118,7 +116,6 @@ struct BgemmKernel<ruy::Path::kStandardCpp, TBitpacked, Spec> {
     for (int j = start_col; j < clamped_end_col; j++) {
       TBitpacked bitpacked_column = 0;
       for (int i = start_row; i < clamped_end_row; i++) {
-        using AccumScalar = typename Spec::AccumScalar;
         AccumScalar accum = 0;
         for (int k = 0; k < depth; k++) {
           TBitpacked lhs_val = Element(lhs, k, i);

--- a/larq_compute_engine/tflite/kernels/bconv2d_impl.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_impl.h
@@ -66,27 +66,26 @@ inline void im2col(const ConvParams& params, const RuntimeShape& input_shape,
 
 // Get the post_activation_multiplier out of the OutputTransform struct
 // Required for the padding functor
-template <typename AccumScalar, typename DstScalar>
+template <typename DstScalar>
 const float* GetPostActivationMultiplier(
-    const OutputTransform<AccumScalar, DstScalar>& output_transform) {
+    const OutputTransform<DstScalar>& output_transform) {
   return nullptr;
 }
-template <typename AccumScalar>
 const float* GetPostActivationMultiplier(
-    const OutputTransform<AccumScalar, float>& output_transform) {
-  return output_transform.post_activation_multiplier;
+    const OutputTransform<float>& output_transform) {
+  return output_transform.multiplier;
 }
 
 template <typename AccumScalar, typename DstScalar>
-inline void BConv2D(
-    const ConvParams& params, const RuntimeShape& input_shape,
-    const TBitpacked* input_data, const RuntimeShape& filter_shape,
-    const TBitpacked* packed_filter_data,
-    const OutputTransform<AccumScalar, DstScalar>& output_transform,
-    const RuntimeShape& output_shape, DstScalar* output_data,
-    const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
-    const float* padding_buffer, const int pad_value,
-    CpuBackendContext* cpu_backend_context) {
+inline void BConv2D(const ConvParams& params, const RuntimeShape& input_shape,
+                    const TBitpacked* input_data,
+                    const RuntimeShape& filter_shape,
+                    const TBitpacked* packed_filter_data,
+                    const OutputTransform<DstScalar>& output_transform,
+                    const RuntimeShape& output_shape, DstScalar* output_data,
+                    const RuntimeShape& im2col_shape, TBitpacked* im2col_data,
+                    const float* padding_buffer, const int pad_value,
+                    CpuBackendContext* cpu_backend_context) {
   TF_LITE_ASSERT_EQ(input_shape.DimensionsCount(), 4);
   TF_LITE_ASSERT_EQ(filter_shape.DimensionsCount(), 4);
   TF_LITE_ASSERT_EQ(output_shape.DimensionsCount(), 4);
@@ -150,8 +149,8 @@ inline void BConv2D(
   dst_params.rows = n;
   dst_params.cols = m;
 
-  BGemm(lhs_params, lhs_data, rhs_params, rhs_data, dst_params, output_data,
-        output_transform, cpu_backend_context);
+  BGemm<AccumScalar>(lhs_params, lhs_data, rhs_params, rhs_data, dst_params,
+                     output_data, output_transform, cpu_backend_context);
 
   if (params.padding_type == PaddingType::kSame && pad_value == 0) {
     const int stride_width = params.stride_width;

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -31,15 +31,15 @@ struct TfLiteBConv2DParams {
   TfLitePaddingValues padding_values{};
   int pad_value = 0;  // Must be 0 or 1
 
-  // These min/max take care of a Relu.
-  // Later they will *also* do the clamping in order to go from int32 to int8
-  std::int32_t output_activation_min;
-  std::int32_t output_activation_max;
+  // Fused activation function
+  TfLiteFusedActivation fused_activation_function{};
 
-  // This is only for int8 mode; it's the post_activation_ values scaled by the
-  // output tensor scale, and the bias includes the output zero-point.
-  std::vector<float> scaled_post_activation_multiplier;
-  std::vector<float> scaled_post_activation_bias;
+  // Computed output transform values. These are only used when writing
+  // float/int8 output.
+  std::int32_t output_transform_clamp_min;
+  std::int32_t output_transform_clamp_max;
+  std::vector<float> output_transform_multiplier;
+  std::vector<float> output_transform_bias;
 
   // This is used when we have 'same-zero' padding.
   std::vector<float> padding_buffer;

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -404,7 +404,7 @@ void test_lce_op_output(const std::vector<std::int8_t>& lce_output_data,
     unrounded_builtin_output[i] = unrounded_int8_output;
   }
 
-  EXPECT_THAT(lce_output_data, ::testing::Pointwise(::testing::FloatNear(0.501),
+  EXPECT_THAT(lce_output_data, ::testing::Pointwise(::testing::FloatNear(0.55),
                                                     unrounded_builtin_output));
 }
 


### PR DESCRIPTION
## What do these changes do?

This is a minor performance optimisation that fuses the subtraction of the back-transformation into the existing output transform multiplier and bias.

## How Has This Been Tested?

CI, and the 'big' kernel tests pass locally for Aarch64 and Arm32.

## Benchmark Results

I benchmarked QuickNet on my Android phone (a OnePlus 6), with `num_runs=250`, and report the average latency and the standard deviation below.

| Number of threads | Baseline      | PR            |
|-------------------|---------------|---------------|
| 1                 | 14.71 +- 0.07 | 14.62 +- 0.06 |
| 4                 | 6.40 +- 0.20  | 6.36 +- 0.26  |

As expected, there is a very minor performance improvement that's pretty much within run variation.

I didn't have converted QuickNet Large/XL models to hand so I haven't benchmarked those yet, let me know if you would like to see those additional benchmarks too.

## Related issue number

N/A.
