### PR TITLE
Add Int8 output support to the optimised binary convolution kernels.

### DIFF
--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -66,6 +66,7 @@ struct BGemmImplUsingRuy {
     constexpr auto BGemmCompiledPaths = ruy::kAllPaths;
 
     ruy::Path bgemm_runtime_path = ruy_ctx->SelectPath(ruy::kAllPaths);
+    RUY_DCHECK_NE(bgemm_runtime_path, ruy::Path::kNone);
 
 #if RUY_PLATFORM_ARM
     if (bgemm_runtime_path == ruy::Path::kNeonDotprod)
@@ -78,11 +79,6 @@ struct BGemmImplUsingRuy {
 
     // For now, writing bitpacked output only has a C++ implementation.
     if (std::is_same<DstScalar, TBitpacked>::value) {
-      bgemm_runtime_path = ruy::Path::kStandardCpp;
-    }
-
-    // For now, int8 output only has a C++ implementation.
-    if (std::is_same<DstScalar, std::int8_t>::value) {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
     }
 

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -310,20 +310,15 @@ void BinaryKernelNeonOutOfOrder4x4(const BinaryKernelParams<4, 4>& params) {
       "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
       "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[rhs_ptr]], #64\n"
 
-      // Perform the backtransformation (in int32)
+      // Load the clamp_max bound (in parallel with the shift)
+      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
+      "dup v12.4s, w2\n"  // clamp_min
+
+      // Perform the backtransformation shift (in int32)
       "shl v24.4s, v24.4s, #1\n"
       "shl v25.4s, v25.4s, #1\n"
       "shl v26.4s, v26.4s, #1\n"
       "shl v27.4s, v27.4s, #1\n"
-
-      // Load the clamp_max bound (in parallel with the sub)
-      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
-      "dup v12.4s, w2\n"  // clamp_min
-
-      "sub v24.4s, v13.4s, v24.4s\n"
-      "sub v25.4s, v13.4s, v25.4s\n"
-      "sub v26.4s, v13.4s, v26.4s\n"
-      "sub v27.4s, v13.4s, v27.4s\n"
 
       // Load the clamp_max bound (in parallel with the clamp_min)
       "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -423,7 +423,9 @@ inline TfLiteStatus EvalChooseKernelType(TfLiteContext* context,
     // there would need to be > 7000 input channels to present an overflow risk.
     const int depth =
         params->filter_height * params->filter_width * params->channels_in;
-    if (std::is_same<DstScalar, float>::value && depth + 512 < 1 << 16) {
+    if ((std::is_same<DstScalar, float>::value ||
+         std::is_same<DstScalar, std::int8_t>::value) &&
+        depth + 512 < 1 << 16) {
       EvalOpt<std::int16_t, DstScalar>(context, node, params);
       return kTfLiteOk;
     }

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -409,8 +409,10 @@ void test_lce_op_output(const std::vector<std::int8_t>& lce_output_data,
     unrounded_builtin_output[i] = unrounded_int8_output;
   }
 
-  EXPECT_THAT(lce_output_data, ::testing::Pointwise(::testing::FloatNear(0.55),
-                                                    unrounded_builtin_output));
+  const float tolerance = high_error_tolerance ? 0.7 : 0.55;
+  EXPECT_THAT(lce_output_data,
+              ::testing::Pointwise(::testing::FloatNear(tolerance),
+                                   unrounded_builtin_output));
 }
 
 template <typename TOutput>


### PR DESCRIPTION
## What do these changes do?

This PR adds support for writing Int8 output to the Aarch64 and Arm32 optimised assembly binary convolution kernels.

## How Has This Been Tested?

CI. The 'big' kernel tests pass locally for Aarch64 and Arm32.

## Benchmark Results

It turns out that benchmarking this change is quite difficult. Usually we use the benchmarking tool and measure the overall latencies of the QuickNet models. However, it appears (verified through profiling) that an Int8-quantised version of QuickNet is substantially slower than a float version because the full-precision ops are slower, in particular the depthwise convolution at the start and the add ops.

Therefore, to benchmark this change I have used the benchmark tool with the Ruy profiler enabled and multiplied the % of time spent on our `BConv2D` op by the average overall latency (`num_runs=250`). This is not a nice way of measuring things - having the profiler enabled *severely* increases run variation - but it should be enough to get a general idea.

These benchmarks were taken on my Android phone (a OnePlus 6), running the QuickNet models single-threaded. The reported values (in ms) are the estimated time spent executing the bconv op.

| Model         | Baseline (float) | Baseline (int8) | PR (int8) |
|---------------|------------------|-----------------|-----------|
| QuickNet      | 11.06            | 190.23          | 10.92     |
| QuickNetLarge | 15.60            | 260.65          | 16.11     |
| QuickNetXL    | 31.73            | 540.93          | 32.86     |

## Related issue number

N/A.
