### PR TITLE
Add an optimised Aarch64 assembly implementation of Int8 bitpacking.

### DIFF
--- a/larq_compute_engine/core/tests/bitpack_tests.cc
+++ b/larq_compute_engine/core/tests/bitpack_tests.cc
@@ -36,9 +36,17 @@ void runBitpackingTest(const int num_rows, const int num_cols,
       ce::core::GetBitpackedMatrixSize(num_rows, num_cols));
 
   // Generate some random data for the input.
-  std::generate(std::begin(input_matrix), std::end(input_matrix), [&gen]() {
-    return std::uniform_real_distribution<>(-1.5, 1.5)(gen);
-  });
+  if (std::is_same<TIn, float>::value) {
+    std::generate(std::begin(input_matrix), std::end(input_matrix), [&gen]() {
+      return std::uniform_real_distribution<>(-1.5, 1.5)(gen);
+    });
+  } else if (std::is_same<TIn, std::int8_t>::value) {
+    std::generate(std::begin(input_matrix), std::end(input_matrix), [&gen]() {
+      return std::uniform_int_distribution<>(-128, 127)(gen);
+    });
+  } else {
+    EXPECT_FALSE(true);
+  }
 
   // Perform the bitpacking.
   ce::core::bitpack_matrix(input_matrix.data(), num_rows, num_cols,
@@ -94,16 +102,15 @@ std::string TestName(
                       param_zp_value_str);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Bitpacking, BitpackingTest,
-    ::testing::Combine(
-        // num_rows
-        ::testing::Values(1, 2, 3, 4, 5, 6, 7, 8, 10, 15, 250),
-        // num_cols
-        ::testing::Values(1, 3, 16, 32, 33, 63, 64, 65, 96, 256),
-        // zero_point
-        ::testing::Values(-1000, -1, 0, 1, 127)),
-    TestName);
+INSTANTIATE_TEST_SUITE_P(Bitpacking, BitpackingTest,
+                         ::testing::Combine(
+                             // num_rows
+                             ::testing::Values(1, 2, 3, 8, 10, 15, 64),
+                             // num_cols
+                             ::testing::Values(1, 3, 16, 32, 33, 63, 64, 128),
+                             // zero_point
+                             ::testing::Values(-1000, -1, 0, 23, 127, 128)),
+                         TestName);
 
 }  // end namespace testing
 }  // namespace compute_engine


### PR DESCRIPTION
This is a re-submission of #493 which for some reason got closed and can't be re-opened...

## What do these changes do?

This PR adds an Aarch64 assembly implementation of Int8 bitpacking.

## How Has This Been Tested?

CI. Specific tests have been added for Int8 Aarch64 bitpacking.

## Benchmark Results

These benchmarks were taken with the LCE benchmarking tool on my Android phone (a OnePlus 6), running the QuickNet models (modified to use Int8 instead of float) single-threaded. I used `num_runs=250` and report the average latency and the standard deviation.

| Model         | Baseline (#492)   | PR            |
|---------------|---------------|---------------|
| QuickNet      | 17.18 +- 0.09 | 16.22 +- 0.05 |
| QuickNetLarge | 24.59 +- 0.10 | 23.21 +- 0.07 |
| QuickNetXL    | 43.27 +- 0.09 | 40.32 +- 0.06 |

With the Ruy profiler, I've observed that with these changes the `LceQuantize` op accounts for `0.57%` of the single-threaded Int8 QuickNet latency.

## Related issue number

N/A.