### PR TITLE
Remove Preprocessed from OutputTransformDetails

### DIFF
--- a/larq_compute_engine/core/bconv2d_output_transform.h
+++ b/larq_compute_engine/core/bconv2d_output_transform.h
@@ -19,7 +19,7 @@ using compute_engine::core::TBitpacked;
 std::int8_t saturate(std::int32_t x) {
 #ifdef __arm__
   std::int8_t y;
-  asm("ssat %[y], 8, %[x]\n" : [ y ] "=r"(y) : [ x ] "r"(x));
+  asm("ssat %[y], #8, %[x]\n" : [ y ] "=r"(y) : [ x ] "r"(x));
   return y;
 #else
   x = std::min<std::int32_t>(x, std::numeric_limits<std::int8_t>::max());

--- a/larq_compute_engine/core/bconv2d_output_transform.h
+++ b/larq_compute_engine/core/bconv2d_output_transform.h
@@ -17,7 +17,7 @@ using compute_engine::core::TBitpacked;
 
 // Clamp an int32 value to int8 range
 std::int8_t saturate(std::int32_t x) {
-#ifdef __thumb__
+#ifdef __arm__
   std::int8_t y;
   asm("ssat %[y], 8, %[x]\n" : [ y ] "=r"(y) : [ x ] "r"(x));
   return y;
@@ -28,7 +28,7 @@ std::int8_t saturate(std::int32_t x) {
 #endif
 }
 
-// round-to-nearest. Handling of ties is allowed to be anything, as discussed in
+// Round-to-nearest. Handling of ties is allowed to be anything, as discussed in
 // https://github.com/tensorflow/tensorflow/issues/25087
 std::int32_t round(float x) {
 #if defined(__thumb__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
@@ -141,8 +141,7 @@ struct OutputTransform<std::int8_t, OutputTransformDetails::Default> {
     float y =
         static_cast<float>(x) * multiplier[out_channel] + bias[out_channel];
     // And then we round back to int32 and clamp to the int8 range
-    std::int32_t z = round(y);
-    return saturate(z);
+    return saturate(round(y));
   }
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
Previously, we had
```cpp
enum class OutputTransformDetails {
  Default,
  Preprocessed,
  PreprocessedIntegerOnly
};
```
but now the `Default` implementation does the same thing that `Preprocessed` does, so this PR removes the `Preprocessed` option and renames `PreprocessedIntegerOnly` to `IntegerOnly`.
The only thing that was still different in the `Preprocessed` version, was the use of a Cortex-M `round()` function, so I've added that here as well.

## How Has This Been Tested?
CI