### PR TITLE
Add bitpacked output support to the Aarch64 optimised int16 kernel.

### DIFF
--- a/larq_compute_engine/core/bgemm_impl_ruy.h
+++ b/larq_compute_engine/core/bgemm_impl_ruy.h
@@ -77,8 +77,10 @@ struct BGemmImplUsingRuy {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
 #endif
 
-    // For now, writing bitpacked output only has a C++ implementation.
-    if (std::is_same<DstScalar, TBitpacked>::value) {
+    // Bitpacked output is only supported in the assembly kernels with int16
+    // accumulators. Otherwise, fall back to the C++ kernel.
+    if (!std::is_same<AccumScalar, std::int16_t>::value &&
+        std::is_same<DstScalar, TBitpacked>::value) {
       bgemm_runtime_path = ruy::Path::kStandardCpp;
     }
 

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -1,3 +1,6 @@
+#ifndef COMPUTE_ENGINE_CORE_BGEMM_KERNELS_ARM64_H_
+#define COMPUTE_ENGINE_CORE_BGEMM_KERNELS_ARM64_H_
+
 #include <cstdint>
 
 #include "larq_compute_engine/core/bgemm_kernels_common.h"
@@ -9,6 +12,94 @@ using namespace ruy;
 using compute_engine::core::TBitpacked;
 
 #if RUY_PLATFORM_NEON_64 && RUY_OPT(ASM)
+
+#define RUY_OFFSET_LHS_BASE_PTR 0
+#define RUY_OFFSET_RHS_BASE_PTR 8
+#define RUY_OFFSET_DST_BASE_PTR 16
+#define RUY_OFFSET_START_ROW 24
+#define RUY_OFFSET_START_COL 28
+#define RUY_OFFSET_LAST_ROW 32
+#define RUY_OFFSET_LAST_COL 36
+#define RUY_OFFSET_DST_ROWS 40
+#define RUY_OFFSET_DST_COLS 44
+#define RUY_OFFSET_LHS_STRIDE 48
+#define RUY_OFFSET_RHS_STRIDE 52
+#define RUY_OFFSET_DST_STRIDE 56
+#define RUY_OFFSET_DEPTH 60
+#define RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN 64
+#define RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX 68
+#define RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER 72
+#define RUY_OFFSET_OUTPUT_TRANSFORM_BIAS 80
+#define RUY_OFFSET_OUTPUT_TRANSFORM_THRESHOLDS 64
+
+template <typename Params>
+void CheckOffsetsInBinaryKernelParams(const Params&) {
+  static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
+  static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
+  static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
+  static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
+  static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
+  static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
+  static_assert(offsetof(Params, last_col) == RUY_OFFSET_LAST_COL, "");
+  static_assert(offsetof(Params, lhs_stride) == RUY_OFFSET_LHS_STRIDE, "");
+  static_assert(offsetof(Params, rhs_stride) == RUY_OFFSET_RHS_STRIDE, "");
+  static_assert(offsetof(Params, dst_stride) == RUY_OFFSET_DST_STRIDE, "");
+  static_assert(offsetof(Params, depth) == RUY_OFFSET_DEPTH, "");
+
+  const std::size_t OT_OFFSET = offsetof(Params, output_transform);
+
+  // For float output
+  static_assert(OT_OFFSET + offsetof(OutputTransform<float>, clamp_min) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN,
+                "");
+  static_assert(OT_OFFSET + offsetof(OutputTransform<float>, clamp_max) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX,
+                "");
+  static_assert(OT_OFFSET + offsetof(OutputTransform<float>, multiplier) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER,
+                "");
+  static_assert(OT_OFFSET + offsetof(OutputTransform<float>, bias) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_BIAS,
+                "");
+
+  // For int8 output
+  static_assert(OT_OFFSET + offsetof(OutputTransform<std::int8_t>, clamp_min) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN,
+                "");
+  static_assert(OT_OFFSET + offsetof(OutputTransform<std::int8_t>, clamp_max) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX,
+                "");
+  static_assert(
+      OT_OFFSET + offsetof(OutputTransform<std::int8_t>, multiplier) ==
+          RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER,
+      "");
+  static_assert(OT_OFFSET + offsetof(OutputTransform<std::int8_t>, bias) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_BIAS,
+                "");
+
+  // For bitpacked output
+  static_assert(OT_OFFSET + offsetof(OutputTransform<TBitpacked>, thresholds) ==
+                    RUY_OFFSET_OUTPUT_TRANSFORM_THRESHOLDS,
+                "");
+}
+
+#define MAKE_ZERO(reg) "eor " #reg ".16b, " #reg ".16b, " #reg ".16b\n"
+
+#define IF_FLOAT_OUTPUT(a) ".if %c[float_output]\n" a ".endif\n"
+
+#define IF_INT8_OUTPUT(a) ".if %c[int8_output]\n" a ".endif\n"
+
+#define IF_BITPACKED_OUTPUT(a) ".if %c[bitpacked_output]\n" a ".endif\n"
+
+#define IF_FLOAT_OR_INT8_OUTPUT(a) \
+  ".if %c[float_output] || %c[int8_output]\n" a ".endif\n"
+
+#define IF_FLOAT_ELIF_INT8_OUTPUT(a, b) \
+  ".if %c[float_output]\n" a ".elseif %c[int8_output]\n" b ".endif\n"
+
+#define IF_FLOAT_ELIF_INT8_ELIF_BITPACKED_OUTPUT(a, b, c)  \
+  ".if %c[float_output]\n" a ".elseif %c[int8_output]\n" b \
+  ".elseif %c[bitpacked_output]\n" c ".endif\n"
 
 // clang-format off
 
@@ -68,47 +159,6 @@ using compute_engine::core::TBitpacked;
 
 // clang-format on
 
-#define RUY_OFFSET_LHS_BASE_PTR 0
-#define RUY_OFFSET_RHS_BASE_PTR 8
-#define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_POST_ACTIVATION_MULTIPLIER 24
-#define RUY_OFFSET_POST_ACTIVATION_BIAS 32
-#define RUY_OFFSET_START_ROW 40
-#define RUY_OFFSET_START_COL 44
-#define RUY_OFFSET_LAST_ROW 48
-#define RUY_OFFSET_LAST_COL 52
-#define RUY_OFFSET_LHS_STRIDE 64
-#define RUY_OFFSET_RHS_STRIDE 68
-#define RUY_OFFSET_DST_STRIDE 72
-#define RUY_OFFSET_DEPTH 76
-#define RUY_OFFSET_CLAMP_MIN 80
-#define RUY_OFFSET_CLAMP_MAX 84
-
-template <typename Params>
-void CheckOffsetsInKernelParams(const Params&) {
-  static_assert(offsetof(Params, lhs_base_ptr) == RUY_OFFSET_LHS_BASE_PTR, "");
-  static_assert(offsetof(Params, rhs_base_ptr) == RUY_OFFSET_RHS_BASE_PTR, "");
-  static_assert(offsetof(Params, dst_base_ptr) == RUY_OFFSET_DST_BASE_PTR, "");
-  static_assert(offsetof(Params, post_activation_multiplier) ==
-                    RUY_OFFSET_POST_ACTIVATION_MULTIPLIER,
-                "");
-  static_assert(
-      offsetof(Params, post_activation_bias) == RUY_OFFSET_POST_ACTIVATION_BIAS,
-      "");
-  static_assert(offsetof(Params, start_row) == RUY_OFFSET_START_ROW, "");
-  static_assert(offsetof(Params, start_col) == RUY_OFFSET_START_COL, "");
-  static_assert(offsetof(Params, last_row) == RUY_OFFSET_LAST_ROW, "");
-  static_assert(offsetof(Params, last_col) == RUY_OFFSET_LAST_COL, "");
-  static_assert(offsetof(Params, lhs_stride) == RUY_OFFSET_LHS_STRIDE, "");
-  static_assert(offsetof(Params, rhs_stride) == RUY_OFFSET_RHS_STRIDE, "");
-  static_assert(offsetof(Params, dst_stride) == RUY_OFFSET_DST_STRIDE, "");
-  static_assert(offsetof(Params, depth) == RUY_OFFSET_DEPTH, "");
-  static_assert(offsetof(Params, clamp_min) == RUY_OFFSET_CLAMP_MIN, "");
-  static_assert(offsetof(Params, clamp_max) == RUY_OFFSET_CLAMP_MAX, "");
-}
-
-// clang-format off
-
 // The asm kernel below has the following NEON register allocation:
 //
 // v24 -- v27 are int32 accumulators.
@@ -133,12 +183,11 @@ void CheckOffsetsInKernelParams(const Params&) {
 // In the MAX_STREAMING part of the kernel, this elementary step
 // is repeated 2 times, using 2x more registers for LHS and RHS.
 
-// clang-format on
-
 template <typename DstScalar>
 void BinaryKernelNeonOutOfOrder4x4(
     const BinaryKernelParams<DstScalar, 4, 4>& params) {
-  CheckOffsetsInKernelParams(params);
+  CheckOffsetsInBinaryKernelParams(params);
+
   ruy::profiler::ScopeLabel label(
       "Binary Kernel (4x4) (kNeon, optimized for out-of-order cores)");
 
@@ -157,30 +206,19 @@ void BinaryKernelNeonOutOfOrder4x4(
   int col = params.start_col;
 
   asm volatile(
-#define RUY_MAKE_ZERO(reg) "dup " #reg ".4s, wzr\n"
-
-#define IF_FLOAT_OUTPUT(a) ".if %c[float_output]\n" a ".endif\n"
-
-#define IF_INT8_OUTPUT(a) ".if %c[int8_output]\n" a ".endif\n"
-
-#define IF_FLOAT_ELIF_INT8_OUTPUT(a, b) \
-  ".if %c[float_output]\n" a ".elseif %c[int8_output]\n" b ".endif\n"
-
-      // clang-format off
-
       // Load some parameters into registers.
       "ldr x5, [%[params], #" RUY_STR(RUY_OFFSET_LHS_BASE_PTR) "]\n"
       "ldr w6, [%[params], #" RUY_STR(RUY_OFFSET_START_ROW) "]\n"
-      RUY_MAKE_ZERO(v24)
+      MAKE_ZERO(v24)
       "ldr w7, [%[params], #" RUY_STR(RUY_OFFSET_LAST_ROW) "]\n"
       "ldr w8, [%[params], #" RUY_STR(RUY_OFFSET_LAST_COL) "]\n"
-      RUY_MAKE_ZERO(v25)
+      MAKE_ZERO(v25)
       "ldr w9, [%[params], #" RUY_STR(RUY_OFFSET_LHS_STRIDE) "]\n"
       "ldr w10, [%[params], #" RUY_STR(RUY_OFFSET_RHS_STRIDE) "]\n"
-      RUY_MAKE_ZERO(v26)
+      MAKE_ZERO(v26)
       "ldr w11, [%[params], #" RUY_STR(RUY_OFFSET_DST_STRIDE) "]\n"
       "ldr w12, [%[params], #" RUY_STR(RUY_OFFSET_DEPTH) "]\n"
-      RUY_MAKE_ZERO(v27)
+      MAKE_ZERO(v27)
 
       // Load the first 64 bytes of LHS and RHS data.
       "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
@@ -299,14 +337,14 @@ void BinaryKernelNeonOutOfOrder4x4(
       "mov %[rhs_ptr], %[rhs_col_ptr]\n"
 
       // Load multiplication bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_MULTIPLIER) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x1, x1, %x[row], lsl #2\n"
       // Load 4 bias-multiplication values.
       "ld1 {v14.4s}, [x1], #16\n"
 
       // Load addition bias
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_BIAS) "]\n"
+      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_BIAS) "]\n"
       // Offset these base pointers as needed given the current row, col.
       "add x1, x1, %x[row], lsl #2\n"
       // Load 4 bias-addition values.
@@ -320,7 +358,7 @@ void BinaryKernelNeonOutOfOrder4x4(
       "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[rhs_ptr]], #64\n"
 
       // Load the clamp_max bound (in parallel with the shift)
-      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
+      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN) "]\n"
       "dup v12.4s, w2\n"  // clamp_min
 
       // Perform the backtransformation shift (in int32)
@@ -330,7 +368,7 @@ void BinaryKernelNeonOutOfOrder4x4(
       "shl v27.4s, v27.4s, #1\n"
 
       // Load the clamp_max bound (in parallel with the clamp_min)
-      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"
+      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX) "]\n"
       "dup v13.4s, w3\n"  // clamp_max
 
       // Perform the activation function, by clamping
@@ -423,16 +461,16 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 IF_FLOAT_ELIF_INT8_OUTPUT(
       "str q24, [x3, #0]\n"
       "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v24)
+      MAKE_ZERO(v24)
       "str q25, [x3, #0]\n"
       "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v25)
+      MAKE_ZERO(v25)
       "str q26, [x3, #0]\n"
       "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v26)
+      MAKE_ZERO(v26)
       "str q27, [x3, #0]\n"
       "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v27)
+      MAKE_ZERO(v27)
 ,
       "str s24, [x3]\n"
       "add x3, x3, x4\n"
@@ -441,10 +479,10 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
       "str s26, [x3]\n"
       "add x3, x3, x4\n"
       "str s27, [x3]\n"
-      RUY_MAKE_ZERO(v24)
-      RUY_MAKE_ZERO(v25)
-      RUY_MAKE_ZERO(v26)
-      RUY_MAKE_ZERO(v27)
+      MAKE_ZERO(v24)
+      MAKE_ZERO(v25)
+      MAKE_ZERO(v26)
+      MAKE_ZERO(v27)
 )
 
       // If all of the 4x4 block fits, we just finished writing it to the
@@ -514,8 +552,6 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 
       "ble 1b\n"
 
-      // clang-format on
-
       : [lhs_col_ptr] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
         [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
         [dst_col_ptr] "+r"(dst_col_ptr), [dst_ptr] "+r"(dst_ptr), [row] "+r"(row), [col] "+r"(col)
@@ -529,24 +565,6 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
         "v26", "v27", "v28", "v29", "v30", "v31");
 }
 
-#undef RUY_OFFSET_POST_ACTIVATION_MULTIPLIER
-#undef RUY_OFFSET_POST_ACTIVATION_BIAS
-#undef RUY_OFFSET_LHS_BASE_PTR
-#undef RUY_OFFSET_CLAMP_MIN
-#undef RUY_OFFSET_CLAMP_MAX
-#undef RUY_OFFSET_START_ROW
-#undef RUY_OFFSET_LAST_ROW
-#undef RUY_OFFSET_LAST_COL
-#undef RUY_OFFSET_LHS_STRIDE
-#undef RUY_OFFSET_RHS_STRIDE
-#undef RUY_OFFSET_DST_STRIDE
-#undef RUY_OFFSET_DEPTH
-#undef RUY_OFFSET_START_COL
-#undef RUY_OFFSET_RHS_BASE_PTR
-#undef RUY_OFFSET_DST_BASE_PTR
-
-// clang-format off
-
 /*
  * The 8x4 kernel defined below uses int16 accumulators. This means that all
  * eight accumulators for a single column fit in a single NEON register, freeing
@@ -559,6 +577,8 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
  * Nevertheless, for safety we use the 4x4 kernel with int32 accumulators
  * instead when `filter_height` * `filter_width` * `input_channels` >= 2^16.
  */
+
+// clang-format off
 
 // XOR-CNT registers: v12 -- v19.
 #define LCE_XOR(Vr, Vl1, Vl2, Vl3, Vl4, Vl5, Vl6, Vl7, Vl8) \
@@ -650,24 +670,6 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 
 // clang-format on
 
-#define RUY_OFFSET_LHS_BASE_PTR 0
-#define RUY_OFFSET_RHS_BASE_PTR 8
-#define RUY_OFFSET_DST_BASE_PTR 16
-#define RUY_OFFSET_POST_ACTIVATION_MULTIPLIER 24
-#define RUY_OFFSET_POST_ACTIVATION_BIAS 32
-#define RUY_OFFSET_START_ROW 40
-#define RUY_OFFSET_START_COL 44
-#define RUY_OFFSET_LAST_ROW 48
-#define RUY_OFFSET_LAST_COL 52
-#define RUY_OFFSET_LHS_STRIDE 64
-#define RUY_OFFSET_RHS_STRIDE 68
-#define RUY_OFFSET_DST_STRIDE 72
-#define RUY_OFFSET_DEPTH 76
-#define RUY_OFFSET_CLAMP_MIN 80
-#define RUY_OFFSET_CLAMP_MAX 84
-
-// clang-format off
-
 // The asm kernel below has the following NEON register allocation:
 //
 // v24 -- v27 are int16 accumulators. During accumulation, v0 -- v7 are used to
@@ -696,12 +698,11 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 // results. v20 -- v23 are used to combine the byte-level CNT results for
 // accumulation into the destination registers.
 
-// clang-format on
-
 template <typename DstScalar>
 void BinaryKernelNeonOutOfOrder8x4(
     const BinaryKernelParams<DstScalar, 8, 4>& params) {
-  CheckOffsetsInKernelParams(params);
+  CheckOffsetsInBinaryKernelParams(params);
+
   ruy::profiler::ScopeLabel label(
       "Binary Kernel (8x4) (kNeon, optimized for out-of-order cores)");
 
@@ -720,30 +721,31 @@ void BinaryKernelNeonOutOfOrder8x4(
   int col = params.start_col;
 
   asm volatile(
-#define RUY_MAKE_ZERO(reg) "dup " #reg ".4s, wzr\n"
-
-#define IF_FLOAT_OUTPUT(a) ".if %c[float_output]\n" a ".endif\n"
-
-#define IF_INT8_OUTPUT(a) ".if %c[int8_output]\n" a ".endif\n"
-
-#define IF_FLOAT_ELIF_INT8_OUTPUT(a, b) \
-  ".if %c[float_output]\n" a ".elseif %c[int8_output]\n" b ".endif\n"
-
-      // clang-format off
-
       // Load some parameters into registers.
       "ldr x5, [%[params], #" RUY_STR(RUY_OFFSET_LHS_BASE_PTR) "]\n"
       "ldr w6, [%[params], #" RUY_STR(RUY_OFFSET_START_ROW) "]\n"
-      RUY_MAKE_ZERO(v24)
+      MAKE_ZERO(v24)
       "ldr w7, [%[params], #" RUY_STR(RUY_OFFSET_LAST_ROW) "]\n"
       "ldr w8, [%[params], #" RUY_STR(RUY_OFFSET_LAST_COL) "]\n"
-      RUY_MAKE_ZERO(v25)
+      MAKE_ZERO(v25)
       "ldr w9, [%[params], #" RUY_STR(RUY_OFFSET_LHS_STRIDE) "]\n"
       "ldr w10, [%[params], #" RUY_STR(RUY_OFFSET_RHS_STRIDE) "]\n"
-      RUY_MAKE_ZERO(v26)
+      MAKE_ZERO(v26)
       "ldr w11, [%[params], #" RUY_STR(RUY_OFFSET_DST_STRIDE) "]\n"
       "ldr w12, [%[params], #" RUY_STR(RUY_OFFSET_DEPTH) "]\n"
-      RUY_MAKE_ZERO(v27)
+      MAKE_ZERO(v27)
+
+IF_BITPACKED_OUTPUT(
+      // Load a constant into the vector register v31, such that each half word
+      // at position i is equal to (1 << i). This will be a bitmask used for
+      // bitpacking the output into bytes.
+      "mov x2, 1\n"
+      "add x2, x2, x2, lsl #17\n"
+      "add x2, x2, x2, lsl #34\n"
+      "lsl x3, x2, #4\n"
+      "ins v31.d[0], x2\n"
+      "ins v31.d[1], x3\n"
+)
 
       // Load the first 128 bytes of LHS and 16 bytes of RHS data.
       "ld1 {v8.4s}, [%[rhs_ptr]], #16\n"
@@ -819,76 +821,192 @@ void BinaryKernelNeonOutOfOrder8x4(
       "mov %[lhs_ptr], %[lhs_col_ptr]\n"
       "mov %[rhs_ptr], %[rhs_col_ptr]\n"
 
+      // Compute how much of the 8x4 block of destination values that we have
+      // computed fits in the destination matrix. Typically, all of it fits, but
+      // when the destination matrix shape is not a multiple of 8x4 there are
+      // some 8x4 blocks along the boundaries that do not fit entirely.
+      "sub w1, %w[dst_rows], %w[row]\n"
+      "sub w2, %w[dst_cols], %w[col]\n"
+      "mov w3, #8\n"
+      "mov w4, #4\n"
+      "cmp w1, #8\n"
+      // Compute w1 = how many rows of the 8x4 block fit.
+      "csel w1, w1, w3, le\n"
+      "cmp w2, #4\n"
+      // Compute w2 = how many cols of the 8x4 block fit.
+      "csel w2, w2, w4, le\n"
+
+IF_BITPACKED_OUTPUT(
+      // Load the thresholds pointer, offset as needed by the current row, and
+      // load 8 values into v29 and v30.
+      "ldr x14, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_THRESHOLDS) "]\n"
+      "add x14, x14, %x[row], lsl #2\n"
+      "ld1 {v29.4s, v30.4s}, [x14]\n"
+
+      // Use "unsigned extend long" instructions to extend to int32 (in order to
+      // do the comparison with the thresholds).
+      "uxtl v20.4s, v24.4h\n"
+      "uxtl2 v21.4s, v24.8h\n"
+      "uxtl v22.4s, v25.4h\n"
+      "uxtl2 v23.4s, v25.8h\n"
+      "ld1 {v8.4s}, [%[rhs_ptr]], #16\n" // In parallel, load next RHS data.
+      "uxtl v24.4s, v26.4h\n"
+      "uxtl2 v25.4s, v26.8h\n"
+      "uxtl v26.4s, v27.4h\n"
+      "uxtl2 v27.4s, v27.8h\n"
+
+      // We want to write a 1-bit if accum > threshold, and so we use "compare
+      // signed greater than" instructions, which fill each element with ones if
+      // accum > threshold, or zeroes otherwise.
+      "ld1 {v0.4s, v1.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
+      "cmgt v20.4s, v20.4s, v29.4s\n"
+      "cmgt v21.4s, v21.4s, v30.4s\n"
+      "cmgt v22.4s, v22.4s, v29.4s\n"
+      "cmgt v23.4s, v23.4s, v30.4s\n"
+      "ld1 {v2.4s, v3.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
+      "cmgt v24.4s, v24.4s, v29.4s\n"
+      "cmgt v25.4s, v25.4s, v30.4s\n"
+      "cmgt v26.4s, v26.4s, v29.4s\n"
+      "cmgt v27.4s, v27.4s, v30.4s\n"
+
+      // Use "extract narrow" instructions to narrow back to int16.
+      "ld1 {v4.4s, v5.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
+      "xtn v20.4h, v20.4s\n"
+      "xtn2 v20.8h, v21.4s\n"
+      "xtn v21.4h, v22.4s\n"
+      "xtn2 v21.8h, v23.4s\n"
+      "ld1 {v6.4s, v7.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
+      "xtn v22.4h, v24.4s\n"
+      "xtn2 v22.8h, v25.4s\n"
+      "xtn v23.4h, v26.4s\n"
+      "xtn2 v23.8h, v27.4s\n"
+
+      // Intersect with the bitmask loaded into v31. Each result register will
+      // contain 8 half word elements with at most one bit set: such that the
+      // element at position i contains (1 << i) if we're writing a 1-bit, or 0
+      // otherwise.
+      "and v20.16b, v20.16b, v31.16b\n"
+      "and v21.16b, v21.16b, v31.16b\n"
+      "and v22.16b, v22.16b, v31.16b\n"
+      "and v23.16b, v23.16b, v31.16b\n"
+
+      // Use "add across vector" instructions to sum all 8 elements of each
+      // register into 0th element position.
+      "addv h20, v20.8h\n"
+      "addv h21, v21.8h\n"
+      "addv h22, v22.8h\n"
+      "addv h23, v23.8h\n"
+
+      // Test if w1 == 8 && w2 == 4, i.e. if all of the 8x4 block fits.
+      "cmp w1, w3\n"
+      "ccmp w2, w4, 0, eq\n"
+      "beq 60f\n"
+
+      // Slow path: not all the 8x4 block fits
+      "mov w15, #1\n"
+      "lsl w15, w15, w1\n"
+      "sub w15, w15, #1\n"
+      "mov v30.b[0], w15\n"
+      "mov w14, w2\n"
+      "mov x3, %[dst_ptr]\n"
+      "and v20.8b, v20.8b, v30.8b\n"
+      "subs w14, w14, #1\n"
+      "st1 {v20.b}[0], [x3], x11\n"
+      "ble 61f\n"
+      "and v21.8b, v21.8b, v30.8b\n"
+      "subs w14, w14, #1\n"
+      "st1 {v21.b}[0], [x3], x11\n"
+      "ble 61f\n"
+      "and v22.8b, v22.8b, v30.8b\n"
+      "subs w14, w14, #1\n"
+      "st1 {v22.b}[0], [x3], x11\n"
+      "ble 61f\n"
+      "and v23.8b, v23.8b, v30.8b\n"
+      "st1 {v23.b}[0], [x3]\n"
+      "b 61f\n"
+
+      // Fast path: all the 8x4 block fits
+      "60:\n"
+      "mov x3, %[dst_ptr]\n"
+      "st1 {v20.b}[0], [x3], x11\n"
+      "st1 {v21.b}[0], [x3], x11\n"
+      "st1 {v22.b}[0], [x3], x11\n"
+      "st1 {v23.b}[0], [x3]\n"
+
+      "61:\n"
+)
+
+IF_FLOAT_OR_INT8_OUTPUT(
       // Now that we know what LHS and RHS data the next iteration of the main
       // loop will need to load, we start loading the first 128 bytes of the LHS
       // and 16 bytes of the RHS into v0 -- v7 and v8 as we don't need them
       // anymore in the rest of the work on the current block. We do it in
       // parallel with the back-transform shift.
 
-      // Load the `clamp_min` bound.
-      "ldr w2, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MIN) "]\n"
-
-      // Load the `clamp_max` bound.
-      "ldr w3, [%[params], #" RUY_STR(RUY_OFFSET_CLAMP_MAX) "]\n"
+      // Calculate the `clamp_min` and `clamp_max` addresses.
+      "add x14, %[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN) "\n"
+      "add x15, %[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX) "\n"
 
       // Perform the back-transformation shift with 'unsigned shift left long'
       // instructions; this performs the necessary left shift and extends the
       // result, so we get a int16 -> int32 transformation for free.
-      "dup v29.4s, w2\n"  // In parallel, duplicate `clamp_min` into v29.
       "ushll v20.4s, v24.4h, #1\n"
       "ushll2 v21.4s, v24.8h, #1\n"
-      "ld1 {v8.4s}, [%[rhs_ptr]], #16\n"
+      "ld1r {v29.4s}, [x14]\n"  // In parallel, duplicate `clamp_min` into v29.
       "ushll v22.4s, v25.4h, #1\n"
       "ushll2 v23.4s, v25.8h, #1\n"
-      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%[lhs_ptr]], #64\n"
+      "ld1r {v30.4s}, [x15]\n"  // In parallel, duplicate `clamp_max` into v30.
       "ushll v24.4s, v26.4h, #1\n"
       "ushll2 v25.4s, v26.8h, #1\n"
+      "ld1 {v8.4s}, [%[rhs_ptr]], #16\n" // In parallel, load next RHS data.
       "ushll v26.4s, v27.4h, #1\n"
       "ushll2 v27.4s, v27.8h, #1\n"
-      "ld1 {v4.4s, v5.4s, v6.4s, v7.4s}, [%[lhs_ptr]], #64\n"
+
+      // Load the multiplier and bias pointers.
+      "ldr x14, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER) "]\n"
+      "ldr x15, [%[params], #" RUY_STR(RUY_OFFSET_OUTPUT_TRANSFORM_BIAS) "]\n"
 
       // Apply the `clamp_min` bound.
-      "dup v30.4s, w3\n"  // In parallel, duplicate `clamp_max` into v30.
+      "ld1 {v0.4s, v1.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
       "smax v20.4s, v20.4s, v29.4s\n"
       "smax v21.4s, v21.4s, v29.4s\n"
+      "ld1 {v2.4s, v3.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
       "smax v22.4s, v22.4s, v29.4s\n"
       "smax v23.4s, v23.4s, v29.4s\n"
+      "ld1 {v4.4s, v5.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
       "smax v24.4s, v24.4s, v29.4s\n"
       "smax v25.4s, v25.4s, v29.4s\n"
+      "ld1 {v6.4s, v7.4s}, [%[lhs_ptr]], #32\n" // In parallel, load next LHS data.
       "smax v26.4s, v26.4s, v29.4s\n"
       "smax v27.4s, v27.4s, v29.4s\n"
 
-      // Load the multiplier and bias pointers.
-      "ldr x1, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_MULTIPLIER) "]\n"
-      "ldr x2, [%[params], #" RUY_STR(RUY_OFFSET_POST_ACTIVATION_BIAS) "]\n"
+      // Offset the multiplier/bias pointers as needed given the current row.
+      "add x14, x14, %x[row], lsl #2\n"
+      "add x15, x15, %x[row], lsl #2\n"
 
       // Apply the clamp_max bound.
       "smin v20.4s, v20.4s, v30.4s\n"
       "smin v21.4s, v21.4s, v30.4s\n"
       "smin v22.4s, v22.4s, v30.4s\n"
       "smin v23.4s, v23.4s, v30.4s\n"
+      "ld1 {v28.4s, v29.4s}, [x14]\n"  // In parallel, load 8 multiplier values.
       "smin v24.4s, v24.4s, v30.4s\n"
       "smin v25.4s, v25.4s, v30.4s\n"
       "smin v26.4s, v26.4s, v30.4s\n"
       "smin v27.4s, v27.4s, v30.4s\n"
 
-      // Offset the multiplier/bias pointers as needed given the current row, col.
-      "add x1, x1, %x[row], lsl #2\n"
-      "add x2, x2, %x[row], lsl #2\n"
-
       // Convert to single precision float.
-      "ld1 {v28.4s, v29.4s}, [x1]\n"  // In parallel, load 8 multiplier values.
       "scvtf v20.4s, v20.4s\n"
       "scvtf v21.4s, v21.4s\n"
       "scvtf v22.4s, v22.4s\n"
       "scvtf v23.4s, v23.4s\n"
+      "ld1 {v30.4s, v31.4s}, [x15]\n"  // In parallel, load 8 bias values.
       "scvtf v24.4s, v24.4s\n"
       "scvtf v25.4s, v25.4s\n"
       "scvtf v26.4s, v26.4s\n"
       "scvtf v27.4s, v27.4s\n"
 
       // Perform the post multiplications.
-      "ld1 {v30.4s, v31.4s}, [x2]\n"  // In parallel, load 8 bias-addition values.
       "fmul v20.4s, v20.4s, v28.4s\n"
       "fmul v21.4s, v21.4s, v29.4s\n"
       "fmul v22.4s, v22.4s, v28.4s\n"
@@ -907,6 +1025,7 @@ void BinaryKernelNeonOutOfOrder8x4(
       "fadd v25.4s, v25.4s, v31.4s\n"
       "fadd v26.4s, v26.4s, v30.4s\n"
       "fadd v27.4s, v27.4s, v31.4s\n"
+)
 
 IF_INT8_OUTPUT(
       // Convert to int32, rounding to nearest with ties to even.
@@ -936,22 +1055,8 @@ IF_INT8_OUTPUT(
       "sqxtn v23.8b, v31.8h\n"
 )
 
-      // Compute how much of the 8x4 block of destination values that we have
-      // computed fits in the destination matrix. Typically, all of it fits, but
-      // when the destination matrix shape is not a multiple of 8x4 there are
-      // some 8x4 blocks along the boundaries that do not fit entirely.
-      "sub w1, %w[dst_rows], %w[row]\n"
-      "sub w2, %w[dst_cols], %w[col]\n"
-      "mov w3, #8\n"
-      "mov w4, #4\n"
-      "cmp w1, #8\n"
-      // Compute w1 = how many rows of the 8x4 block fit.
-      "csel w1, w1, w3, le\n"
-      "cmp w2, #4\n"
-      // Compute w2 = how many cols of the 8x4 block fit.
-      "csel w2, w2, w4, le\n"
-
-      // Test if w1==8 && w2 == 4, i.e. if all of the 8x4 block fits.
+IF_FLOAT_OR_INT8_OUTPUT(
+      // Test if w1 == 8 && w2 == 4, i.e. if all of the 8x4 block fits.
       "cmp w1, w3\n"
       "ccmp w2, w4, 0, eq\n"
       // Yes, all of the 8x4 block fits, go to fast path.
@@ -959,11 +1064,7 @@ IF_INT8_OUTPUT(
       // Not all of the 8x4 block fits.
       // Set (x3 address, x4 stride) to write to `dst_tmp_buf`.
       "mov x3, %[dst_tmp_buf]\n"
-IF_FLOAT_ELIF_INT8_OUTPUT(
-      "mov x4, #32\n"
-,
-      "mov x4, #8\n"
-)
+      IF_FLOAT_ELIF_INT8_OUTPUT("mov x4, #32\n", "mov x4, #8\n")
       "b 31f\n"
       "30:\n"
       // Yes, all of the 8x4 block fits.
@@ -974,35 +1075,27 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 
       // Write our values to the destination described by
       // (x3 address, x4 stride).
-IF_FLOAT_ELIF_INT8_OUTPUT(
-      "str q20, [x3]\n"
-      "str q21, [x3, #16]\n"
-      "add x3, x3, x4\n"
-      "str q22, [x3]\n"
-      "str q23, [x3, #16]\n"
-      "add x3, x3, x4\n"
-      "str q24, [x3]\n"
-      "str q25, [x3, #16]\n"
-      "add x3, x3, x4\n"
-      RUY_MAKE_ZERO(v24)
-      RUY_MAKE_ZERO(v25)
-      "str q26, [x3]\n"
-      "str q27, [x3, #16]\n"
-      RUY_MAKE_ZERO(v26)
-      RUY_MAKE_ZERO(v27)
-,
-      "str d20, [x3]\n"
-      "add x3, x3, x4\n"
-      "str d21, [x3]\n"
-      "add x3, x3, x4\n"
-      "str d22, [x3]\n"
-      "add x3, x3, x4\n"
-      "str d23, [x3]\n"
-      RUY_MAKE_ZERO(v24)
-      RUY_MAKE_ZERO(v25)
-      RUY_MAKE_ZERO(v26)
-      RUY_MAKE_ZERO(v27)
-)
+      IF_FLOAT_ELIF_INT8_OUTPUT(
+            "str q20, [x3]\n"
+            "str q21, [x3, #16]\n"
+            "add x3, x3, x4\n"
+            "str q22, [x3]\n"
+            "str q23, [x3, #16]\n"
+            "add x3, x3, x4\n"
+            "str q24, [x3]\n"
+            "str q25, [x3, #16]\n"
+            "add x3, x3, x4\n"
+            "str q26, [x3]\n"
+            "str q27, [x3, #16]\n"
+      ,
+            "str d20, [x3]\n"
+            "add x3, x3, x4\n"
+            "str d21, [x3]\n"
+            "add x3, x3, x4\n"
+            "str d22, [x3]\n"
+            "add x3, x3, x4\n"
+            "str d23, [x3]\n"
+      )
 
       // If all of the 8x4 block fits, we just finished writing it to the
       // destination, so we skip the next part.
@@ -1016,31 +1109,29 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
       "50:\n"
       "mov w15, #0\n"
       "51:\n"
-IF_FLOAT_ELIF_INT8_OUTPUT(
-      "ldr w13, [x3, x15, lsl #2]\n"
-      "str w13, [x4, x15, lsl #2]\n"
-,
-      "ldrb w13, [x3, x15]\n"
-      "strb w13, [x4, x15]\n"
-)
+      IF_FLOAT_ELIF_INT8_OUTPUT(
+            "ldr w13, [x3, x15, lsl #2]\n"
+            "str w13, [x4, x15, lsl #2]\n"
+      ,
+            "ldrb w13, [x3, x15]\n"
+            "strb w13, [x4, x15]\n"
+      )
       "add w15, w15, #1\n"
       "cmp w15, w1\n"
       "blt 51b\n"
       "add w14, w14, #1\n"
-IF_FLOAT_ELIF_INT8_OUTPUT(
-      "add x3, x3, #32\n"
-,
-      "add x3, x3, #8\n"
-)
+      IF_FLOAT_ELIF_INT8_OUTPUT("add x3, x3, #32\n", "add x3, x3, #8\n")
       "add x4, x4, x11\n"
       "cmp w14, w2\n"
       "blt 50b\n"
       "41:\n"
-IF_FLOAT_ELIF_INT8_OUTPUT(
-      "add %[dst_ptr], %[dst_ptr], #32\n"
-,
-      "add %[dst_ptr], %[dst_ptr], #8\n"
 )
+
+      // Clear accumulators.
+      MAKE_ZERO(v24)
+      MAKE_ZERO(v25)
+      MAKE_ZERO(v26)
+      MAKE_ZERO(v27)
 
       // At this point we have completely finished writing values to the
       // destination matrix for the current block.
@@ -1052,6 +1143,13 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
       "beq 20f\n"  // Yes, end row.
       // Not end row. Move to the next row.
       "add %w[row], %w[row], #8\n"
+IF_FLOAT_ELIF_INT8_ELIF_BITPACKED_OUTPUT(
+      "add %[dst_ptr], %[dst_ptr], #32\n"
+,
+      "add %[dst_ptr], %[dst_ptr], #8\n"
+,
+      "add %[dst_ptr], %[dst_ptr], #1\n"
+)
       "b 21f\n"
       "20:\n"
       // Was already at end row.
@@ -1070,34 +1168,46 @@ IF_FLOAT_ELIF_INT8_OUTPUT(
 
       "ble 1b\n"
 
-      // clang-format on
-
       : [lhs_col_ptr] "+r"(lhs_col_ptr), [rhs_col_ptr] "+r"(rhs_col_ptr),
         [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
         [dst_col_ptr] "+r"(dst_col_ptr), [dst_ptr] "+r"(dst_ptr), [row] "+r"(row), [col] "+r"(col)
       : [params] "r"(&params), [dst_rows] "r"(params.dst_rows),
         [dst_cols] "r"(params.dst_cols), [dst_tmp_buf] "r"(params.dst_tmp_buf),
         [float_output]"i"(std::is_same<DstScalar, float>::value),
-        [int8_output]"i"(std::is_same<DstScalar, std::int8_t>::value)
+        [int8_output]"i"(std::is_same<DstScalar, std::int8_t>::value),
+        [bitpacked_output]"i"(std::is_same<DstScalar, TBitpacked>::value)
       : "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "cc",
         "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12",
         "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25",
         "v26", "v27", "v28", "v29", "v30", "v31");
 }
-#undef RUY_OFFSET_POST_ACTIVATION_MULTIPLIER
-#undef RUY_OFFSET_POST_ACTIVATION_BIAS
+
+#undef MAKE_ZERO
+#undef IF_FLOAT_OUTPUT
+#undef IF_INT8_OUTPUT
+#undef IF_BITPACKED_OUTPUT
+#undef IF_FLOAT_OR_INT8_OUTPUT
+#undef IF_FLOAT_ELIF_INT8_OUTPUT
+#undef IF_FLOAT_ELIF_INT8_ELIF_BITPACKED_OUTPUT
+
 #undef RUY_OFFSET_LHS_BASE_PTR
-#undef RUY_OFFSET_CLAMP_MIN
-#undef RUY_OFFSET_CLAMP_MAX
+#undef RUY_OFFSET_RHS_BASE_PTR
+#undef RUY_OFFSET_DST_BASE_PTR
 #undef RUY_OFFSET_START_ROW
+#undef RUY_OFFSET_START_COL
 #undef RUY_OFFSET_LAST_ROW
 #undef RUY_OFFSET_LAST_COL
+#undef RUY_OFFSET_DST_ROWS
+#undef RUY_OFFSET_DST_COLS
 #undef RUY_OFFSET_LHS_STRIDE
 #undef RUY_OFFSET_RHS_STRIDE
 #undef RUY_OFFSET_DST_STRIDE
 #undef RUY_OFFSET_DEPTH
-#undef RUY_OFFSET_START_COL
-#undef RUY_OFFSET_RHS_BASE_PTR
-#undef RUY_OFFSET_DST_BASE_PTR
+#undef RUY_OFFSET_OUTPUT_TRANSFORM_MULTIPLIER
+#undef RUY_OFFSET_OUTPUT_TRANSFORM_BIAS
+#undef RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MIN
+#undef RUY_OFFSET_OUTPUT_TRANSFORM_CLAMP_MAX
+#undef RUY_OFFSET_OUTPUT_TRANSFORM_THRESHOLDS
 
 #endif  // RUY_PLATFORM_NEON_64 && RUY_OPT(ASM)
+#endif  // COMPUTE_ENGINE_CORE_BGEMM_KERNELS_ARM64_H_

--- a/larq_compute_engine/core/bgemm_kernels_common.h
+++ b/larq_compute_engine/core/bgemm_kernels_common.h
@@ -2,14 +2,15 @@
 #define COMPUTE_EGNINE_TFLITE_KERNELS_BGEMM_KERNELS_COMMON_H_
 
 #include "larq_compute_engine/core/bconv2d_output_transform.h"
+#include "larq_compute_engine/core/types.h"
 #include "ruy/kernel_common.h"
 
 using namespace ruy;
 
-using compute_engine::core::OutputTransform;
-
-using compute_engine::core::bitpacking_bitwidth;
-using compute_engine::core::TBitpacked;
+namespace ce = compute_engine;
+using ce::core::bitpacking_bitwidth;
+using ce::core::OutputTransform;
+using ce::core::TBitpacked;
 
 // Our version of `ruy::MulParams`; The original is in `ruy/mul_params.h`.
 // We simply use our `OutputTransform` struct.
@@ -52,11 +53,6 @@ struct BinaryKernelParams {
   const TBitpacked* lhs_base_ptr;
   const TBitpacked* rhs_base_ptr;
   DstScalar* dst_base_ptr;
-  // post_mutiply and post_activation_bias are currently float
-  // in order to accomodate for batchnorm scales
-  // Later this might be changed to the int8 system of multipliers+shifts
-  const float* post_activation_multiplier;
-  const float* post_activation_bias;
   std::int32_t start_row;
   std::int32_t start_col;
   std::int32_t last_row;
@@ -67,42 +63,57 @@ struct BinaryKernelParams {
   std::int32_t rhs_stride;
   std::int32_t dst_stride;
   std::int32_t depth;
-  std::int32_t clamp_min;
-  std::int32_t clamp_max;
-  DstScalar dst_tmp_buf[LhsCols * RhsCols];
+  OutputTransform<DstScalar> output_transform;
+  DstScalar dst_tmp_buf[LhsCols * RhsCols];  // Used for float or int8 output
 };
 
 template <typename AccumScalar, typename DstScalar, int LhsCols, int RhsCols>
 inline void MakeBinaryKernelParams(
-    const PMat<TBitpacked>& lhs, const PMat<TBitpacked>& rhs,
-    const BinaryMulParams<AccumScalar, DstScalar>& spec, int start_row,
+    const PMat<TBitpacked>& lhs, const PMat<TBitpacked>& rhs, int start_row,
     int start_col, int end_row, int end_col, Mat<DstScalar>* dst,
+    const BinaryMulParams<AccumScalar, DstScalar>& spec,
     BinaryKernelParams<DstScalar, LhsCols, RhsCols>* params) {
-  const int depth = lhs.layout.rows;
   RUY_DCHECK_EQ(start_row % LhsCols, 0);
   RUY_DCHECK_EQ(start_col % RhsCols, 0);
   RUY_DCHECK_EQ(end_row % LhsCols, 0);
   RUY_DCHECK_EQ(end_col % RhsCols, 0);
+  if (std::is_same<DstScalar, TBitpacked>::value) {
+    RUY_DCHECK_EQ(start_row % 8, 0);
+    RUY_DCHECK_EQ(end_row % 8, 0);
+  }
 
   params->lhs_base_ptr = lhs.data + start_row * lhs.layout.stride;
   params->rhs_base_ptr = rhs.data + start_col * rhs.layout.stride;
-  params->dst_base_ptr =
-      dst->data.get() + start_col * dst->layout.stride + start_row;
-
-  params->post_activation_multiplier = spec.output_transform.multiplier;
-  params->post_activation_bias = spec.output_transform.bias;
+  if (std::is_same<DstScalar, TBitpacked>::value) {
+    // When writing bitpacked output with multiple threads, the start/end row
+    // will not necessarily be aligned to a TBitpacked boundary (though they are
+    // guaranteed to be aligned to a byte boundary). For example, start_row
+    // could be 8, in which case we'd be writing into the second byte of each
+    // TBitpacked value. Hence the need for char pointer arithmetic.
+    params->dst_base_ptr =
+        (DstScalar*)((char*)(dst->data.get() +
+                             start_col * ce::core::GetBitpackedSize(
+                                             dst->layout.stride)) +
+                     start_row / 8);
+  } else {
+    params->dst_base_ptr =
+        dst->data.get() + start_col * dst->layout.stride + start_row;
+  }
   params->start_row = start_row;
   params->start_col = start_col;
   params->last_row = end_row - LhsCols;
   params->last_col = end_col - RhsCols;
-  params->lhs_stride = sizeof(TBitpacked) * lhs.layout.stride;
-  params->rhs_stride = sizeof(TBitpacked) * rhs.layout.stride;
-  params->dst_stride = sizeof(DstScalar) * dst->layout.stride;
-  params->depth = depth;
-  params->clamp_min = spec.output_transform.clamp_min;
-  params->clamp_max = spec.output_transform.clamp_max;
   params->dst_rows = dst->layout.rows;
   params->dst_cols = dst->layout.cols;
+  params->lhs_stride = sizeof(TBitpacked) * lhs.layout.stride;
+  params->rhs_stride = sizeof(TBitpacked) * rhs.layout.stride;
+  params->dst_stride =
+      sizeof(DstScalar) * (std::is_same<DstScalar, TBitpacked>::value
+                               ? ce::core::GetBitpackedSize(dst->layout.stride)
+                               : dst->layout.stride);
+  params->depth = lhs.layout.rows;
+  params->output_transform =
+      spec.output_transform;  // This is a four word copy, but that's okay.
 
   RUY_DCHECK_LT(params->last_row, params->dst_rows);
   RUY_DCHECK_LT(params->last_col, params->dst_cols);


### PR DESCRIPTION
## What do these changes do?

This PR adds support for writing bitpacked output to the optimised assembly Aarch64 kernel with 16-bit accumulators.

Bitpacked output remains unsupported by the Aarch64 fallback optimised kernel with 32-bit accumulators, and the Arm32 optimised kernel. The reason for this is that the Aarch64 int16 kernel has a 8x4 kernel layout that writes eight output channels in parallel, whereas the others have a 4x4 kernel layout that writes only four channels in parallel. With eight channels we can always pack the bits into a byte, whereas four channels would require something more complicated (especially to support multi-threading).

## How Has This Been Tested?

CI. The 'big' kernel tests for Aarch64 and Arm32 pass locally.

## Benchmark Results

To benchmark this change, I've taken the binary alexnet model from Larq Zoo, modified it to use one-padding instead of zero-padding, and run the LCE benchmark tool (with `num_runs=250`) on my Android phone, a OnePlus 6, reporting the average latency and standard deviation:

| Model                             | Baseline       | PR            |
|-----------------------------------|----------------|---------------|
| Binary AlexNet (with one-padding) | 111.42 +- 0.60 | 64.95 +- 0.14 |

Note that the binary alexnet model includes large binary dense layers at the end of the model which are not currently accelerated by LCE. Thus, the performance improvement for the bconv op alone will be greater than the overall latency suggests. 

## Related issue number

N/A.
