### PR TITLE
Fix bug introduced by #497. Make sure OPT kernels run.

### DIFF
--- a/larq_compute_engine/core/bgemm_trmul_params.h
+++ b/larq_compute_engine/core/bgemm_trmul_params.h
@@ -22,7 +22,7 @@ void PopulateBgemmTrMulParams(const Mat<TBitpacked>& lhs,
   params->mul_params = ToVoidPtr(&mul_params);
 
   // Optimised code paths only support all matrices being column-major
-  if (ruy::IsColMajorTrMul(*params) && ThePath != ruy::Path::kStandardCpp) {
+  if (!ruy::IsColMajorTrMul(*params) && ThePath != ruy::Path::kStandardCpp) {
     PopulateBgemmTrMulParams<ruy::Path::kStandardCpp>(lhs, rhs, dst, mul_params,
                                                       params);
     return;


### PR DESCRIPTION
## What do these changes do?

#497 accidentally disabled OPT kernels from running. This restores them.

## How Has This Been Tested?

CI.

## Benchmark Results

I've verified that the optimised kernel is running on my Android phone.

## Related issue number

#497.