### PR TITLE
Simplify MAKE_ZERO macro

### DIFF
--- a/larq_compute_engine/core/bgemm_kernels_arm32.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm32.h
@@ -85,7 +85,7 @@ void CheckOffsetsInKernelParams(const Params&) {
                 "");
 }
 
-#define MAKE_ZERO(reg) "veor.s8 " #reg ", " #reg ", " #reg "\n"
+#define MAKE_ZERO(reg) "vmov.s8 " #reg ", #0\n"
 
 #define IF_FLOAT_OUTPUT(a) ".if %c[float_output]\n" a ".endif\n"
 

--- a/larq_compute_engine/core/bgemm_kernels_arm64.h
+++ b/larq_compute_engine/core/bgemm_kernels_arm64.h
@@ -83,7 +83,7 @@ void CheckOffsetsInBinaryKernelParams(const Params&) {
                 "");
 }
 
-#define MAKE_ZERO(reg) "eor " #reg ".16b, " #reg ".16b, " #reg ".16b\n"
+#define MAKE_ZERO(reg) "movi " #reg ".16b, #0\n"
 
 #define IF_FLOAT_OUTPUT(a) ".if %c[float_output]\n" a ".endif\n"
 


### PR DESCRIPTION
## What do these changes do?
This PR replaces the `eor` to zero the vector register with a `movi` instruction to simplify the macro a bit. The A72 optimisation guide lists that `eor` and `movi` have the same latency and throughput numbers so the performance should be equivalent.

## How Has This Been Tested?
CI

## Benchmark Results
I briefly ran some benchmarks on my phone and couldn't measure any difference.

## Related issue number
Followup on https://github.com/larq/compute-engine/pull/496#discussion_r485692386
