### PR TITLE
Add padding to temporary arrays to ensure we don't read beyond bounds.

### DIFF
--- a/larq_compute_engine/core/types.h
+++ b/larq_compute_engine/core/types.h
@@ -8,6 +8,11 @@
 namespace compute_engine {
 namespace core {
 
+// In our kernels we may occasionally read (but never write) beyond the end of
+// an array. This is the maximum number of extra bytes that will be read, and
+// should be added as padding to the end of tensor allocations.
+#define LCE_EXTRA_BYTES 16
+
 // Define these once here, so they can be included everywhere.
 using TBitpacked = std::int32_t;
 constexpr std::size_t bitpacking_bitwidth =

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -298,8 +298,10 @@ void OneTimeSetup(TfLiteContext* context, TfLiteNode* node,
   // If applicable, fuse the back-transformation and int8 scale/zero-point into
   // the output transform multiplier/bias.
   if (output->type == kTfLiteFloat32 || output->type == kTfLiteInt8) {
-    params->output_transform_multiplier.resize(params->channels_out);
-    params->output_transform_bias.resize(params->channels_out);
+    params->output_transform_multiplier.resize(params->channels_out +
+                                               LCE_EXTRA_BYTES / sizeof(float));
+    params->output_transform_bias.resize(params->channels_out +
+                                         LCE_EXTRA_BYTES / sizeof(float));
 
     const auto filter_shape = GetTensorShape(GetInput(context, node, 1));
     const std::int32_t backtransform_add =


### PR DESCRIPTION
## What do these changes do?

@Tombana and I had a conversation last week about the fact that in our (optimised) kernels we sometimes read beyond the bounds of our temporary arrays. For example, in the int16 accumulator kernel we read eight output transform multiplier/biases, even if there's only a single output channel (and so only one value in each array). This currently doesn't seem to be causing a problem in practice, but could lead to undefined behaviour and/or segfaults.

This PR adds a `LCE_EXTRA_BYTES` value (inspired by this [definition in XNNPack](https://github.com/google/XNNPACK/blob/68447302abcfad0d4b6b19a1efe7d7eef8833f4a/include/xnnpack.h#L24-L25)), set to 16, and uses it to add padding to our intermediate tensors.

## How Has This Been Tested?

CI.

## Benchmark Results

N/A.

## Related issue number

N/A.
