### PR TITLE
Make Interpreter::get_shapes and get_types more generic

### DIFF
--- a/larq_compute_engine/tflite/python/interpreter_wrapper_utils.h
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_utils.h
@@ -55,8 +55,10 @@ class InterpreterWrapperBase {
 
  protected:
   std::unique_ptr<InterpreterType> interpreter_;
-  pybind11::list get_types(const std::vector<int>& tensors) const;
-  pybind11::list get_shapes(const std::vector<int>& tensors) const;
+  template <typename TensorList>
+  pybind11::list get_types(const TensorList& tensors) const;
+  template <typename TensorList>
+  pybind11::list get_shapes(const TensorList& tensors) const;
 };
 
 TfLiteType TfLiteTypeFromPyType(pybind11::dtype py_type) {
@@ -135,8 +137,9 @@ bool SetTensorFromNumpy(const TfLiteTensor* tensor,
 }
 
 template <typename InterpreterType>
+template <typename TensorList>
 pybind11::list InterpreterWrapperBase<InterpreterType>::get_types(
-    const std::vector<int>& tensors) const {
+    const TensorList& tensors) const {
   pybind11::list result;
 
   for (auto tensor_id : tensors) {
@@ -148,8 +151,9 @@ pybind11::list InterpreterWrapperBase<InterpreterType>::get_types(
 }
 
 template <typename InterpreterType>
+template <typename TensorList>
 pybind11::list InterpreterWrapperBase<InterpreterType>::get_shapes(
-    const std::vector<int>& tensors) const {
+    const TensorList& tensors) const {
   pybind11::list result;
 
   for (auto tensor_id : tensors) {


### PR DESCRIPTION
## What do these changes do?
`interpreter->outputs()` might not always be `std::vectors` so this code would fail to compile in those cases. This PR templates the code to make it also work in those cases

## How Has This Been Tested?
CI

## Related issue number
Supersedes #508 
