### PR TITLE
Add support for iterators in Interpreter.predict

### DIFF
--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -7,10 +7,10 @@ from larq_compute_engine.tflite.python import interpreter_wrapper_lite
 
 __all__ = ["Interpreter"]
 
+Data = Union[np.ndarray, List[np.ndarray]]
 
-def data_generator(
-    x: Union[np.ndarray, List[np.ndarray]]
-) -> Iterator[List[np.ndarray]]:
+
+def data_generator(x: Data) -> Iterator[List[np.ndarray]]:
     if not isinstance(x, (list, np.ndarray)) or len(x) == 0:
         raise ValueError(
             "Expected either a non-empty list of inputs or a Numpy array with "
@@ -67,9 +67,7 @@ class Interpreter:
         """Returns a list of output shapes."""
         return self.interpreter.output_shapes
 
-    def predict(
-        self, x: Union[np.ndarray, List[np.ndarray]], verbose: int = 0
-    ) -> Union[np.ndarray, List[np.ndarray]]:
+    def predict(self, x: Data, verbose: int = 0) -> Data:
         """Generates output predictions for the input samples.
 
         # Arguments

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -25,7 +25,7 @@ def data_generator(x: Union[Data, Iterator[Data]]) -> Iterator[List[np.ndarray]]
                 yield [np.expand_dims(inp, axis=0) for inp in inputs]
     else:
         raise ValueError(
-            "Expected either a list of inputs or a Numpy array with implicit initial"
+            "Expected either a list of inputs or a Numpy array with implicit initial "
             f"batch dimension or an iterator yielding one of the above. Received: {x}"
         )
 


### PR DESCRIPTION
This adds support for iterators as input to `Interpreter.predict()` and improves the readability by explicitely handling iterations by `data_generator()`.

This makes it possible to support `tf.data.Dataset` as inputs via `Interpreter.predict(dataset.as_numpy_iterator())` or `Interpreter.predict(tfds.as_numpy(dataset))`.
I didn't add support for directly passing a `tf.data.Dataset`, since ` .as_numpy_iterator()` is only available in newer versions of TensorFlow with eager execution enabled and `tfds.as_numpy` would require an additional dependency.