### PR TITLE
Add optimised 'Indirect BGEMM' binary convolution kernels.

### DIFF
--- a/larq_compute_engine/core/bconv2d/BUILD
+++ b/larq_compute_engine/core/bconv2d/BUILD
@@ -31,13 +31,30 @@ cc_library(
 )
 
 cc_library(
-    name = "optimized",
+    name = "optimized_bgemm",
     hdrs = [
-        "optimized.h",
+        "optimized_bgemm.h",
     ],
     deps = [
         ":zero_padding_correction",
         "//larq_compute_engine/core/bgemm",
+        "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_context",
+        "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_gemm",
+        "@org_tensorflow//tensorflow/lite/kernels:padding",
+        "@org_tensorflow//tensorflow/lite/kernels/internal:optimized_base",
+        "@ruy//ruy/profiler:instrumentation",
+    ],
+)
+
+cc_library(
+    name = "optimized_indirect_bgemm",
+    hdrs = [
+        "optimized_indirect_bgemm.h",
+    ],
+    deps = [
+        ":zero_padding_correction",
+        "//larq_compute_engine/core/indirect_bgemm:kernels",
+        "//larq_compute_engine/core/indirect_bgemm:prepare",
         "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_context",
         "@org_tensorflow//tensorflow/lite/kernels:cpu_backend_gemm",
         "@org_tensorflow//tensorflow/lite/kernels:padding",

--- a/larq_compute_engine/core/bconv2d/optimized_indirect_bgemm.h
+++ b/larq_compute_engine/core/bconv2d/optimized_indirect_bgemm.h
@@ -1,0 +1,68 @@
+#ifndef COMPUTE_ENGINE_CORE_BCONV2D_OPTIMIZED_INDIRECT_BGEMM_H_
+#define COMPUTE_ENGINE_CORE_BCONV2D_OPTIMIZED_INDIRECT_BGEMM_H_
+
+#include "larq_compute_engine/core/bconv2d/zero_padding_correction.h"
+#include "larq_compute_engine/core/indirect_bgemm/kernel.h"
+#include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace compute_engine {
+namespace core {
+namespace bconv2d {
+
+template <typename AccumScalar, typename DstScalar>
+inline void BConv2DOptimizedIndirectBGEMM(
+    const indirect_bgemm::IndirectBGEMMKernel<DstScalar> kernel,
+    const compute_engine::tflite::bconv2d::TfLiteBConv2DParams* conv_params,
+    const RuntimeShape& bitpacked_input_shape, const RuntimeShape& output_shape,
+    const OutputTransform<DstScalar>& output_transform,
+    const TBitpacked* packed_weights, const TBitpacked** indirection_buffer,
+    DstScalar* output_data, const float* padding_buffer, const int pad_value) {
+  TF_LITE_ASSERT_EQ(bitpacked_input_shape.DimensionsCount(), 4);
+  TF_LITE_ASSERT_EQ(output_shape.DimensionsCount(), 4);
+
+  ruy::profiler::ScopeLabel label("BConv2D (optimized, indirect BGEMM)");
+
+  const std::int32_t conv_kernel_size =
+      conv_params->filter_height * conv_params->filter_width;
+  const std::int32_t bitpacked_input_channels = bitpacked_input_shape.Dims(3);
+  const std::int32_t output_size = output_shape.Dims(1) * output_shape.Dims(2);
+  const std::int32_t output_channels = conv_params->channels_out;
+
+  indirect_bgemm::RunKernel(kernel, conv_kernel_size, bitpacked_input_channels,
+                            output_size, output_channels, output_transform,
+                            packed_weights, indirection_buffer, output_data);
+
+  if (std::is_same<DstScalar, float>::value &&
+      conv_params->padding_type == TfLitePadding::kTfLitePaddingSame &&
+      pad_value == 0) {
+    ruy::profiler::ScopeLabel label("Zero padding correction");
+
+    const int stride_width = conv_params->stride_width;
+    const int stride_height = conv_params->stride_height;
+    const int dilation_width_factor = conv_params->dilation_width_factor;
+    const int dilation_height_factor = conv_params->dilation_height_factor;
+    const int batches = MatchingDim(bitpacked_input_shape, 0, output_shape, 0);
+    const int input_depth = conv_params->channels_in;
+    const int input_width = bitpacked_input_shape.Dims(2);
+    const int input_height = bitpacked_input_shape.Dims(1);
+    const int filter_height = conv_params->filter_height;
+    const int filter_width = conv_params->filter_width;
+    const int output_depth = output_shape.Dims(3);
+    const int output_width = output_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+
+    zero_padding_correction::ApplyCorrection(
+        batches, input_height, input_width, input_depth, filter_height,
+        filter_width, output_depth, stride_height, stride_width,
+        dilation_height_factor, dilation_width_factor,
+        reinterpret_cast<float*>(output_data), output_height, output_width,
+        padding_buffer);
+  }
+}
+
+}  // namespace bconv2d
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_CORE_BCONV2D_OPTIMIZED_INDIRECT_BGEMM_H_

--- a/larq_compute_engine/core/indirect_bgemm/BUILD
+++ b/larq_compute_engine/core/indirect_bgemm/BUILD
@@ -1,0 +1,30 @@
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "prepare",
+    hdrs = [
+        "prepare.h",
+    ],
+    deps = [
+        "//larq_compute_engine/core:types",
+        "//larq_compute_engine/tflite/kernels:bconv2d_params",
+        "@org_tensorflow//tensorflow/lite/kernels/internal:types",
+    ],
+)
+
+cc_library(
+    name = "kernels",
+    hdrs = [
+        "kernel.h",
+        "kernel_4x2_portable.h",
+    ],
+    deps = [
+        "//larq_compute_engine/core:types",
+        "//larq_compute_engine/core/bconv2d:output_transform",
+        "//larq_compute_engine/tflite/kernels:bconv2d_params",
+        "@org_tensorflow//tensorflow/lite/kernels/internal:types",
+        "@ruy//ruy/profiler:instrumentation",
+    ],
+)

--- a/larq_compute_engine/core/indirect_bgemm/kernel.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel.h
@@ -1,0 +1,79 @@
+
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_H_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "larq_compute_engine/core/indirect_bgemm/kernel_4x2_portable.h"
+#include "larq_compute_engine/core/types.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_params.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+using namespace tflite;
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+
+using compute_engine::tflite::bconv2d::TfLiteBConv2DParams;
+
+template <typename DstScalar>
+struct IndirectBGEMMKernel {
+  using MicroKernelFunction = void(const std::int32_t, const std::int32_t,
+                                   const std::int32_t, const std::int32_t,
+                                   const bconv2d::OutputTransform<DstScalar>&,
+                                   const TBitpacked*, const TBitpacked**,
+                                   DstScalar*);
+  MicroKernelFunction* micro_kernel_function;
+  const std::int32_t block_size_output_channels;
+  const std::int32_t block_size_pixels;
+};
+
+// This function allows us to select which kernel to use at runtime based on any
+// parameter we choose: destination scalar; conv params; input/output shapes;
+// even detected CPU features.
+//     It is very important that this function is deterministic, as we rely on
+// the fact that the same kernel is selected for each call to `Eval` (as long as
+// the input shape doesn't change).
+template <typename DstScalar>
+inline IndirectBGEMMKernel<DstScalar> SelectRuntimeKernel(
+    const TfLiteBConv2DParams* conv_params,
+    const RuntimeShape& bitpacked_input_shape,
+    const RuntimeShape& output_shape) {
+  // For now there is only one kernel available.
+  return IndirectBGEMMKernel<DstScalar>{
+      &kernel_4x2_portable::RunKernel<DstScalar>, 4, 2};
+}
+
+template <typename DstScalar>
+void RunKernel(const IndirectBGEMMKernel<DstScalar>& kernel,
+               const std::int32_t conv_kernel_size,
+               const std::int32_t bitpacked_input_channels,
+               const std::int32_t output_size,
+               const std::int32_t output_channels,
+               const bconv2d::OutputTransform<DstScalar>& output_transform,
+               const TBitpacked* packed_weights_ptr,
+               const TBitpacked** indirection_buffer, DstScalar* output_ptr) {
+  // TODO: implement multithreading here.
+  for (std::int32_t pixel_start = 0; pixel_start < output_size;
+       pixel_start += kernel.block_size_pixels) {
+    const std::int32_t output_stride =
+        std::is_same<DstScalar, TBitpacked>::value
+            ? bitpacking::GetBitpackedSize(output_channels)
+            : output_channels;
+    kernel.micro_kernel_function(
+        std::min(output_size - pixel_start, kernel.block_size_pixels),
+        conv_kernel_size, bitpacked_input_channels, output_channels,
+        output_transform, packed_weights_ptr,
+        indirection_buffer + pixel_start * conv_kernel_size,
+        output_ptr + pixel_start * output_stride);
+  }
+}
+
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_H_

--- a/larq_compute_engine/core/indirect_bgemm/kernel_4x2_portable.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_4x2_portable.h
@@ -1,0 +1,245 @@
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_4x2_PORTABLE_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_4x2_PORTABLE_H_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "larq_compute_engine/core/bconv2d/output_transform.h"
+#include "larq_compute_engine/core/types.h"
+#include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+namespace kernel_4x2_portable {
+
+/**
+ * A 4x2 C++ micro-kernel for float or int8 output.
+ */
+template <typename DstScalar>
+void RunKernel(const std::int32_t block_num_pixels,
+               const std::int32_t conv_kernel_size,
+               const std::int32_t channels_in, const std::int32_t channels_out,
+               const bconv2d::OutputTransform<DstScalar>& output_transform,
+               const TBitpacked* weights_ptr,
+               const TBitpacked** indirection_buffer, DstScalar* output_ptr) {
+  static_assert(std::is_same<DstScalar, float>::value ||
+                    std::is_same<DstScalar, std::int8_t>::value,
+                "");
+
+  ruy::profiler::ScopeLabel label("Indirect BGEMM block (4x2, portable)");
+
+  TFLITE_DCHECK_GE(block_num_pixels, 1);
+  TFLITE_DCHECK_LE(block_num_pixels, 2);
+  TFLITE_DCHECK_GE(conv_kernel_size, 1);
+  TFLITE_DCHECK_GE(channels_in, 1);
+  TFLITE_DCHECK_GE(channels_out, 1);
+
+  DstScalar* output_ptr_0 = output_ptr;
+  DstScalar* output_ptr_1 = output_ptr + channels_out;
+
+  // At the end of the output array we might get a block where the number of
+  // pixels is less than 2, if the overall output size is not a multiple of 2.
+  // When this happens we set the 'leftover' output pointer equal to the first
+  // output pointer, so that there's no risk of writing beyond the array bounds.
+  // At the end, when we write to the output array, we do it 'back to front' so
+  // that the outputs for the first pixel are written last, which means that the
+  // result will still be correct.
+  if (block_num_pixels < 2) {
+    output_ptr_1 = output_ptr_0;
+  }
+
+  std::int32_t c_out_index = 0;
+  do {
+    // Accumulators
+    std::int32_t acc_00 = 0, acc_01 = 0;
+    std::int32_t acc_10 = 0, acc_11 = 0;
+    std::int32_t acc_20 = 0, acc_21 = 0;
+    std::int32_t acc_30 = 0, acc_31 = 0;
+
+    std::int32_t k_size_index = conv_kernel_size;
+    do {
+      const TBitpacked* activations_ptr_0 = indirection_buffer[0];
+      const TBitpacked* activations_ptr_1 = indirection_buffer[1];
+      indirection_buffer += 2;
+
+      std::int32_t c_in_index = channels_in;
+      do {
+        const TBitpacked w_0 = weights_ptr[0];
+        const TBitpacked w_1 = weights_ptr[1];
+        const TBitpacked w_2 = weights_ptr[2];
+        const TBitpacked w_3 = weights_ptr[3];
+        weights_ptr += 4;
+
+        const TBitpacked a_0 = *activations_ptr_0++;
+        const TBitpacked a_1 = *activations_ptr_1++;
+
+        acc_00 += xor_popcount(w_0, a_0);
+        acc_10 += xor_popcount(w_1, a_0);
+        acc_20 += xor_popcount(w_2, a_0);
+        acc_30 += xor_popcount(w_3, a_0);
+        acc_01 += xor_popcount(w_0, a_1);
+        acc_11 += xor_popcount(w_1, a_1);
+        acc_21 += xor_popcount(w_2, a_1);
+        acc_31 += xor_popcount(w_3, a_1);
+      } while (--c_in_index > 0);
+    } while (--k_size_index > 0);
+
+    if (channels_out - c_out_index >= 4) {
+      output_ptr_1[0] = output_transform.Run(acc_01, c_out_index);
+      output_ptr_1[1] = output_transform.Run(acc_11, c_out_index + 1);
+      output_ptr_1[2] = output_transform.Run(acc_21, c_out_index + 2);
+      output_ptr_1[3] = output_transform.Run(acc_31, c_out_index + 3);
+      output_ptr_1 += 4;
+      output_ptr_0[0] = output_transform.Run(acc_00, c_out_index);
+      output_ptr_0[1] = output_transform.Run(acc_10, c_out_index + 1);
+      output_ptr_0[2] = output_transform.Run(acc_20, c_out_index + 2);
+      output_ptr_0[3] = output_transform.Run(acc_30, c_out_index + 3);
+      output_ptr_0 += 4;
+
+      indirection_buffer -= 2 * conv_kernel_size;
+      c_out_index += 4;
+    } else {
+      if (channels_out - c_out_index >= 2) {
+        output_ptr_1[0] = output_transform.Run(acc_01, c_out_index);
+        output_ptr_1[1] = output_transform.Run(acc_11, c_out_index + 1);
+        output_ptr_1 += 2;
+        output_ptr_0[0] = output_transform.Run(acc_00, c_out_index);
+        output_ptr_0[1] = output_transform.Run(acc_10, c_out_index + 1);
+        output_ptr_0 += 2;
+
+        acc_01 = acc_21;
+        acc_00 = acc_20;
+        c_out_index += 2;
+      }
+      if (channels_out - c_out_index >= 1) {
+        output_ptr_1[0] = output_transform.Run(acc_01, c_out_index);
+        output_ptr_0[0] = output_transform.Run(acc_00, c_out_index);
+      }
+
+      c_out_index = channels_out;
+    }
+  } while (c_out_index < channels_out);
+}
+
+/**
+ * A 4x2 C++ micro-kernel for bitpacked output.
+ */
+template <>
+void RunKernel<TBitpacked>(
+    const std::int32_t block_num_pixels, const std::int32_t conv_kernel_size,
+    const std::int32_t channels_in, const std::int32_t channels_out,
+    const bconv2d::OutputTransform<TBitpacked>& output_transform,
+    const TBitpacked* weights_ptr, const TBitpacked** indirection_buffer,
+    TBitpacked* output_ptr) {
+  ruy::profiler::ScopeLabel label("Indirect BGEMM block (4x2, portable)");
+
+  TFLITE_DCHECK_GE(block_num_pixels, 1);
+  TFLITE_DCHECK_LE(block_num_pixels, 2);
+  TFLITE_DCHECK_GE(conv_kernel_size, 1);
+  TFLITE_DCHECK_GE(channels_in, 1);
+  TFLITE_DCHECK_GE(channels_out, 1);
+
+  TBitpacked* output_ptr_0 = output_ptr;
+  TBitpacked* output_ptr_1 =
+      output_ptr + bitpacking::GetBitpackedSize(channels_out);
+
+  // At the end of the output array we might get a block where the number of
+  // pixels is less than 2, if the overall output size is not a multiple of 2.
+  // When this happens we set the 'leftover' output pointer equal to the first
+  // output pointer, so that there's no risk of writing beyond the array bounds.
+  // At the end, when we write to the output array, we do it 'back to front' so
+  // that the outputs for the first pixel are written last, which means that the
+  // result will still be correct.
+  if (block_num_pixels < 2) {
+    output_ptr_1 = output_ptr_0;
+  }
+
+  // We will accumulate bits into these per-pixel columns and write a bitpacked
+  // value when the columns are full.
+  TBitpacked output_col_0 = 0, output_col_1 = 0;
+
+  std::int32_t c_out_index = 0;
+  do {
+    // Accumulators
+    std::int32_t acc_00 = 0, acc_01 = 0;
+    std::int32_t acc_10 = 0, acc_11 = 0;
+    std::int32_t acc_20 = 0, acc_21 = 0;
+    std::int32_t acc_30 = 0, acc_31 = 0;
+
+    std::int32_t k_size_index = conv_kernel_size;
+    do {
+      const TBitpacked* activations_ptr_0 = indirection_buffer[0];
+      const TBitpacked* activations_ptr_1 = indirection_buffer[1];
+      indirection_buffer += 2;
+
+      std::int32_t c_in_index = channels_in;
+      do {
+        const TBitpacked w_0 = weights_ptr[0];
+        const TBitpacked w_1 = weights_ptr[1];
+        const TBitpacked w_2 = weights_ptr[2];
+        const TBitpacked w_3 = weights_ptr[3];
+        weights_ptr += 4;
+
+        const TBitpacked a_0 = *activations_ptr_0++;
+        const TBitpacked a_1 = *activations_ptr_1++;
+
+        acc_00 += xor_popcount(w_0, a_0);
+        acc_10 += xor_popcount(w_1, a_0);
+        acc_20 += xor_popcount(w_2, a_0);
+        acc_30 += xor_popcount(w_3, a_0);
+        acc_01 += xor_popcount(w_0, a_1);
+        acc_11 += xor_popcount(w_1, a_1);
+        acc_21 += xor_popcount(w_2, a_1);
+        acc_31 += xor_popcount(w_3, a_1);
+      } while (--c_in_index > 0);
+    } while (--k_size_index > 0);
+
+    output_col_0 |= TBitpacked(output_transform.Run(acc_00, c_out_index))
+                    << (c_out_index % bitpacking_bitwidth);
+    output_col_0 |= TBitpacked(output_transform.Run(acc_10, c_out_index + 1))
+                    << ((c_out_index + 1) % bitpacking_bitwidth);
+    output_col_0 |= TBitpacked(output_transform.Run(acc_20, c_out_index + 2))
+                    << ((c_out_index + 2) % bitpacking_bitwidth);
+    output_col_0 |= TBitpacked(output_transform.Run(acc_30, c_out_index + 3))
+                    << ((c_out_index + 3) % bitpacking_bitwidth);
+    output_col_1 |= TBitpacked(output_transform.Run(acc_01, c_out_index))
+                    << (c_out_index % bitpacking_bitwidth);
+    output_col_1 |= TBitpacked(output_transform.Run(acc_11, c_out_index + 1))
+                    << ((c_out_index + 1) % bitpacking_bitwidth);
+    output_col_1 |= TBitpacked(output_transform.Run(acc_21, c_out_index + 2))
+                    << ((c_out_index + 2) % bitpacking_bitwidth);
+    output_col_1 |= TBitpacked(output_transform.Run(acc_31, c_out_index + 3))
+                    << ((c_out_index + 3) % bitpacking_bitwidth);
+
+    indirection_buffer -= 2 * conv_kernel_size;
+    c_out_index += 4;
+
+    // Write the bitpacked columns whenever they are full, or if we've computed
+    // the last output column value.
+    if (c_out_index % bitpacking_bitwidth == 0 || c_out_index >= channels_out) {
+      // If this is a 'leftover output channel' block (because the number of
+      // output channels isn't a multiple of four) then zero-out the extra bits.
+      if (c_out_index % bitpacking_bitwidth != 0) {
+        output_col_0 &=
+            (TBitpacked(1) << (channels_out % bitpacking_bitwidth)) - 1;
+        output_col_1 &=
+            (TBitpacked(1) << (channels_out % bitpacking_bitwidth)) - 1;
+      }
+
+      *output_ptr_1++ = output_col_1;
+      output_col_1 = 0;
+      *output_ptr_0++ = output_col_0;
+      output_col_0 = 0;
+    }
+  } while (c_out_index < channels_out);
+}
+
+}  // namespace kernel_4x2_portable
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_4x2_PORTABLE_H_

--- a/larq_compute_engine/core/indirect_bgemm/prepare.h
+++ b/larq_compute_engine/core/indirect_bgemm/prepare.h
@@ -1,0 +1,145 @@
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_PREPARE_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_PREPARE_H_
+
+#include <cstdint>
+
+#include "larq_compute_engine/core/types.h"
+#include "larq_compute_engine/tflite/kernels/bconv2d_params.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+using namespace tflite;
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+
+// This function is (heavily) adapted from this XNNPack function:
+// https://github.com/google/XNNPACK/blob/80a8ac59849bfdae8d2e1409f5642baa502c0b9e/src/indirection.c#L18-L76
+void FillIndirectionBuffer(const int block_size_pixels,
+                           const TfLiteBConv2DParams* conv_params,
+                           const RuntimeShape& bitpacked_input_shape,
+                           const RuntimeShape& output_shape,
+                           const TBitpacked* input_ptr,
+                           std::vector<const TBitpacked*>& indirection_buffer,
+                           std::vector<TBitpacked>& zero_buffer) {
+  using std::int32_t;
+
+  const int32_t kernel_height = conv_params->filter_height;
+  const int32_t kernel_width = conv_params->filter_width;
+  const int32_t stride_height = conv_params->stride_height;
+  const int32_t stride_width = conv_params->stride_width;
+  const int32_t dilation_height = conv_params->dilation_height_factor;
+  const int32_t dilation_width = conv_params->dilation_width_factor;
+  const int32_t input_padding_top = conv_params->padding_values.height;
+  const int32_t input_padding_left = conv_params->padding_values.width;
+
+  const int32_t input_height = bitpacked_input_shape.Dims(1);
+  const int32_t input_width = bitpacked_input_shape.Dims(2);
+  const int32_t bitpacked_input_channels = bitpacked_input_shape.Dims(3);
+
+  const int32_t output_height = output_shape.Dims(1);
+  const int32_t output_width = output_shape.Dims(2);
+
+  const int32_t output_size = output_height * output_width;
+  const int32_t kernel_size = kernel_height * kernel_width;
+  const int32_t tiled_output_size =
+      block_size_pixels *
+      ((output_size + block_size_pixels - 1) / block_size_pixels);
+
+  indirection_buffer.resize(tiled_output_size * kernel_size);
+  zero_buffer.assign(kernel_size * bitpacked_input_channels, 0);
+
+  for (int32_t output_tile_start = 0; output_tile_start < tiled_output_size;
+       output_tile_start += block_size_pixels) {
+    for (int32_t output_tile_offset = 0; output_tile_offset < block_size_pixels;
+         output_tile_offset++) {
+      const int32_t output_index =
+          std::min(output_tile_start + output_tile_offset, output_size - 1);
+      const int32_t output_x = output_index % output_width;
+      const int32_t output_y = output_index / output_width;
+      for (int32_t kernel_y = 0; kernel_y < kernel_height; kernel_y++) {
+        const int32_t input_y = output_y * stride_height +
+                                kernel_y * dilation_height - input_padding_top;
+        if (0 <= input_y && input_y < input_height) {
+          for (int32_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
+            const int32_t input_x = output_x * stride_width +
+                                    kernel_x * dilation_width -
+                                    input_padding_left;
+            const int32_t kernel_index = kernel_y * kernel_width + kernel_x;
+            const int32_t index = output_tile_start * kernel_size +
+                                  kernel_index * block_size_pixels +
+                                  output_tile_offset;
+            if (0 <= input_x && input_x < input_width) {
+              indirection_buffer.at(index) =
+                  (input_ptr + (input_y * input_width + input_x) *
+                                   bitpacked_input_channels);
+            } else {
+              indirection_buffer.at(index) = zero_buffer.data();
+            }
+          }
+        } else {
+          for (int32_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
+            const int32_t kernel_index = kernel_y * kernel_width + kernel_x;
+            const int32_t index = output_tile_start * kernel_size +
+                                  kernel_index * block_size_pixels +
+                                  output_tile_offset;
+            indirection_buffer.at(index) = zero_buffer.data();
+          }
+        }
+      }
+    }
+  }
+}
+
+// This function is (heavily) adapted from this XNNPack function:
+// https://github.com/google/XNNPACK/blob/80a8ac59849bfdae8d2e1409f5642baa502c0b9e/src/packing.c#L429-L484
+void PackWeights(const int block_size_output_channels,
+                 const TfLiteBConv2DParams* conv_params,
+                 const RuntimeShape& bitpacked_input_shape,
+                 const RuntimeShape& output_shape,
+                 const TBitpacked* weights_ptr,
+                 std::vector<TBitpacked>& packed_weights) {
+  using std::int32_t;
+
+  const int32_t bitpacked_input_channels = bitpacked_input_shape.Dims(3);
+  const int32_t output_channels = conv_params->channels_out;
+  const int32_t kernel_size =
+      conv_params->filter_height * conv_params->filter_width;
+
+  const int32_t rounded_up_output_channels =
+      block_size_output_channels *
+      ((output_channels + block_size_output_channels - 1) /
+       block_size_output_channels);
+
+  packed_weights.resize(rounded_up_output_channels * kernel_size *
+                        bitpacked_input_channels);
+
+  int32_t packed_weights_index = 0;
+
+  for (int32_t block_start = 0; block_start < output_channels;
+       block_start += block_size_output_channels) {
+    const int32_t block_size =
+        std::min(output_channels - block_start, block_size_output_channels);
+    for (int32_t ki = 0; ki < kernel_size; ki++) {
+      for (int32_t ci = 0; ci < bitpacked_input_channels; ci++) {
+        for (int32_t block_offset = 0; block_offset < block_size;
+             block_offset++) {
+          const int32_t weights_index = (block_start + block_offset) *
+                                            kernel_size *
+                                            bitpacked_input_channels +
+                                        ki * bitpacked_input_channels + ci;
+          packed_weights.at(packed_weights_index++) =
+              weights_ptr[weights_index];
+        }
+        packed_weights_index += block_size_output_channels - block_size;
+      }
+    }
+  }
+}
+
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_PREPARE_H_

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -12,6 +12,9 @@ cc_library(
     hdrs = [
         "bconv2d_params.h",
     ],
+    deps = [
+        "//larq_compute_engine/core:types",
+    ],
 )
 
 cc_library(
@@ -57,10 +60,13 @@ cc_library(
         ":bconv2d_params",
         ":utils",
         "//larq_compute_engine/core:bmaxpool",
-        "//larq_compute_engine/core/bconv2d:optimized",
+        "//larq_compute_engine/core/bconv2d:optimized_bgemm",
+        "//larq_compute_engine/core/bconv2d:optimized_indirect_bgemm",
         "//larq_compute_engine/core/bconv2d:reference",
         "//larq_compute_engine/core/bitpacking:bitpack",
         "//larq_compute_engine/core/bitpacking:utils",
+        "//larq_compute_engine/core/indirect_bgemm:kernels",
+        "//larq_compute_engine/core/indirect_bgemm:prepare",
         "@flatbuffers",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",

--- a/larq_compute_engine/tflite/kernels/bconv2d_params.h
+++ b/larq_compute_engine/tflite/kernels/bconv2d_params.h
@@ -3,11 +3,14 @@
 
 #include <vector>
 
+#include "larq_compute_engine/core/types.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 
 namespace compute_engine {
 namespace tflite {
 namespace bconv2d {
+
+using core::TBitpacked;
 
 const int kTensorNotAllocated = -1;
 
@@ -43,6 +46,11 @@ struct TfLiteBConv2DParams {
 
   // This is used when we have 'same-zero' padding.
   std::vector<float> padding_buffer;
+
+  // These are used in the 'indirect bgemm' kernels.
+  std::vector<TBitpacked> packed_weights;
+  std::vector<const TBitpacked*> indirection_buffer;
+  std::vector<TBitpacked> zero_buffer;
 
   // IDs are the arbitrary identifiers used by TF Lite to identify and access
   // memory buffers. They are unique in the entire TF Lite context.


### PR DESCRIPTION
## What do these changes do?

This PR adds a new type of binary convolution kernel that uses an 'indirect' BGEMM algorithm that doesn't require im2col. This is an adaptation of the algorithm introduced in the paper [The Indirect Convolution Algorithm](https://arxiv.org/pdf/1907.02129.pdf) and used extensively in the [XNNPack](https://github.com/google/xnnpack) library.

Only one BGEMM-micro kernel is included: a portable 4x2 kernel written in C++. However, this PR lays the groundwork for adding additional micro-kernels -- including hand-optimised and architecture-specific variations -- in the future. As such, the focus of this PR is not performance; the new kernel will be substantially slower than our existing highly-optimised im2col + BGEMM kernel, which will remain the default.

## How Has This Been Tested?

CI. The non-CI 'big' kernel tests pass locally for Aarch64 and Arm32.

## Benchmark Results

Benchmarks aren't really relevant because this PR does not change the default optimised kernel that is run, but to give a rough idea I ran QuickNet on my Raspberry Pi 4B with our three different kernel types:

| Kernel                                         | Average latency over 250 runs (ms) |
|------------------------------------------------|:----------------------------------:|
| Optimised im2col + BGEMM (hand-tuned assembly) | 30.0                               |
| Optimised indirect BGEMM (C++)  - *this PR*      | 128.8                              |
| Reference (C++)                                | 269.5                              |

## Related issue number

N/A.