### PR TITLE
Add optimised indirect bgemm kernels for Aarch64.

### DIFF
--- a/larq_compute_engine/core/indirect_bgemm/BUILD
+++ b/larq_compute_engine/core/indirect_bgemm/BUILD
@@ -19,6 +19,9 @@ cc_library(
     hdrs = [
         "kernel.h",
         "kernel_4x2_portable.h",
+        "kernel_8x4x1_aarch64.h",
+        "kernel_8x4x2_aarch64.h",
+        "kernel_8x4x4_aarch64.h",
     ],
     deps = [
         "//larq_compute_engine/core:types",

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
@@ -21,16 +21,13 @@ namespace core {
 namespace indirect_bgemm {
 namespace kernel_8x4x1_aarch64 {
 
-/**
- * This block of instructions takes as input the activation vector registers
- * a_0, ..., a_3 and the weight vector registers w_0, w_1, and computes 'binary
- * multiplication and accumulation' (BMLA) using XOR and popcount instructions,
- * adding the results to the 16-bit accumulator vector registers accum_0, ...,
- * accum_3.
- *
- * Additionally, it loads the next values into a_0, ..., a_3 (from the pointers
- * a_ptr_0, ..., a_ptr_3) and into w_0, w_1 (from the pointer w_ptr).
- */
+// This block of instructions takes as input the activation vector registers
+// a_0, ..., a_3 and the weight vector registers w_0, w_1, and computes
+// 'binary multiplication and accumulation' (BMLA) using XOR and popcount
+// instructions, adding the results to the 16-bit accumulator vector registers
+// accum_0, ..., accum_3.
+//     It also reloads data for the next loop iteration into a_0, ..., a_3 and
+// w_0, w_1 from the pointers a_ptr_0, ..., a_ptr_3 and w_ptr.
 #define XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32   \
   "eor v0.16b, %[a_0].16b, %[w_0].16b\n\t" \
   "eor v1.16b, %[a_1].16b, %[w_0].16b\n\t" \
@@ -65,10 +62,49 @@ namespace kernel_8x4x1_aarch64 {
   "uadalp %[accum_3].8h, v3.16b\n\t"
 
 /**
- * This function performs the accumulation loop when we know that the depth is
- * greater than one, i.e. the (bitpacked) number of input channels is greater
- * than 32.
+ * Accumulation loops
+ *
+ * There are two variants of the accumulation loop: one for when we know the
+ * depth is greater than one, i.e. the number of input channels is greater than
+ * 32; and one for when we know the depth is equal to one, i.e. the number of
+ * input channels is equal to 32. The latter case allows for a slight
+ * optimisation.
+ *
+ * The accumulation loops use inline assembly but are equivalent to the
+ * following pseudocode:
+ *
+ *     accum_0 = 0;
+ *     accum_1 = 0;
+ *     accum_2 = 0;
+ *     accum_3 = 0;
+ *
+ *     // This block is removed in the depth=1 case
+ *     a_ptr_0 = indirection_buffer[0];
+ *     a_ptr_1 = indirection_buffer[1];
+ *     a_ptr_2 = indirection_buffer[2];
+ *     a_ptr_3 = indirection_buffer[3];
+ *     indirection_buffer += 4;
+ *
+ *     int ks = kernel_size;
+ *     do {
+ *         // This loop is removed in the depth=1 case
+ *         for (int d = 0; d < depth - 1; d++) {
+ *             XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+ *         }
+ *
+ *         // Before the final inner (depth loop) iteration, set the activation
+ *         // pointers so that the activations for the next outer loop iteration
+ *         // are loaded correctly.
+ *         a_ptr_0 = indirection_buffer[0];
+ *         a_ptr_1 = indirection_buffer[1];
+ *         a_ptr_2 = indirection_buffer[2];
+ *         a_ptr_3 = indirection_buffer[3];
+ *         indirection_buffer += 4;
+ *
+ *         XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+ *     } while (--ks > 0);
  */
+
 inline void AccumulationLoop_Depth2OrMore(
     std::int32_t conv_kernel_size, const std::int32_t depth,
     int32x4_t weights[2], int32x4_t activations[4], uint16x8_t accumulators[4],
@@ -125,10 +161,6 @@ inline void AccumulationLoop_Depth2OrMore(
         "v7");
 }
 
-/**
- * This function performs the accumulation loop when we know that the depth is
- * equal to one, i.e. the (bitpacked) number of input channels is 32.
- */
 inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
                                     int32x4_t weights[2],
                                     int32x4_t activations[4],
@@ -177,9 +209,15 @@ inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
 #undef XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
 
 /**
- * The output transform and store function for float output. Also reloads the
- * weight and activation registers for the next iteration.
+ * Output transforms
+ *
+ * These destination-type-specific functions take the accumulator values and
+ * perform the output transform, before storing the results in the output array.
+ * They additionally reload data into the weight and activation registers for
+ * the first iteration of the next accumulation loop.
  */
+
+// Float output transform
 inline void OutputTransformAndLoadNextAndStore(
     const std::int32_t c_out_index, const std::int32_t channels_out,
     uint16x8_t accumulators[4], int32x4_t weights[2], int32x4_t activations[4],
@@ -335,10 +373,7 @@ inline void OutputTransformAndLoadNextAndStore(
   }
 }
 
-/**
- * The output transform and store function for int8 output. Also reloads the
- * weight and activation registers for the next iteration.
- */
+// Int8 output transform
 inline void OutputTransformAndLoadNextAndStore(
     const std::int32_t c_out_index, const std::int32_t channels_out,
     uint16x8_t accumulators[4], int32x4_t weights[2], int32x4_t activations[4],

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
@@ -79,10 +79,12 @@ namespace kernel_8x4x1_aarch64 {
  *     accum_3 = 0;
  *
  *     // This block is removed in the depth=1 case
- *     a_ptr_0 = indirection_buffer[0];
- *     a_ptr_1 = indirection_buffer[1];
- *     a_ptr_2 = indirection_buffer[2];
- *     a_ptr_3 = indirection_buffer[3];
+ *     // The first set of activations is already loaded, so this +1
+ *     // ensures that the first 'block' loads the next set of activations.
+ *     a_ptr_0 = indirection_buffer[0] + 1;
+ *     a_ptr_1 = indirection_buffer[1] + 1;
+ *     a_ptr_2 = indirection_buffer[2] + 1;
+ *     a_ptr_3 = indirection_buffer[3] + 1;
  *     indirection_buffer += 4;
  *
  *     int ks = kernel_size;

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
@@ -1,0 +1,593 @@
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x1_AARCH64_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x1_AARCH64_H_
+
+#ifndef __aarch64__
+#pragma GCC error "ERROR: This file should only be compiled for Aarch64."
+#endif
+
+#include <arm_neon.h>
+
+#include <cstdint>
+#include <type_traits>
+
+#include "larq_compute_engine/core/bconv2d/output_transform.h"
+#include "larq_compute_engine/core/types.h"
+#include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+namespace kernel_8x4x1_aarch64 {
+
+/**
+ * This block of instructions takes as input the activation vector registers
+ * a_0, ..., a_3 and the weight vector registers w_0, w_1, and computes 'binary
+ * multiplication and accumulation' (BMLA) using XOR and popcount instructions,
+ * adding the results to the 16-bit accumulator vector registers accum_0, ...,
+ * accum_3.
+ *
+ * Additionally, it loads the next values into a_0, ..., a_3 (from the pointers
+ * a_ptr_0, ..., a_ptr_3) and into w_0, w_1 (from the pointer w_ptr).
+ */
+#define XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32   \
+  "eor v0.16b, %[a_0].16b, %[w_0].16b\n\t" \
+  "eor v1.16b, %[a_1].16b, %[w_0].16b\n\t" \
+  "eor v2.16b, %[a_2].16b, %[w_0].16b\n\t" \
+  "eor v3.16b, %[a_3].16b, %[w_0].16b\n\t" \
+  "eor v4.16b, %[a_0].16b, %[w_1].16b\n\t" \
+  "eor v5.16b, %[a_1].16b, %[w_1].16b\n\t" \
+  "ldr %q[w_0], [%[w_ptr]]\n\t"            \
+  "eor v6.16b, %[a_2].16b, %[w_1].16b\n\t" \
+  "eor v7.16b, %[a_3].16b, %[w_1].16b\n\t" \
+  "ldr %q[w_1], [%[w_ptr], #16]\n\t"       \
+  "cnt v0.16b, v0.16b\n\t"                 \
+  "cnt v1.16b, v1.16b\n\t"                 \
+  "ld1r {%[a_0].4s}, [%[a_ptr_0]], #4\n\t" \
+  "cnt v2.16b, v2.16b\n\t"                 \
+  "cnt v3.16b, v3.16b\n\t"                 \
+  "ld1r {%[a_1].4s}, [%[a_ptr_1]], #4\n\t" \
+  "cnt v4.16b, v4.16b\n\t"                 \
+  "cnt v5.16b, v5.16b\n\t"                 \
+  "ld1r {%[a_2].4s}, [%[a_ptr_2]], #4\n\t" \
+  "cnt v6.16b, v6.16b\n\t"                 \
+  "cnt v7.16b, v7.16b\n\t"                 \
+  "ld1r {%[a_3].4s}, [%[a_ptr_3]], #4\n\t" \
+  "addp v0.16b, v0.16b, v4.16b\n\t"        \
+  "addp v1.16b, v1.16b, v5.16b\n\t"        \
+  "addp v2.16b, v2.16b, v6.16b\n\t"        \
+  "addp v3.16b, v3.16b, v7.16b\n\t"        \
+  "add %[w_ptr], %[w_ptr], #32\n\t"        \
+  "uadalp %[accum_0].8h, v0.16b\n\t"       \
+  "uadalp %[accum_1].8h, v1.16b\n\t"       \
+  "uadalp %[accum_2].8h, v2.16b\n\t"       \
+  "uadalp %[accum_3].8h, v3.16b\n\t"
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * greater than one, i.e. the (bitpacked) number of input channels is greater
+ * than 32.
+ */
+inline void AccumulationLoop_Depth2OrMore(
+    std::int32_t conv_kernel_size, const std::int32_t depth,
+    int32x4_t weights[2], int32x4_t activations[4], uint16x8_t accumulators[4],
+    TBitpacked*& weights_ptr, TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth > 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0 = indirection_buffer[0] + 1;
+  TBitpacked* a_ptr_1 = indirection_buffer[1] + 1;
+  TBitpacked* a_ptr_2 = indirection_buffer[2] + 1;
+  TBitpacked* a_ptr_3 = indirection_buffer[3] + 1;
+
+  asm volatile(
+      // w0 is the outer (kernel size) loop counter
+      "mov w0, %w[kernel_size]\n\t"
+
+      // w1 is the inner (depth) loop counter
+      "sub w1, %w[depth], #1\n\t"
+
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop start label
+      "subs w1, w1, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+
+      "bgt 0b\n\t"  // Inner loop branch
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "sub w1, %w[depth], #1\n\t"
+      "subs w0, w0, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+
+      "bgt 0b\n\t"  // Outer loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
+        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
+        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
+        "v7");
+}
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * equal to one, i.e. the (bitpacked) number of input channels is 32.
+ */
+inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
+                                    int32x4_t weights[2],
+                                    int32x4_t activations[4],
+                                    uint16x8_t accumulators[4],
+                                    TBitpacked*& weights_ptr,
+                                    TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth = 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0;
+  TBitpacked* a_ptr_1;
+  TBitpacked* a_ptr_2;
+  TBitpacked* a_ptr_3;
+
+  asm volatile(
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop label
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "subs %w[ks_index], %w[ks_index], #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+
+      "bgt 0b\n\t"  // Loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
+        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
+        [ ks_index ] "+r"(conv_kernel_size)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7");
+}
+
+#undef XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
+
+/**
+ * The output transform and store function for float output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[2], int32x4_t activations[4],
+    const bconv2d::OutputTransform<float>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    float*& output_ptr_0, float*& output_ptr_1, float*& output_ptr_2,
+    float*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Float output transform and store");
+
+  // Declare result registers.
+  float32x4x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr q4, [%[bias_addr]]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr q5, [%[bias_addr], #16]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ld1r {%[a_0].4s}, [x0]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ld1r {%[a_1].4s}, [x1]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, and add the bias. Note
+      // that the float conversion instructions ("scvtf") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave the float multiply and add instructions
+      // between the "scvtf" instructions.
+      "ld1r {%[a_2].4s}, [x2]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ld1r {%[a_3].4s}, [x3]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v4.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v5.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v4.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v5.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v4.4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1q_f32(output_ptr_3, results[3].val[0]);
+    vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
+    output_ptr_3 += 8;
+    vst1q_f32(output_ptr_2, results[2].val[0]);
+    vst1q_f32(output_ptr_2 + 4, results[2].val[1]);
+    output_ptr_2 += 8;
+    vst1q_f32(output_ptr_1, results[1].val[0]);
+    vst1q_f32(output_ptr_1 + 4, results[1].val[1]);
+    output_ptr_1 += 8;
+    vst1q_f32(output_ptr_0, results[0].val[0]);
+    vst1q_f32(output_ptr_0 + 4, results[0].val[1]);
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT_LOW(index)                           \
+  vst1q_lane_f32(output_ptr_3 + index, results[3].val[0], index); \
+  vst1q_lane_f32(output_ptr_2 + index, results[2].val[0], index); \
+  vst1q_lane_f32(output_ptr_1 + index, results[1].val[0], index); \
+  vst1q_lane_f32(output_ptr_0 + index, results[0].val[0], index);
+#define STORE_SINGLE_ELEMENT_HIGH(index)                              \
+  vst1q_lane_f32(output_ptr_3 + 4 + index, results[3].val[1], index); \
+  vst1q_lane_f32(output_ptr_2 + 4 + index, results[2].val[1], index); \
+  vst1q_lane_f32(output_ptr_1 + 4 + index, results[1].val[1], index); \
+  vst1q_lane_f32(output_ptr_0 + 4 + index, results[0].val[1], index);
+    STORE_SINGLE_ELEMENT_LOW(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT_LOW(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT_LOW(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT_LOW(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT_HIGH(0)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT_HIGH(1)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT_HIGH(2)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT_LOW
+#undef STORE_SINGLE_ELEMENT_HIGH
+  }
+}
+
+/**
+ * The output transform and store function for int8 output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[2], int32x4_t activations[4],
+    const bconv2d::OutputTransform<std::int8_t>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    std::int8_t*& output_ptr_0, std::int8_t*& output_ptr_1,
+    std::int8_t*& output_ptr_2, std::int8_t*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Int8 output transform and store");
+
+  // Declare result registers. These are wider than we need for just the final
+  // int8 values, which is necessary for intermediate results.
+  int8x16x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr q4, [%[bias_addr]]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr q5, [%[bias_addr], #16]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ld1r {%[a_0].4s}, [x0]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ld1r {%[a_1].4s}, [x1]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, add the bias, convert
+      // back to integer, and use a series of "saturating extract narrow"
+      // instructions to narrow the result to Int8. Note that the float
+      // conversion instructions ("scvtf" and "fcvtns") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave other instructions between them.
+      "ld1r {%[a_2].4s}, [x2]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ld1r {%[a_3].4s}, [x3]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v4.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v5.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v4.4s\n\t"
+      "fcvtns %[result_30].4s, %[result_30].4s\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v5.4s\n\t"
+      "fcvtns %[result_31].4s, %[result_31].4s\n\t"
+      "sqxtn %[result_30].4h, %[result_30].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_30].8h, %[result_31].4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v4.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
+      "fcvtns %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
+      "fcvtns %[result_21].4s, %[result_21].4s\n\t"
+      "sqxtn %[result_20].4h, %[result_20].4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
+      "fcvtns %[result_10].4s, %[result_10].4s\n\t"
+      "sqxtn2 %[result_20].8h, %[result_21].4s\n\t"
+      "fcvtns %[result_11].4s, %[result_11].4s\n\t"
+      "sqxtn %[result_10].4h, %[result_10].4s\n\t"
+      "sqxtn %[result_30].8b, %[result_30].8h\n\t"
+      "fcvtns %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_10].8h, %[result_11].4s\n\t"
+      "sqxtn %[result_20].8b, %[result_20].8h\n\t"
+      "fcvtns %[result_01].4s, %[result_01].4s\n\t"
+      "sqxtn %[result_00].4h, %[result_00].4s\n\t"
+      "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
+      "sqxtn %[result_10].8b, %[result_10].8h\n\t"
+      "sqxtn %[result_00].8b, %[result_00].8h\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
+    output_ptr_3 += 8;
+    vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));
+    output_ptr_2 += 8;
+    vst1_s8(output_ptr_1, vget_low_s8(results[1].val[0]));
+    output_ptr_1 += 8;
+    vst1_s8(output_ptr_0, vget_low_s8(results[0].val[0]));
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT(index)                                          \
+  vst1_lane_s8(output_ptr_3 + index, vget_low_s8(results[3].val[0]), index); \
+  vst1_lane_s8(output_ptr_2 + index, vget_low_s8(results[2].val[0]), index); \
+  vst1_lane_s8(output_ptr_1 + index, vget_low_s8(results[1].val[0]), index); \
+  vst1_lane_s8(output_ptr_0 + index, vget_low_s8(results[0].val[0]), index);
+    STORE_SINGLE_ELEMENT(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT(4)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT(5)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT(6)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT
+  }
+}
+
+/**
+ * A 8x4x1 Neon micro-kernel for float or int8 output on Aarch64.
+ */
+template <typename DstScalar, bool Depth2OrMore>
+void RunKernel(const std::int32_t block_num_pixels,
+               const std::int32_t conv_kernel_size,
+               const std::int32_t channels_in, const std::int32_t channels_out,
+               const bconv2d::OutputTransform<DstScalar>& output_transform,
+               const TBitpacked* weights_ptr_,
+               const TBitpacked** indirection_buffer_, DstScalar* output_ptr) {
+  // Correctness of this function relies on TBitpacked being four bytes.
+  static_assert(sizeof(TBitpacked) == 4, "");
+
+  ruy::profiler::ScopeLabel label(
+      "Indirect BGEMM block (8x4x1, Aarch64 optimised)");
+
+  TFLITE_DCHECK_GE(block_num_pixels, 1);
+  TFLITE_DCHECK_LE(block_num_pixels, 4);
+  TFLITE_DCHECK_GE(conv_kernel_size, 1);
+  TFLITE_DCHECK_GE(channels_in, 1);
+  TFLITE_DCHECK_GE(channels_out, 1);
+
+  if (conv_kernel_size < 1 || channels_in < 1 || channels_out < 1) return;
+
+  TBitpacked** indirection_buffer =
+      const_cast<TBitpacked**>(indirection_buffer_);
+  TBitpacked* weights_ptr = const_cast<TBitpacked*>(weights_ptr_);
+
+  DstScalar* output_ptr_0 = output_ptr;
+  DstScalar* output_ptr_1 = output_ptr + channels_out;
+  DstScalar* output_ptr_2 = output_ptr + 2 * channels_out;
+  DstScalar* output_ptr_3 = output_ptr + 3 * channels_out;
+
+  // At the end of the output array we might get a block where the number of
+  // pixels is less than 4. When this happens we set the 'leftover' output
+  // pointer equal to the first output pointer, so that there's no risk of
+  // writing beyond the array bounds. At the end we write to the output array
+  // 'back to front' so that the outputs for the first pixel are written last,
+  // which means that the result will still be correct.
+  if (block_num_pixels < 4) {
+    output_ptr_3 = output_ptr_0;
+    if (block_num_pixels < 3) {
+      output_ptr_2 = output_ptr_0;
+      if (block_num_pixels < 2) {
+        output_ptr_1 = output_ptr_0;
+      }
+    }
+  }
+
+  // Pre-load weights and activations.
+  int32x4_t weights[2] = {vld1q_s32(weights_ptr), vld1q_s32(weights_ptr + 4)};
+  weights_ptr += 8;
+  int32x4_t activations[4] = {vld1q_dup_s32(indirection_buffer[0]),
+                              vld1q_dup_s32(indirection_buffer[1]),
+                              vld1q_dup_s32(indirection_buffer[2]),
+                              vld1q_dup_s32(indirection_buffer[3])};
+
+  std::int32_t c_out_index = 0;
+  do {
+    uint16x8_t accumulators[4];
+
+    if (Depth2OrMore) {
+      AccumulationLoop_Depth2OrMore(conv_kernel_size, channels_in, weights,
+                                    activations, accumulators, weights_ptr,
+                                    indirection_buffer);
+    } else {
+      AccumulationLoop_Depth1(conv_kernel_size, weights, activations,
+                              accumulators, weights_ptr, indirection_buffer);
+    }
+
+    OutputTransformAndLoadNextAndStore(
+        c_out_index, channels_out, accumulators, weights, activations,
+        output_transform, weights_ptr, indirection_buffer, output_ptr_0,
+        output_ptr_1, output_ptr_2, output_ptr_3);
+
+    c_out_index += 8;
+  } while (c_out_index < channels_out);
+}
+
+}  // namespace kernel_8x4x1_aarch64
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x1_AARCH64_H_

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
@@ -1,0 +1,636 @@
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x2_AARCH64_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x2_AARCH64_H_
+
+#ifndef __aarch64__
+#pragma GCC error "ERROR: This file should only be compiled for Aarch64."
+#endif
+
+#include <arm_neon.h>
+
+#include <cstdint>
+#include <type_traits>
+
+#include "larq_compute_engine/core/bconv2d/output_transform.h"
+#include "larq_compute_engine/core/types.h"
+#include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+namespace kernel_8x4x2_aarch64 {
+
+/**
+ * This block of instructions takes as input the activation vector registers
+ * a_0, ..., a_3 and the weight vector registers w_0, ..., w_3, and computes
+ * 'binary multiplication and accumulation' (BMLA) using XOR and popcount
+ * instructions, adding the results to the 16-bit accumulator vector registers
+ * accum_0, ..., accum_3.
+ *
+ * Additionally, it loads the next values into a_0, ..., a_3 (from the pointers
+ * a_ptr_0, ..., a_ptr_3) and into w_0, ..., w_3 (from the pointer w_ptr).
+ */
+#define XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64    \
+  "eor v0.16b, %[a_0].16b, %[w_0].16b\n\t"  \
+  "eor v1.16b, %[a_1].16b, %[w_0].16b\n\t"  \
+  "eor v2.16b, %[a_2].16b, %[w_0].16b\n\t"  \
+  "eor v3.16b, %[a_3].16b, %[w_0].16b\n\t"  \
+  "eor v4.16b, %[a_0].16b, %[w_1].16b\n\t"  \
+  "eor v5.16b, %[a_1].16b, %[w_1].16b\n\t"  \
+  "eor v6.16b, %[a_2].16b, %[w_1].16b\n\t"  \
+  "eor v7.16b, %[a_3].16b, %[w_1].16b\n\t"  \
+  "eor v8.16b, %[a_0].16b, %[w_2].16b\n\t"  \
+  "eor v9.16b, %[a_1].16b, %[w_2].16b\n\t"  \
+  "eor v10.16b, %[a_2].16b, %[w_2].16b\n\t" \
+  "eor v11.16b, %[a_3].16b, %[w_2].16b\n\t" \
+  "eor v12.16b, %[a_0].16b, %[w_3].16b\n\t" \
+  "eor v13.16b, %[a_1].16b, %[w_3].16b\n\t" \
+  "eor v14.16b, %[a_2].16b, %[w_3].16b\n\t" \
+  "eor v15.16b, %[a_3].16b, %[w_3].16b\n\t" \
+  "cnt v0.16b, v0.16b\n\t"                  \
+  "cnt v1.16b, v1.16b\n\t"                  \
+  "ld1r {%[a_0].2d}, [%[a_ptr_0]], #8\n\t"  \
+  "cnt v2.16b, v2.16b\n\t"                  \
+  "cnt v3.16b, v3.16b\n\t"                  \
+  "ld1r {%[a_1].2d}, [%[a_ptr_1]], #8\n\t"  \
+  "cnt v4.16b, v4.16b\n\t"                  \
+  "cnt v5.16b, v5.16b\n\t"                  \
+  "ld1r {%[a_2].2d}, [%[a_ptr_2]], #8\n\t"  \
+  "cnt v6.16b, v6.16b\n\t"                  \
+  "cnt v7.16b, v7.16b\n\t"                  \
+  "ld1r {%[a_3].2d}, [%[a_ptr_3]], #8\n\t"  \
+  "cnt v8.16b, v8.16b\n\t"                  \
+  "cnt v9.16b, v9.16b\n\t"                  \
+  "ldr %q[w_0], [%[w_ptr]]\n\t"             \
+  "cnt v10.16b, v10.16b\n\t"                \
+  "cnt v11.16b, v11.16b\n\t"                \
+  "ldr %q[w_1], [%[w_ptr], #16]\n\t"        \
+  "cnt v12.16b, v12.16b\n\t"                \
+  "cnt v13.16b, v13.16b\n\t"                \
+  "ldr %q[w_2], [%[w_ptr], #32]\n\t"        \
+  "cnt v14.16b, v14.16b\n\t"                \
+  "cnt v15.16b, v15.16b\n\t"                \
+  "ldr %q[w_3], [%[w_ptr], #48]\n\t"        \
+  "addp v0.16b, v0.16b, v4.16b\n\t"         \
+  "addp v1.16b, v1.16b, v5.16b\n\t"         \
+  "addp v2.16b, v2.16b, v6.16b\n\t"         \
+  "addp v3.16b, v3.16b, v7.16b\n\t"         \
+  "addp v8.16b, v8.16b, v12.16b\n\t"        \
+  "addp v9.16b, v9.16b, v13.16b\n\t"        \
+  "addp v10.16b, v10.16b, v14.16b\n\t"      \
+  "addp v11.16b, v11.16b, v15.16b\n\t"      \
+  "addp v0.16b, v0.16b, v8.16b\n\t"         \
+  "addp v1.16b, v1.16b, v9.16b\n\t"         \
+  "addp v2.16b, v2.16b, v10.16b\n\t"        \
+  "addp v3.16b, v3.16b, v11.16b\n\t"        \
+  "add %[w_ptr], %[w_ptr], #64\n\t"         \
+  "uadalp %[accum_0].8h, v0.16b\n\t"        \
+  "uadalp %[accum_1].8h, v1.16b\n\t"        \
+  "uadalp %[accum_2].8h, v2.16b\n\t"        \
+  "uadalp %[accum_3].8h, v3.16b\n\t"
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * greater than one, i.e. the (bitpacked) number of input channels is greater
+ * than 64.
+ */
+inline void AccumulationLoop_Depth2OrMore(
+    std::int32_t conv_kernel_size, const std::int32_t depth,
+    int32x4_t weights[4], int32x4_t activations[4], uint16x8_t accumulators[4],
+    TBitpacked*& weights_ptr, TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth > 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0 = indirection_buffer[0] + 2;
+  TBitpacked* a_ptr_1 = indirection_buffer[1] + 2;
+  TBitpacked* a_ptr_2 = indirection_buffer[2] + 2;
+  TBitpacked* a_ptr_3 = indirection_buffer[3] + 2;
+
+  asm volatile(
+      // w0 is the outer (kernel size) loop counter
+      "mov w0, %w[kernel_size]\n\t"
+
+      // w1 is the inner (depth) loop counter
+      "sub w1, %w[depth], #1\n\t"
+
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop start label
+      "subs w1, w1, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+
+      "bgt 0b\n\t"  // Inner loop branch
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "sub w1, %w[depth], #1\n\t"
+      "subs w0, w0, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+
+      "bgt 0b\n\t"  // Outer loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
+        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
+        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
+        "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15");
+}
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * equal to one, i.e. the (bitpacked) number of input channels is 64.
+ */
+inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
+                                    int32x4_t weights[4],
+                                    int32x4_t activations[4],
+                                    uint16x8_t accumulators[4],
+                                    TBitpacked*& weights_ptr,
+                                    TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth = 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0;
+  TBitpacked* a_ptr_1;
+  TBitpacked* a_ptr_2;
+  TBitpacked* a_ptr_3;
+
+  asm volatile(
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop label
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "subs %w[ks_index], %w[ks_index], #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+
+      "bgt 0b\n\t"  // Loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
+        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
+        [ ks_index ] "+r"(conv_kernel_size)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+        "v9", "v10", "v11", "v12", "v13", "v14", "v15");
+}
+
+#undef XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+
+/**
+ * The output transform and store function for float output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[4], int32x4_t activations[4],
+    const bconv2d::OutputTransform<float>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    float*& output_ptr_0, float*& output_ptr_1, float*& output_ptr_2,
+    float*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Float output transform and store");
+
+  // Declare result registers.
+  float32x4x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr q4, [%[bias_addr]]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr q5, [%[bias_addr], #16]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ld1r {%[a_0].2d}, [x0]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ld1r {%[a_1].2d}, [x1]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, and add the bias. Note
+      // that the float conversion instructions ("scvtf") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave the float multiply and add instructions
+      // between the "scvtf" instructions.
+      "ld1r {%[a_2].2d}, [x2]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ld1r {%[a_3].2d}, [x3]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-64]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v4.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-48]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v5.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "ldr %q[w_2], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v4.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "ldr %q[w_3], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v5.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v4.4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1q_f32(output_ptr_3, results[3].val[0]);
+    vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
+    output_ptr_3 += 8;
+    vst1q_f32(output_ptr_2, results[2].val[0]);
+    vst1q_f32(output_ptr_2 + 4, results[2].val[1]);
+    output_ptr_2 += 8;
+    vst1q_f32(output_ptr_1, results[1].val[0]);
+    vst1q_f32(output_ptr_1 + 4, results[1].val[1]);
+    output_ptr_1 += 8;
+    vst1q_f32(output_ptr_0, results[0].val[0]);
+    vst1q_f32(output_ptr_0 + 4, results[0].val[1]);
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT_LOW(index)                           \
+  vst1q_lane_f32(output_ptr_3 + index, results[3].val[0], index); \
+  vst1q_lane_f32(output_ptr_2 + index, results[2].val[0], index); \
+  vst1q_lane_f32(output_ptr_1 + index, results[1].val[0], index); \
+  vst1q_lane_f32(output_ptr_0 + index, results[0].val[0], index);
+#define STORE_SINGLE_ELEMENT_HIGH(index)                              \
+  vst1q_lane_f32(output_ptr_3 + 4 + index, results[3].val[1], index); \
+  vst1q_lane_f32(output_ptr_2 + 4 + index, results[2].val[1], index); \
+  vst1q_lane_f32(output_ptr_1 + 4 + index, results[1].val[1], index); \
+  vst1q_lane_f32(output_ptr_0 + 4 + index, results[0].val[1], index);
+    STORE_SINGLE_ELEMENT_LOW(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT_LOW(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT_LOW(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT_LOW(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT_HIGH(0)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT_HIGH(1)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT_HIGH(2)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT_LOW
+#undef STORE_SINGLE_ELEMENT_HIGH
+  }
+}
+
+/**
+ * The output transform and store function for int8 output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[4], int32x4_t activations[4],
+    const bconv2d::OutputTransform<std::int8_t>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    std::int8_t*& output_ptr_0, std::int8_t*& output_ptr_1,
+    std::int8_t*& output_ptr_2, std::int8_t*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Int8 output transform and store");
+
+  // Declare result registers. These are wider than we need for just the final
+  // int8 values, which is necessary for intermediate results.
+  int8x16x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr q4, [%[bias_addr]]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr q5, [%[bias_addr], #16]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ld1r {%[a_0].2d}, [x0]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ld1r {%[a_1].2d}, [x1]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, add the bias, convert
+      // back to integer, and use a series of "saturating extract narrow"
+      // instructions to narrow the result to Int8. Note that the float
+      // conversion instructions ("scvtf" and "fcvtns") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave other instructions between them.
+      "ld1r {%[a_2].2d}, [x2]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ld1r {%[a_3].2d}, [x3]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-64]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v4.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-48]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v5.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "ldr %q[w_2], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v4.4s\n\t"
+      "fcvtns %[result_30].4s, %[result_30].4s\n\t"
+      "ldr %q[w_3], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v5.4s\n\t"
+      "fcvtns %[result_31].4s, %[result_31].4s\n\t"
+      "sqxtn %[result_30].4h, %[result_30].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_30].8h, %[result_31].4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v4.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
+      "fcvtns %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
+      "fcvtns %[result_21].4s, %[result_21].4s\n\t"
+      "sqxtn %[result_20].4h, %[result_20].4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
+      "fcvtns %[result_10].4s, %[result_10].4s\n\t"
+      "sqxtn2 %[result_20].8h, %[result_21].4s\n\t"
+      "fcvtns %[result_11].4s, %[result_11].4s\n\t"
+      "sqxtn %[result_10].4h, %[result_10].4s\n\t"
+      "sqxtn %[result_30].8b, %[result_30].8h\n\t"
+      "fcvtns %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_10].8h, %[result_11].4s\n\t"
+      "sqxtn %[result_20].8b, %[result_20].8h\n\t"
+      "fcvtns %[result_01].4s, %[result_01].4s\n\t"
+      "sqxtn %[result_00].4h, %[result_00].4s\n\t"
+      "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
+      "sqxtn %[result_10].8b, %[result_10].8h\n\t"
+      "sqxtn %[result_00].8b, %[result_00].8h\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
+    output_ptr_3 += 8;
+    vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));
+    output_ptr_2 += 8;
+    vst1_s8(output_ptr_1, vget_low_s8(results[1].val[0]));
+    output_ptr_1 += 8;
+    vst1_s8(output_ptr_0, vget_low_s8(results[0].val[0]));
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT(index)                                          \
+  vst1_lane_s8(output_ptr_3 + index, vget_low_s8(results[3].val[0]), index); \
+  vst1_lane_s8(output_ptr_2 + index, vget_low_s8(results[2].val[0]), index); \
+  vst1_lane_s8(output_ptr_1 + index, vget_low_s8(results[1].val[0]), index); \
+  vst1_lane_s8(output_ptr_0 + index, vget_low_s8(results[0].val[0]), index);
+    STORE_SINGLE_ELEMENT(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT(4)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT(5)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT(6)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT
+  }
+}
+
+/**
+ * A 8x4x2 Neon micro-kernel for float or int8 output on Aarch64.
+ */
+template <typename DstScalar, bool Depth2OrMore>
+void RunKernel(const std::int32_t block_num_pixels,
+               const std::int32_t conv_kernel_size,
+               const std::int32_t channels_in, const std::int32_t channels_out,
+               const bconv2d::OutputTransform<DstScalar>& output_transform,
+               const TBitpacked* weights_ptr_,
+               const TBitpacked** indirection_buffer_, DstScalar* output_ptr) {
+  // Correctness of this function relies on TBitpacked being four bytes.
+  static_assert(sizeof(TBitpacked) == 4, "");
+
+  ruy::profiler::ScopeLabel label(
+      "Indirect BGEMM block (8x4x2, Aarch64 optimised)");
+
+  TFLITE_DCHECK_GE(block_num_pixels, 1);
+  TFLITE_DCHECK_LE(block_num_pixels, 4);
+  TFLITE_DCHECK_GE(conv_kernel_size, 1);
+  TFLITE_DCHECK_GE(channels_in, 2);
+  TFLITE_DCHECK_EQ(channels_in % 2, 0);
+  TFLITE_DCHECK_GE(channels_out, 1);
+
+  if (conv_kernel_size < 1 || channels_in < 2 || channels_out < 1) return;
+
+  TBitpacked** indirection_buffer =
+      const_cast<TBitpacked**>(indirection_buffer_);
+  TBitpacked* weights_ptr = const_cast<TBitpacked*>(weights_ptr_);
+
+  DstScalar* output_ptr_0 = output_ptr;
+  DstScalar* output_ptr_1 = output_ptr + channels_out;
+  DstScalar* output_ptr_2 = output_ptr + 2 * channels_out;
+  DstScalar* output_ptr_3 = output_ptr + 3 * channels_out;
+
+  // At the end of the output array we might get a block where the number of
+  // pixels is less than 4. When this happens we set the 'leftover' output
+  // pointer equal to the first output pointer, so that there's no risk of
+  // writing beyond the array bounds. At the end we write to the output array
+  // 'back to front' so that the outputs for the first pixel are written last,
+  // which means that the result will still be correct.
+  if (block_num_pixels < 4) {
+    output_ptr_3 = output_ptr_0;
+    if (block_num_pixels < 3) {
+      output_ptr_2 = output_ptr_0;
+      if (block_num_pixels < 2) {
+        output_ptr_1 = output_ptr_0;
+      }
+    }
+  }
+
+  // Pre-load weights and activations.
+  int32x4_t weights[4] = {vld1q_s32(weights_ptr), vld1q_s32(weights_ptr + 4),
+                          vld1q_s32(weights_ptr + 8),
+                          vld1q_s32(weights_ptr + 12)};
+  weights_ptr += 16;
+  int32x4_t activations[4] = {
+      vreinterpretq_s32_s64(
+          vld1q_dup_s64((std::int64_t*)indirection_buffer[0])),
+      vreinterpretq_s32_s64(
+          vld1q_dup_s64((std::int64_t*)indirection_buffer[1])),
+      vreinterpretq_s32_s64(
+          vld1q_dup_s64((std::int64_t*)indirection_buffer[2])),
+      vreinterpretq_s32_s64(
+          vld1q_dup_s64((std::int64_t*)indirection_buffer[3]))};
+
+  std::int32_t c_out_index = 0;
+  do {
+    uint16x8_t accumulators[4];
+
+    if (Depth2OrMore) {
+      AccumulationLoop_Depth2OrMore(conv_kernel_size, channels_in / 2, weights,
+                                    activations, accumulators, weights_ptr,
+                                    indirection_buffer);
+    } else {
+      AccumulationLoop_Depth1(conv_kernel_size, weights, activations,
+                              accumulators, weights_ptr, indirection_buffer);
+    }
+
+    OutputTransformAndLoadNextAndStore(
+        c_out_index, channels_out, accumulators, weights, activations,
+        output_transform, weights_ptr, indirection_buffer, output_ptr_0,
+        output_ptr_1, output_ptr_2, output_ptr_3);
+
+    c_out_index += 8;
+  } while (c_out_index < channels_out);
+}
+
+}  // namespace kernel_8x4x2_aarch64
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x2_AARCH64_H_

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
@@ -105,10 +105,12 @@ namespace kernel_8x4x2_aarch64 {
  *     accum_3 = 0;
  *
  *     // This block is removed in the depth=1 case
- *     a_ptr_0 = indirection_buffer[0];
- *     a_ptr_1 = indirection_buffer[1];
- *     a_ptr_2 = indirection_buffer[2];
- *     a_ptr_3 = indirection_buffer[3];
+ *     // The first set of activations is already loaded, so this +1
+ *     // ensures that the first 'block' loads the next set of activations.
+ *     a_ptr_0 = indirection_buffer[0] + 1;
+ *     a_ptr_1 = indirection_buffer[1] + 1;
+ *     a_ptr_2 = indirection_buffer[2] + 1;
+ *     a_ptr_3 = indirection_buffer[3] + 1;
  *     indirection_buffer += 4;
  *
  *     int ks = kernel_size;

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
@@ -21,16 +21,13 @@ namespace core {
 namespace indirect_bgemm {
 namespace kernel_8x4x2_aarch64 {
 
-/**
- * This block of instructions takes as input the activation vector registers
- * a_0, ..., a_3 and the weight vector registers w_0, ..., w_3, and computes
- * 'binary multiplication and accumulation' (BMLA) using XOR and popcount
- * instructions, adding the results to the 16-bit accumulator vector registers
- * accum_0, ..., accum_3.
- *
- * Additionally, it loads the next values into a_0, ..., a_3 (from the pointers
- * a_ptr_0, ..., a_ptr_3) and into w_0, ..., w_3 (from the pointer w_ptr).
- */
+// This block of instructions takes as input the activation vector registers
+// a_0, ..., a_3 and the weight vector registers w_0, ..., w_3, and computes
+// 'binary multiplication and accumulation' (BMLA) using XOR and popcount
+// instructions, adding the results to the 16-bit accumulator vector registers
+// accum_0, ..., accum_3.
+//     It also reloads data for the next loop iteration into a_0, ..., a_3 and
+// w_0, ..., w_3 from the pointers a_ptr_0, ..., a_ptr_3 and w_ptr.
 #define XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64    \
   "eor v0.16b, %[a_0].16b, %[w_0].16b\n\t"  \
   "eor v1.16b, %[a_1].16b, %[w_0].16b\n\t"  \
@@ -91,10 +88,49 @@ namespace kernel_8x4x2_aarch64 {
   "uadalp %[accum_3].8h, v3.16b\n\t"
 
 /**
- * This function performs the accumulation loop when we know that the depth is
- * greater than one, i.e. the (bitpacked) number of input channels is greater
- * than 64.
+ * Accumulation loops
+ *
+ * There are two variants of the accumulation loop: one for when we know the
+ * depth is greater than one, i.e. the number of input channels is greater than
+ * 64; and one for when we know the depth is equal to one, i.e. the number of
+ * input channels is equal to 64. The latter case allows for a slight
+ * optimisation.
+ *
+ * The accumulation loops use inline assembly but are equivalent to the
+ * following pseudocode:
+ *
+ *     accum_0 = 0;
+ *     accum_1 = 0;
+ *     accum_2 = 0;
+ *     accum_3 = 0;
+ *
+ *     // This block is removed in the depth=1 case
+ *     a_ptr_0 = indirection_buffer[0];
+ *     a_ptr_1 = indirection_buffer[1];
+ *     a_ptr_2 = indirection_buffer[2];
+ *     a_ptr_3 = indirection_buffer[3];
+ *     indirection_buffer += 4;
+ *
+ *     int ks = kernel_size;
+ *     do {
+ *         // This loop is removed in the depth=1 case
+ *         for (int d = 0; d < depth - 1; d++) {
+ *             XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+ *         }
+ *
+ *         // Before the final inner (depth loop) iteration, set the activation
+ *         // pointers so that the activations for the next outer loop iteration
+ *         // are loaded correctly.
+ *         a_ptr_0 = indirection_buffer[0];
+ *         a_ptr_1 = indirection_buffer[1];
+ *         a_ptr_2 = indirection_buffer[2];
+ *         a_ptr_3 = indirection_buffer[3];
+ *         indirection_buffer += 4;
+ *
+ *         XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
+ *     } while (--ks > 0);
  */
+
 inline void AccumulationLoop_Depth2OrMore(
     std::int32_t conv_kernel_size, const std::int32_t depth,
     int32x4_t weights[4], int32x4_t activations[4], uint16x8_t accumulators[4],
@@ -152,10 +188,6 @@ inline void AccumulationLoop_Depth2OrMore(
         "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15");
 }
 
-/**
- * This function performs the accumulation loop when we know that the depth is
- * equal to one, i.e. the (bitpacked) number of input channels is 64.
- */
 inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
                                     int32x4_t weights[4],
                                     int32x4_t activations[4],
@@ -206,9 +238,15 @@ inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
 #undef XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
 
 /**
- * The output transform and store function for float output. Also reloads the
- * weight and activation registers for the next iteration.
+ * Output transforms
+ *
+ * These destination-type-specific functions take the accumulator values and
+ * perform the output transform, before storing the results in the output array.
+ * They additionally reload data into the weight and activation registers for
+ * the first iteration of the next accumulation loop.
  */
+
+// Float output transform
 inline void OutputTransformAndLoadNextAndStore(
     const std::int32_t c_out_index, const std::int32_t channels_out,
     uint16x8_t accumulators[4], int32x4_t weights[4], int32x4_t activations[4],
@@ -367,10 +405,7 @@ inline void OutputTransformAndLoadNextAndStore(
   }
 }
 
-/**
- * The output transform and store function for int8 output. Also reloads the
- * weight and activation registers for the next iteration.
- */
+// Int8 output transform
 inline void OutputTransformAndLoadNextAndStore(
     const std::int32_t c_out_index, const std::int32_t channels_out,
     uint16x8_t accumulators[4], int32x4_t weights[4], int32x4_t activations[4],

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
@@ -1,0 +1,704 @@
+#ifndef COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x4_AARCH64_H_
+#define COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x4_AARCH64_H_
+
+#ifndef __aarch64__
+#pragma GCC error "ERROR: This file should only be compiled for Aarch64."
+#endif
+
+#include <arm_neon.h>
+
+#include <cstdint>
+#include <type_traits>
+
+#include "larq_compute_engine/core/bconv2d/output_transform.h"
+#include "larq_compute_engine/core/types.h"
+#include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace compute_engine {
+namespace core {
+namespace indirect_bgemm {
+namespace kernel_8x4x4_aarch64 {
+
+/**
+ * This block of instructions takes as input the activation vector registers
+ * a_0, ..., a_3 and the weight vector registers w_0, ..., w_7, and computes
+ * 'binary multiplication and accumulation' (BMLA) using XOR and popcount
+ * instructions, adding the results to the 16-bit accumulator vector registers
+ * accum_0, ..., accum_3.
+ *
+ * Additionally, it loads the next values into a_0, ..., a_3 (from the pointers
+ * a_ptr_0, ..., a_ptr_3) and into w_0, ..., w_7 (from the pointer w_ptr).
+ */
+#define XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128      \
+  "eor v0.16b, %[a_0].16b, %[w_0].16b\n\t"     \
+  "eor v1.16b, %[a_1].16b, %[w_0].16b\n\t"     \
+  "eor v2.16b, %[a_2].16b, %[w_0].16b\n\t"     \
+  "eor v3.16b, %[a_3].16b, %[w_0].16b\n\t"     \
+  "eor v4.16b, %[a_0].16b, %[w_1].16b\n\t"     \
+  "eor v5.16b, %[a_1].16b, %[w_1].16b\n\t"     \
+  "eor v6.16b, %[a_2].16b, %[w_1].16b\n\t"     \
+  "eor v7.16b, %[a_3].16b, %[w_1].16b\n\t"     \
+  "eor v8.16b, %[a_0].16b, %[w_2].16b\n\t"     \
+  "eor v9.16b, %[a_1].16b, %[w_2].16b\n\t"     \
+  "eor v10.16b, %[a_2].16b, %[w_2].16b\n\t"    \
+  "eor v11.16b, %[a_3].16b, %[w_2].16b\n\t"    \
+  "eor v12.16b, %[a_0].16b, %[w_3].16b\n\t"    \
+  "eor v13.16b, %[a_1].16b, %[w_3].16b\n\t"    \
+  "eor v14.16b, %[a_2].16b, %[w_3].16b\n\t"    \
+  "eor v15.16b, %[a_3].16b, %[w_3].16b\n\t"    \
+  "cnt v0.16b, v0.16b\n\t"                     \
+  "cnt v1.16b, v1.16b\n\t"                     \
+  "cnt v2.16b, v2.16b\n\t"                     \
+  "cnt v3.16b, v3.16b\n\t"                     \
+  "cnt v4.16b, v4.16b\n\t"                     \
+  "cnt v5.16b, v5.16b\n\t"                     \
+  "cnt v6.16b, v6.16b\n\t"                     \
+  "cnt v7.16b, v7.16b\n\t"                     \
+  "cnt v8.16b, v8.16b\n\t"                     \
+  "cnt v9.16b, v9.16b\n\t"                     \
+  "cnt v10.16b, v10.16b\n\t"                   \
+  "cnt v11.16b, v11.16b\n\t"                   \
+  "cnt v12.16b, v12.16b\n\t"                   \
+  "cnt v13.16b, v13.16b\n\t"                   \
+  "cnt v14.16b, v14.16b\n\t"                   \
+  "cnt v15.16b, v15.16b\n\t"                   \
+  "addp v0.16b, v0.16b, v4.16b\n\t"            \
+  "addp v1.16b, v1.16b, v5.16b\n\t"            \
+  "addp v2.16b, v2.16b, v6.16b\n\t"            \
+  "addp v3.16b, v3.16b, v7.16b\n\t"            \
+  "addp v8.16b, v8.16b, v12.16b\n\t"           \
+  "addp v9.16b, v9.16b, v13.16b\n\t"           \
+  "addp v10.16b, v10.16b, v14.16b\n\t"         \
+  "addp v11.16b, v11.16b, v15.16b\n\t"         \
+                                               \
+  "eor v4.16b, %[a_0].16b, %[w_4].16b\n\t"     \
+  "eor v5.16b, %[a_1].16b, %[w_4].16b\n\t"     \
+  "eor v6.16b, %[a_2].16b, %[w_4].16b\n\t"     \
+  "eor v7.16b, %[a_3].16b, %[w_4].16b\n\t"     \
+  "eor v12.16b, %[a_0].16b, %[w_5].16b\n\t"    \
+  "eor v13.16b, %[a_1].16b, %[w_5].16b\n\t"    \
+  "eor v14.16b, %[a_2].16b, %[w_5].16b\n\t"    \
+  "eor v15.16b, %[a_3].16b, %[w_5].16b\n\t"    \
+  "eor %[w_0].16b, %[a_0].16b, %[w_6].16b\n\t" \
+  "eor %[w_1].16b, %[a_1].16b, %[w_6].16b\n\t" \
+  "eor %[w_2].16b, %[a_2].16b, %[w_6].16b\n\t" \
+  "eor %[w_3].16b, %[a_3].16b, %[w_6].16b\n\t" \
+  "eor %[w_4].16b, %[a_0].16b, %[w_7].16b\n\t" \
+  "eor %[w_5].16b, %[a_1].16b, %[w_7].16b\n\t" \
+  "eor %[w_6].16b, %[a_2].16b, %[w_7].16b\n\t" \
+  "eor %[w_7].16b, %[a_3].16b, %[w_7].16b\n\t" \
+  "cnt v4.16b, v4.16b\n\t"                     \
+  "cnt v5.16b, v5.16b\n\t"                     \
+  "cnt v6.16b, v6.16b\n\t"                     \
+  "cnt v7.16b, v7.16b\n\t"                     \
+  "ld1 {%[a_0].4s}, [%[a_ptr_0]], #16\n\t"     \
+  "cnt v12.16b, v12.16b\n\t"                   \
+  "cnt v13.16b, v13.16b\n\t"                   \
+  "cnt v14.16b, v14.16b\n\t"                   \
+  "cnt v15.16b, v15.16b\n\t"                   \
+  "ld1 {%[a_1].4s}, [%[a_ptr_1]], #16\n\t"     \
+  "cnt %[w_0].16b, %[w_0].16b\n\t"             \
+  "cnt %[w_1].16b, %[w_1].16b\n\t"             \
+  "cnt %[w_2].16b, %[w_2].16b\n\t"             \
+  "cnt %[w_3].16b, %[w_3].16b\n\t"             \
+  "ld1 {%[a_2].4s}, [%[a_ptr_2]], #16\n\t"     \
+  "cnt %[w_4].16b, %[w_4].16b\n\t"             \
+  "cnt %[w_5].16b, %[w_5].16b\n\t"             \
+  "cnt %[w_6].16b, %[w_6].16b\n\t"             \
+  "cnt %[w_7].16b, %[w_7].16b\n\t"             \
+  "ld1 {%[a_3].4s}, [%[a_ptr_3]], #16\n\t"     \
+  "addp v4.16b, v4.16b, v12.16b\n\t"           \
+  "addp v5.16b, v5.16b, v13.16b\n\t"           \
+  "addp v6.16b, v6.16b, v14.16b\n\t"           \
+  "addp v7.16b, v7.16b, v15.16b\n\t"           \
+  "addp v12.16b, %[w_0].16b, %[w_4].16b\n\t"   \
+  "addp v13.16b, %[w_1].16b, %[w_5].16b\n\t"   \
+  "addp v14.16b, %[w_2].16b, %[w_6].16b\n\t"   \
+  "addp v15.16b, %[w_3].16b, %[w_7].16b\n\t"   \
+                                               \
+  "ldr %q[w_0], [%[w_ptr]]\n\t"                \
+  "addp v0.16b, v0.16b, v8.16b\n\t"            \
+  "addp v1.16b, v1.16b, v9.16b\n\t"            \
+  "ldr %q[w_1], [%[w_ptr], #16]\n\t"           \
+  "addp v2.16b, v2.16b, v10.16b\n\t"           \
+  "addp v3.16b, v3.16b, v11.16b\n\t"           \
+  "ldr %q[w_2], [%[w_ptr], #32]\n\t"           \
+  "addp v4.16b, v4.16b, v12.16b\n\t"           \
+  "addp v5.16b, v5.16b, v13.16b\n\t"           \
+  "ldr %q[w_3], [%[w_ptr], #48]\n\t"           \
+  "addp v6.16b, v6.16b, v14.16b\n\t"           \
+  "addp v7.16b, v7.16b, v15.16b\n\t"           \
+                                               \
+  "ldr %q[w_4], [%[w_ptr], #64]\n\t"           \
+  "addp v0.16b, v0.16b, v4.16b\n\t"            \
+  "addp v1.16b, v1.16b, v5.16b\n\t"            \
+  "ldr %q[w_5], [%[w_ptr], #80]\n\t"           \
+  "addp v2.16b, v2.16b, v6.16b\n\t"            \
+  "addp v3.16b, v3.16b, v7.16b\n\t"            \
+                                               \
+  "ldr %q[w_6], [%[w_ptr], #96]\n\t"           \
+  "uadalp %[accum_0].8h, v0.16b\n\t"           \
+  "uadalp %[accum_1].8h, v1.16b\n\t"           \
+  "ldr %q[w_7], [%[w_ptr], #112]\n\t"          \
+  "uadalp %[accum_2].8h, v2.16b\n\t"           \
+  "uadalp %[accum_3].8h, v3.16b\n\t"           \
+  "add %[w_ptr], %[w_ptr], #128\n\t"
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * greater than one, i.e. the (bitpacked) number of input channels is greater
+ * than 128.
+ */
+inline void AccumulationLoop_Depth2OrMore(
+    std::int32_t conv_kernel_size, const std::int32_t depth,
+    int32x4_t weights[8], int32x4_t activations[4], uint16x8_t accumulators[4],
+    TBitpacked*& weights_ptr, TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth > 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0 = indirection_buffer[0] + 4;
+  TBitpacked* a_ptr_1 = indirection_buffer[1] + 4;
+  TBitpacked* a_ptr_2 = indirection_buffer[2] + 4;
+  TBitpacked* a_ptr_3 = indirection_buffer[3] + 4;
+
+  asm volatile(
+      // w0 is the outer (kernel size) loop counter
+      "mov w0, %w[kernel_size]\n\t"
+
+      // w1 is the inner (channels in) loop counter
+      "sub w1, %w[depth], #1\n\t"
+
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop start label
+      "subs w1, w1, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
+
+      "bgt 0b\n\t"  // Inner loop branch
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "sub w1, %w[depth], #1\n\t"
+      "subs w0, w0, #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
+
+      "bgt 0b\n\t"  // Outer loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
+        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
+        [ w_4 ] "w"(weights[4]), [ w_5 ] "w"(weights[5]),
+        [ w_6 ] "w"(weights[6]), [ w_7 ] "w"(weights[7]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
+        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
+        "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15");
+}
+
+/**
+ * This function performs the accumulation loop when we know that the depth is
+ * greater one, i.e. the (bitpacked) number of input channels is 128.
+ */
+inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
+                                    int32x4_t weights[8],
+                                    int32x4_t activations[4],
+                                    uint16x8_t accumulators[4],
+                                    TBitpacked*& weights_ptr,
+                                    TBitpacked** indirection_buffer) {
+  ruy::profiler::ScopeLabel label("Accumulation loop (depth = 1)");
+
+  // Declare these variables so we can use named registers in the ASM block.
+  TBitpacked** indirection_buffer_ = indirection_buffer + 4;
+  TBitpacked* a_ptr_0;
+  TBitpacked* a_ptr_1;
+  TBitpacked* a_ptr_2;
+  TBitpacked* a_ptr_3;
+
+  asm volatile(
+      // Zero-out the accumulator registers
+      "movi %[accum_0].8h, #0\n\t"
+      "movi %[accum_1].8h, #0\n\t"
+      "movi %[accum_2].8h, #0\n\t"
+      "movi %[accum_3].8h, #0\n\t"
+
+      "0:\n\t"  // Loop label
+
+      "ldp %[a_ptr_0], %[a_ptr_1], [%[indirection_buffer]]\n\t"
+      "ldp %[a_ptr_2], %[a_ptr_3], [%[indirection_buffer], #16]\n\t"
+      "add %[indirection_buffer], %[indirection_buffer], #32\n\t"
+      "subs %w[ks_index], %w[ks_index], #1\n\t"
+
+      XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
+
+      "bgt 0b\n\t"  // Loop branch
+      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
+        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
+        [ w_ptr ] "+r"(weights_ptr),
+        [ indirection_buffer ] "+r"(indirection_buffer_),
+        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
+        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
+        [ ks_index ] "+r"(conv_kernel_size)
+      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
+        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
+        [ w_4 ] "w"(weights[4]), [ w_5 ] "w"(weights[5]),
+        [ w_6 ] "w"(weights[6]), [ w_7 ] "w"(weights[7]),
+        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
+        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+        "v9", "v10", "v11", "v12", "v13", "v14", "v15");
+}
+
+#undef XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
+
+/**
+ * The output transform and store function for float output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[8], int32x4_t activations[4],
+    const bconv2d::OutputTransform<float>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    float*& output_ptr_0, float*& output_ptr_1, float*& output_ptr_2,
+    float*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Float output transform and store");
+
+  // Declare result registers.
+  float32x4x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr %q[a_0], [x0]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "ldr %q[a_1], [x1]\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr %q[a_2], [x2]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "ldr %q[a_3], [x3]\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-128]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "ldr q0, [%[bias_addr]]\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-112]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "ldr %q[w_2], [%[w_ptr], #-96]\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, and add the bias. Note
+      // that the float conversion instructions ("scvtf") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave the float multiply and add instructions
+      // between the "scvtf" instructions.
+      "ldr q1, [%[bias_addr], #16]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ldr %q[w_3], [%[w_ptr], #-80]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_4], [%[w_ptr], #-64]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_5], [%[w_ptr], #-48]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "ldr %q[w_6], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "ldr %q[w_7], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
+        [ w_4 ] "=&w"(weights[4]), [ w_5 ] "=&w"(weights[5]),
+        [ w_6 ] "=&w"(weights[6]), [ w_7 ] "=&w"(weights[7]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1q_f32(output_ptr_3, results[3].val[0]);
+    vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
+    output_ptr_3 += 8;
+    vst1q_f32(output_ptr_2, results[2].val[0]);
+    vst1q_f32(output_ptr_2 + 4, results[2].val[1]);
+    output_ptr_2 += 8;
+    vst1q_f32(output_ptr_1, results[1].val[0]);
+    vst1q_f32(output_ptr_1 + 4, results[1].val[1]);
+    output_ptr_1 += 8;
+    vst1q_f32(output_ptr_0, results[0].val[0]);
+    vst1q_f32(output_ptr_0 + 4, results[0].val[1]);
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT_LOW(index)                           \
+  vst1q_lane_f32(output_ptr_3 + index, results[3].val[0], index); \
+  vst1q_lane_f32(output_ptr_2 + index, results[2].val[0], index); \
+  vst1q_lane_f32(output_ptr_1 + index, results[1].val[0], index); \
+  vst1q_lane_f32(output_ptr_0 + index, results[0].val[0], index);
+#define STORE_SINGLE_ELEMENT_HIGH(index)                              \
+  vst1q_lane_f32(output_ptr_3 + 4 + index, results[3].val[1], index); \
+  vst1q_lane_f32(output_ptr_2 + 4 + index, results[2].val[1], index); \
+  vst1q_lane_f32(output_ptr_1 + 4 + index, results[1].val[1], index); \
+  vst1q_lane_f32(output_ptr_0 + 4 + index, results[0].val[1], index);
+    STORE_SINGLE_ELEMENT_LOW(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT_LOW(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT_LOW(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT_LOW(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT_HIGH(0)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT_HIGH(1)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT_HIGH(2)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT_LOW
+#undef STORE_SINGLE_ELEMENT_HIGH
+  }
+}
+
+/**
+ * The output transform and store function for int8 output. Also reloads the
+ * weight and activation registers for the next iteration.
+ */
+inline void OutputTransformAndLoadNextAndStore(
+    const std::int32_t c_out_index, const std::int32_t channels_out,
+    uint16x8_t accumulators[4], int32x4_t weights[8], int32x4_t activations[4],
+    const bconv2d::OutputTransform<std::int8_t>& output_transform,
+    const TBitpacked* weights_ptr, TBitpacked** indirection_buffer,
+    std::int8_t*& output_ptr_0, std::int8_t*& output_ptr_1,
+    std::int8_t*& output_ptr_2, std::int8_t*& output_ptr_3) {
+  ruy::profiler::ScopeLabel label("Int8 output transform and store");
+
+  // Declare result registers. These are wider than we need for just the final
+  // int8 values, which is necessary for intermediate results.
+  int8x16x2_t results[4];
+
+  asm("ldp x0, x1, [%[indirection_buffer]]\n\t"
+
+      // Use "unsigned shift left long" instructions to perform the
+      // back-transformation left-shift and extend the result to int32.
+      "ld1r {v0.4s}, [%[clamp_min_addr]]\n\t"
+      "ushll %[result_00].4s, %[accum_0].4h, #1\n\t"
+      "ushll %[result_10].4s, %[accum_1].4h, #1\n\t"
+      "ld1r {v1.4s}, [%[clamp_max_addr]]\n\t"
+      "ushll %[result_20].4s, %[accum_2].4h, #1\n\t"
+      "ushll %[result_30].4s, %[accum_3].4h, #1\n\t"
+      "ldr q2, [%[multiplier_addr]]\n\t"
+      "ushll2 %[result_31].4s, %[accum_3].8h, #1\n\t"
+      "ushll2 %[result_21].4s, %[accum_2].8h, #1\n\t"
+      "ldr q3, [%[multiplier_addr], #16]\n\t"
+      "ushll2 %[result_11].4s, %[accum_1].8h, #1\n\t"
+      "ushll2 %[result_01].4s, %[accum_0].8h, #1\n\t"
+
+      "ldp x2, x3, [%[indirection_buffer], #16]\n\t"
+
+      // Perform clamping
+      "ldr %q[a_0], [x0]\n\t"
+      "smax %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "smax %[result_31].4s, %[result_31].4s, v0.4s\n\t"
+      "ldr %q[a_1], [x1]\n\t"
+      "smax %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "smax %[result_21].4s, %[result_21].4s, v0.4s\n\t"
+      "ldr %q[a_2], [x2]\n\t"
+      "smax %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "smax %[result_11].4s, %[result_11].4s, v0.4s\n\t"
+      "ldr %q[a_3], [x3]\n\t"
+      "smax %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "smax %[result_01].4s, %[result_01].4s, v0.4s\n\t"
+      "ldr %q[w_0], [%[w_ptr], #-128]\n\t"
+      "smin %[result_30].4s, %[result_30].4s, v1.4s\n\t"
+      "smin %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "ldr q0, [%[bias_addr]]\n\t"
+      "smin %[result_20].4s, %[result_20].4s, v1.4s\n\t"
+      "smin %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "ldr %q[w_1], [%[w_ptr], #-112]\n\t"
+      "smin %[result_10].4s, %[result_10].4s, v1.4s\n\t"
+      "smin %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "ldr %q[w_2], [%[w_ptr], #-96]\n\t"
+      "smin %[result_00].4s, %[result_00].4s, v1.4s\n\t"
+      "smin %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+
+      // Convert to float, multiply by the multiplier, and add the bias. Note
+      // that the float conversion instructions ("scvtf") are *very* slow and
+      // block the Neon pipeline. It is therefore important for optimal
+      // performance to interleave the float multiply and add instructions
+      // between the "scvtf" instructions.
+      "ldr q1, [%[bias_addr], #16]\n\t"
+      "scvtf %[result_30].4s, %[result_30].4s\n\t"
+      "scvtf %[result_31].4s, %[result_31].4s\n\t"
+      "ldr %q[w_3], [%[w_ptr], #-80]\n\t"
+      "scvtf %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_30].4s, %[result_30].4s, v2.4s\n\t"
+      "scvtf %[result_21].4s, %[result_21].4s\n\t"
+      "ldr %q[w_4], [%[w_ptr], #-64]\n\t"
+      "fmul %[result_31].4s, %[result_31].4s, v3.4s\n\t"
+      "fadd %[result_30].4s, %[result_30].4s, v0.4s\n\t"
+      "scvtf %[result_10].4s, %[result_10].4s\n\t"
+      "ldr %q[w_5], [%[w_ptr], #-48]\n\t"
+      "fmul %[result_20].4s, %[result_20].4s, v2.4s\n\t"
+      "fadd %[result_31].4s, %[result_31].4s, v1.4s\n\t"
+      "scvtf %[result_11].4s, %[result_11].4s\n\t"
+      "ldr %q[w_6], [%[w_ptr], #-32]\n\t"
+      "fmul %[result_21].4s, %[result_21].4s, v3.4s\n\t"
+      "fadd %[result_20].4s, %[result_20].4s, v0.4s\n\t"
+      "fcvtns %[result_30].4s, %[result_30].4s\n\t"
+      "ldr %q[w_7], [%[w_ptr], #-16]\n\t"
+      "fmul %[result_10].4s, %[result_10].4s, v2.4s\n\t"
+      "fadd %[result_21].4s, %[result_21].4s, v1.4s\n\t"
+      "fcvtns %[result_31].4s, %[result_31].4s\n\t"
+      "sqxtn %[result_30].4h, %[result_30].4s\n\t"
+      "fmul %[result_11].4s, %[result_11].4s, v3.4s\n\t"
+      "scvtf %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_30].8h, %[result_31].4s\n\t"
+      "fadd %[result_10].4s, %[result_10].4s, v0.4s\n\t"
+      "scvtf %[result_01].4s, %[result_01].4s\n\t"
+      "fmul %[result_00].4s, %[result_00].4s, v2.4s\n\t"
+      "fadd %[result_11].4s, %[result_11].4s, v1.4s\n\t"
+      "fcvtns %[result_20].4s, %[result_20].4s\n\t"
+      "fmul %[result_01].4s, %[result_01].4s, v3.4s\n\t"
+      "fadd %[result_00].4s, %[result_00].4s, v0.4s\n\t"
+      "fcvtns %[result_21].4s, %[result_21].4s\n\t"
+      "sqxtn %[result_20].4h, %[result_20].4s\n\t"
+      "fadd %[result_01].4s, %[result_01].4s, v1.4s\n\t"
+      "fcvtns %[result_10].4s, %[result_10].4s\n\t"
+      "sqxtn2 %[result_20].8h, %[result_21].4s\n\t"
+      "fcvtns %[result_11].4s, %[result_11].4s\n\t"
+      "sqxtn %[result_10].4h, %[result_10].4s\n\t"
+      "sqxtn %[result_30].8b, %[result_30].8h\n\t"
+      "fcvtns %[result_00].4s, %[result_00].4s\n\t"
+      "sqxtn2 %[result_10].8h, %[result_11].4s\n\t"
+      "sqxtn %[result_20].8b, %[result_20].8h\n\t"
+      "fcvtns %[result_01].4s, %[result_01].4s\n\t"
+      "sqxtn %[result_00].4h, %[result_00].4s\n\t"
+      "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
+      "sqxtn %[result_10].8b, %[result_10].8h\n\t"
+      "sqxtn %[result_00].8b, %[result_00].8h\n\t"
+      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
+        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
+        [ w_4 ] "=&w"(weights[4]), [ w_5 ] "=&w"(weights[5]),
+        [ w_6 ] "=&w"(weights[6]), [ w_7 ] "=&w"(weights[7]),
+        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
+        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
+        [ result_00 ] "=&w"(results[0].val[0]),
+        [ result_01 ] "=&w"(results[0].val[1]),
+        [ result_10 ] "=&w"(results[1].val[0]),
+        [ result_11 ] "=&w"(results[1].val[1]),
+        [ result_20 ] "=&w"(results[2].val[0]),
+        [ result_21 ] "=&w"(results[2].val[1]),
+        [ result_30 ] "=&w"(results[3].val[0]),
+        [ result_31 ] "=&w"(results[3].val[1])
+      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
+        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
+        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
+        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
+        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
+        [ bias_addr ] "r"(output_transform.bias + c_out_index),
+        [ w_ptr ] "r"(weights_ptr),
+        [ indirection_buffer ] "r"(indirection_buffer)
+      : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
+
+  if (channels_out - c_out_index >= 8) {
+    vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
+    output_ptr_3 += 8;
+    vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));
+    output_ptr_2 += 8;
+    vst1_s8(output_ptr_1, vget_low_s8(results[1].val[0]));
+    output_ptr_1 += 8;
+    vst1_s8(output_ptr_0, vget_low_s8(results[0].val[0]));
+    output_ptr_0 += 8;
+  } else {
+#define STORE_SINGLE_ELEMENT(index)                                          \
+  vst1_lane_s8(output_ptr_3 + index, vget_low_s8(results[3].val[0]), index); \
+  vst1_lane_s8(output_ptr_2 + index, vget_low_s8(results[2].val[0]), index); \
+  vst1_lane_s8(output_ptr_1 + index, vget_low_s8(results[1].val[0]), index); \
+  vst1_lane_s8(output_ptr_0 + index, vget_low_s8(results[0].val[0]), index);
+    STORE_SINGLE_ELEMENT(0)
+    if (channels_out - c_out_index >= 2) {
+      STORE_SINGLE_ELEMENT(1)
+      if (channels_out - c_out_index >= 3) {
+        STORE_SINGLE_ELEMENT(2)
+        if (channels_out - c_out_index >= 4) {
+          STORE_SINGLE_ELEMENT(3)
+          if (channels_out - c_out_index >= 5) {
+            STORE_SINGLE_ELEMENT(4)
+            if (channels_out - c_out_index >= 6) {
+              STORE_SINGLE_ELEMENT(5)
+              if (channels_out - c_out_index >= 7) {
+                STORE_SINGLE_ELEMENT(6)
+              }
+            }
+          }
+        }
+      }
+    }
+#undef STORE_SINGLE_ELEMENT
+  }
+}
+
+/**
+ * A 8x4x4 Neon micro-kernel for float or int8 output on Aarch64.
+ */
+template <typename DstScalar, bool Depth2OrMore>
+void RunKernel(const std::int32_t block_num_pixels,
+               const std::int32_t conv_kernel_size,
+               const std::int32_t channels_in, const std::int32_t channels_out,
+               const bconv2d::OutputTransform<DstScalar>& output_transform,
+               const TBitpacked* weights_ptr_,
+               const TBitpacked** indirection_buffer_, DstScalar* output_ptr) {
+  // Correctness of this function relies on TBitpacked being four bytes.
+  static_assert(sizeof(TBitpacked) == 4, "");
+
+  ruy::profiler::ScopeLabel label(
+      "Indirect BGEMM block (8x4x4, Aarch64 optimised)");
+
+  TFLITE_DCHECK_GE(block_num_pixels, 1);
+  TFLITE_DCHECK_LE(block_num_pixels, 4);
+  TFLITE_DCHECK_GE(conv_kernel_size, 1);
+  TFLITE_DCHECK_GE(channels_in, 4);
+  TFLITE_DCHECK_EQ(channels_in % 4, 0);
+  TFLITE_DCHECK_GE(channels_out, 1);
+
+  if (conv_kernel_size < 1 || channels_in < 4 || channels_out < 1) return;
+
+  TBitpacked** indirection_buffer =
+      const_cast<TBitpacked**>(indirection_buffer_);
+  TBitpacked* weights_ptr = const_cast<TBitpacked*>(weights_ptr_);
+
+  DstScalar* output_ptr_0 = output_ptr;
+  DstScalar* output_ptr_1 = output_ptr + channels_out;
+  DstScalar* output_ptr_2 = output_ptr + 2 * channels_out;
+  DstScalar* output_ptr_3 = output_ptr + 3 * channels_out;
+
+  // At the end of the output array we might get a block where the number of
+  // pixels is less than 4. When this happens we set the 'leftover' output
+  // pointer equal to the first output pointer, so that there's no risk of
+  // writing beyond the array bounds. At the end we write to the output array
+  // 'back to front' so that the outputs for the first pixel are written last,
+  // which means that the result will still be correct.
+  if (block_num_pixels < 4) {
+    output_ptr_3 = output_ptr_0;
+    if (block_num_pixels < 3) {
+      output_ptr_2 = output_ptr_0;
+      if (block_num_pixels < 2) {
+        output_ptr_1 = output_ptr_0;
+      }
+    }
+  }
+
+  // Pre-load weights and activations.
+  int32x4_t weights[8] = {
+      vld1q_s32(weights_ptr),      vld1q_s32(weights_ptr + 4),
+      vld1q_s32(weights_ptr + 8),  vld1q_s32(weights_ptr + 12),
+      vld1q_s32(weights_ptr + 16), vld1q_s32(weights_ptr + 20),
+      vld1q_s32(weights_ptr + 24), vld1q_s32(weights_ptr + 28)};
+  weights_ptr += 32;
+  int32x4_t activations[4] = {
+      vld1q_s32(indirection_buffer[0]), vld1q_s32(indirection_buffer[1]),
+      vld1q_s32(indirection_buffer[2]), vld1q_s32(indirection_buffer[3])};
+
+  std::int32_t c_out_index = 0;
+  do {
+    // Declare accumulators
+    uint16x8_t accumulators[4];
+
+    if (Depth2OrMore) {
+      AccumulationLoop_Depth2OrMore(conv_kernel_size, channels_in / 4, weights,
+                                    activations, accumulators, weights_ptr,
+                                    indirection_buffer);
+    } else {
+      AccumulationLoop_Depth1(conv_kernel_size, weights, activations,
+                              accumulators, weights_ptr, indirection_buffer);
+    }
+
+    OutputTransformAndLoadNextAndStore(
+        c_out_index, channels_out, accumulators, weights, activations,
+        output_transform, weights_ptr, indirection_buffer, output_ptr_0,
+        output_ptr_1, output_ptr_2, output_ptr_3);
+
+    c_out_index += 8;
+  } while (c_out_index < channels_out);
+}
+
+}  // namespace kernel_8x4x4_aarch64
+}  // namespace indirect_bgemm
+}  // namespace core
+}  // namespace compute_engine
+
+#endif  // COMPUTE_ENGINE_INDIRECT_BGEMM_KERNEL_8x4x4_AARCH64_H_

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
@@ -161,10 +161,12 @@ namespace kernel_8x4x4_aarch64 {
  *     accum_3 = 0;
  *
  *     // This block is removed in the depth=1 case
- *     a_ptr_0 = indirection_buffer[0];
- *     a_ptr_1 = indirection_buffer[1];
- *     a_ptr_2 = indirection_buffer[2];
- *     a_ptr_3 = indirection_buffer[3];
+ *     // The first set of activations is already loaded, so this +1
+ *     // ensures that the first 'block' loads the next set of activations.
+ *     a_ptr_0 = indirection_buffer[0] + 1;
+ *     a_ptr_1 = indirection_buffer[1] + 1;
+ *     a_ptr_2 = indirection_buffer[2] + 1;
+ *     a_ptr_3 = indirection_buffer[3] + 1;
  *     indirection_buffer += 4;
  *
  *     int ks = kernel_size;

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -416,8 +416,8 @@ void EvalOptIndirectBGEMM(TfLiteContext* context, TfLiteNode* node,
         output_shape, GetTensorData<TBitpacked>(input),
         conv_params->indirection_buffer, conv_params->zero_buffer);
     core::indirect_bgemm::PackWeights(
-        kernel.block_size_output_channels, conv_params, bitpacked_input_shape,
-        output_shape, GetTensorData<TBitpacked>(filter),
+        kernel.block_size_output_channels, kernel.block_size_depth, conv_params,
+        bitpacked_input_shape, output_shape, GetTensorData<TBitpacked>(filter),
         conv_params->packed_weights);
   }
 

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -688,9 +688,12 @@ using ::testing::ValuesIn;
 INSTANTIATE_TEST_SUITE_P(
     SmallTest, BConv2DOpTest,
     ::testing::Combine(
-        Values(std::array<int, 4>{1, 4, 4, 1},
-               std::array<int, 4>{1, 4, 4, 64}),  // input shape [BHWI]
-        Values(std::array<int, 3>{1, 1, 1}, std::array<int, 3>{3, 3, 1},
+        Values(std::array<int, 4>{1, 4, 4, 4}, std::array<int, 4>{1, 4, 4, 64},
+               std::array<int, 4>{1, 4, 4, 96},
+               std::array<int, 4>{1, 4, 4, 128},
+               std::array<int, 4>{1, 4, 4, 192},
+               std::array<int, 4>{1, 4, 4, 256}),  // input shape [BHWI]
+        Values(std::array<int, 3>{1, 1, 1}, std::array<int, 3>{3, 3, 4},
                std::array<int, 3>{3, 3, 64}),  // filter shape [HWO]
         Values(std::array<int, 2>{1, 1}),      // strides height/width
         Values(std::array<int, 2>{1, 1}),      // dilation height/width
@@ -700,8 +703,8 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(BConv2DOpTest::GetKernelsTuples(*kKernelMap))),
     TestParam::TestNameSuffix);
 
-// Separately, for optimised kernels only, test a very large input channel and
-// filter size combination that would overflow 16-bit accumulators (to check
+// Separately, for optimised BGEMM kernels only, test a very large input channel
+// and filter size combination that would overflow 16-bit accumulators (to check
 // that we successfully fall back to the 32-bit accumulator kernels if
 // necessary).
 INSTANTIATE_TEST_SUITE_P(
@@ -720,20 +723,21 @@ INSTANTIATE_TEST_SUITE_P(
             compute_engine::tflite::Register_BCONV_2D_OPT_BGEMM})),
     TestParam::TestNameSuffix);
 
-// The BigTest suite will be skipped in the qemu CI runs as they take more than
-// an hour.
+// The BigTest suite will be skipped in the qemu CI runs as they take a long
+// time to run.
 INSTANTIATE_TEST_SUITE_P(
     BigTest, BConv2DOpTest,
     ::testing::Combine(
-        Values(std::array<int, 4>{1, 7, 7, 1}, std::array<int, 4>{1, 8, 5, 1},
-               std::array<int, 4>{1, 7, 7, 64}, std::array<int, 4>{1, 8, 5, 64},
-               std::array<int, 4>{1, 7, 7, 130},
-               std::array<int, 4>{1, 8, 5, 130}),  // input shape [BHWI]
+        Values(std::array<int, 4>{1, 7, 7, 4}, std::array<int, 4>{1, 8, 5, 64},
+               std::array<int, 4>{1, 7, 7, 96},
+               std::array<int, 4>{1, 8, 5, 128},
+               std::array<int, 4>{1, 7, 7, 192},
+               std::array<int, 4>{1, 8, 5, 256}),  // input shape [BHWI]
         Values(std::array<int, 3>{1, 1, 1}, std::array<int, 3>{3, 3, 1},
-               std::array<int, 3>{2, 3, 1}, std::array<int, 3>{1, 1, 4},
-               std::array<int, 3>{3, 3, 4}, std::array<int, 3>{2, 3, 4},
-               std::array<int, 3>{1, 1, 64}, std::array<int, 3>{3, 3, 64},
-               std::array<int, 3>{2, 3, 64}),  // filter shape [HWO]
+               std::array<int, 3>{2, 3, 2}, std::array<int, 3>{1, 1, 3},
+               std::array<int, 3>{3, 3, 4}, std::array<int, 3>{2, 3, 5},
+               std::array<int, 3>{1, 1, 6}, std::array<int, 3>{3, 3, 7},
+               std::array<int, 3>{2, 3, 32}),  // filter shape [HWO]
         Values(std::array<int, 2>{1, 1},
                std::array<int, 2>{2, 3}),  // strides height/width
         Values(std::array<int, 2>{1, 1},


### PR DESCRIPTION
## What do these changes do?

This PR adds optimised Indirect BGEMM kernels for Aarch64, which support float or int8 output. The kernels are written in a combination of Arm NEON intrinsics and inline assembly.

Concretely, three new kernels are added (ordered least to most efficient):
* `8x4x1_aarch64` - an 8x4 kernel that operates on depths in blocks of 1 (multiples of 32 input channels).
* `8x4x2_aarch64` - an 8x4 kernel that operates on depths in blocks of 2 (multiples of 64 input channels).
* `8x4x4_aarch64` - an 8x4 kernel that operates on depths in blocks of 4 (multiples of 128 input channels).

Additionally, each kernel has two variants: one for where the depth is exactly 1/2/4 (exactly 32/64/128 input channels), and one for any depth. The former case allows a slight optimisation as there is no need to loop over the depth dimension.

The kernel that's used is selected at runtime.

## How Has This Been Tested?

The existing kernel tests have been extended to cover more combinations of input/output channels. The 'big' kernel tests that don't run on CI pass locally for Aarch64 and Arm32.

## Benchmark Results

These benchmarks were taken with the LCE benchmarking tool on a Raspberry Pi 4B (running 64-bit Ubuntu) and on my Android phone (a OnePlus 6). To benchmark float outputs, I used the QuickNet models. To benchmark int8 outputs, I used the same QuickNet models but modified them to use Int8 tensors throughout.

All inference was run single-threaded as the Indirect BGEMM doesn't support multithreading yet. I used `num_runs=250` and report the average latency in ms and the standard deviation, for the im2col + BGEMM baseline and the kernels in this PR.

### Raspberry Pi 4B

| Model              | Baseline (im2col + BGEMM) | PR (indirect BGEMM) | % change |
|--------------------|:-------------------------:|:-------------------:|:--------:|
| QuickNet           | 30.04 +- 0.07             | 28.85 +- 0.06       | -4.0%    |
| QuickNetLarge      | 46.09 +- 0.08             | 43.74 +- 0.05       | -5.1%    |
| QuickNetXL         | 78.96 +- 0.09             | 75.22 +- 0.09       | -4.7%    |
| QuickNet Int8      | 33.96 +- 0.05             | 33.60 +- 0.05       | -1.1%    |
| QuickNetLarge Int8 | 48.75 +- 0.06             | 47.68 +- 0.04       | -2.2%    |
| QuickNetXL Int8    | 83.75 +- 0.06             | 82.07 +- 0.06       | -2.0%    |

### OnePlus 6

| Model              | Baseline (im2col + BGEMM) | PR (indirect BGEMM) | % change |
|--------------------|:-------------------------:|:-------------------:|:--------:|
| QuickNet           | 14.63 +- 0.06             | 14.31 +- 0.06       | -2.2%    |
| QuickNetLarge      | 22.07 +- 0.07             | 21.29 +- 0.06       | -3.5%    |
| QuickNetXL         | 38.14 +- 0.08             | 36.95 +- 0.08       | -3.1%    |
| QuickNet Int8      | 16.11 +- 0.07             | 15.89 +- 0.05       | -1.4%    |
| QuickNetLarge Int8 | 23.04 +- 0.06             | 22.47 +- 0.06       | -2.5%    |
| QuickNetXL Int8    | 40.05 +- 0.05             | 39.29 +- 0.06       | -1.9%    |

These results show a small but consistent improvement in latency, that's slightly more pronounced on the Raspberry Pi than the OnePlus 6, and is stronger for float output than int8 output.

## Related issue number

N/A.
