### PR TITLE
Add support for batched inputs in the indirect BGEMM kernels

### DIFF
--- a/larq_compute_engine/core/bconv2d/optimized_indirect_bgemm.h
+++ b/larq_compute_engine/core/bconv2d/optimized_indirect_bgemm.h
@@ -26,7 +26,8 @@ inline void BConv2DOptimizedIndirectBGEMM(
   const std::int32_t conv_kernel_size =
       conv_params->filter_height * conv_params->filter_width;
   const std::int32_t bitpacked_input_channels = bitpacked_input_shape.Dims(3);
-  const std::int32_t output_size = output_shape.Dims(1) * output_shape.Dims(2);
+  const std::int32_t output_size =
+      output_shape.Dims(0) * output_shape.Dims(1) * output_shape.Dims(2);
   const std::int32_t output_channels = conv_params->channels_out;
 
   indirect_bgemm::RunKernel(kernel, conv_kernel_size, bitpacked_input_channels,

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -728,8 +728,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     BigTest, BConv2DOpTest,
     ::testing::Combine(
-        Values(std::array<int, 4>{1, 7, 7, 4}, std::array<int, 4>{1, 8, 5, 64},
-               std::array<int, 4>{1, 7, 7, 96},
+        Values(std::array<int, 4>{1, 7, 7, 4}, std::array<int, 4>{3, 8, 5, 64},
+               std::array<int, 4>{10, 7, 7, 96},
                std::array<int, 4>{1, 8, 5, 128},
                std::array<int, 4>{1, 7, 7, 192},
                std::array<int, 4>{1, 8, 5, 256}),  // input shape [BHWI]


### PR DESCRIPTION
## What do these changes do?

This PR adds support for batched inputs to the indirect BGEMM kernels and adds test cases in `bconv2d_test.cc` to test for batched input shapes.

## How Has This Been Tested?

New test cases. The 'big' kernel tests pass locally (AArch64).

## Benchmark Results

N/A.

## Related issue number

~~This builds on top of #518 and so will remain a draft until that PR is merged.~~
