### PR TITLE
Initialise batch norm stats for e2e models

### DIFF
--- a/larq_compute_engine/tests/end2end_test.py
+++ b/larq_compute_engine/tests/end2end_test.py
@@ -27,17 +27,16 @@ def toy_model(**kwargs):
                 use_bias=False,
                 activation=activation,
             )(x)
-            x = tf.keras.layers.BatchNormalization(
-                gamma_initializer=tf.keras.initializers.RandomNormal(1.0),
-                beta_initializer="uniform",
-            )(x)
+            x = tf.keras.layers.BatchNormalization(momentum=0.7)(x)
             return tf.keras.layers.add([x, shortcut])
 
         return dummy
 
     img_input = tf.keras.layers.Input(shape=(224, 224, 3))
     out = img_input
-    out = tf.keras.layers.Conv2D(filters=32, kernel_size=3, padding="same")(out)
+    out = tf.keras.layers.Conv2D(filters=32, kernel_size=3, strides=2, padding="same")(
+        out
+    )
 
     # Test zero-padding
     out = block("same", 0.0, "relu")(out)
@@ -55,10 +54,7 @@ def toy_model_sequential(**kwargs):
         [
             tf.keras.layers.Input((224, 224, 3)),
             tf.keras.layers.Conv2D(16, (3, 3), strides=(2, 2), padding="same"),
-            tf.keras.layers.BatchNormalization(
-                gamma_initializer=tf.keras.initializers.RandomNormal(1.0),
-                beta_initializer="uniform",
-            ),
+            tf.keras.layers.BatchNormalization(momentum=0.7),
             # This will be converted to a float->bitpacked binary max pool.
             tf.keras.layers.MaxPooling2D((2, 2)),
             lq.layers.QuantConv2D(
@@ -71,10 +67,10 @@ def toy_model_sequential(**kwargs):
                 use_bias=False,
             ),
             tf.keras.layers.BatchNormalization(
-                # Use an initialiser with mean 0 to test the negative
+                momentum=0.7,
+                # Use a Gamma initialiser with mean -0.1 to test the negative
                 # multipliers corner-case.
-                gamma_initializer=tf.keras.initializers.RandomNormal(mean=0.0),
-                beta_initializer="uniform",
+                gamma_initializer=tf.keras.initializers.RandomNormal(mean=-0.1),
             ),
             lq.layers.QuantConv2D(
                 32,
@@ -87,10 +83,10 @@ def toy_model_sequential(**kwargs):
                 use_bias=False,
             ),
             tf.keras.layers.BatchNormalization(
-                # Use an initialiser with mean 0 to test the negative
+                momentum=0.7,
+                # Use a Gamma initialiser with mean -0.1 to test the negative
                 # multipliers corner-case.
-                gamma_initializer=tf.keras.initializers.RandomNormal(0.0),
-                beta_initializer="uniform",
+                gamma_initializer=tf.keras.initializers.RandomNormal(mean=-0.1),
             ),
             # This will be converted to a bitpacked->bitpacked binary max pool.
             # Test some funky filter/stride combination.
@@ -104,10 +100,7 @@ def toy_model_sequential(**kwargs):
                 pad_values=1.0,
                 use_bias=False,
             ),
-            tf.keras.layers.BatchNormalization(
-                gamma_initializer=tf.keras.initializers.RandomNormal(1.0),
-                beta_initializer="uniform",
-            ),
+            tf.keras.layers.BatchNormalization(momentum=0.7),
             tf.keras.layers.GlobalAvgPool2D(),
         ]
     )
@@ -121,7 +114,7 @@ def toy_model_int8(**kwargs):
     img = tf.keras.layers.Input(shape=(224, 224, 3))
     x = quant(img)
     x = lq.layers.QuantConv2D(
-        12, 3, input_quantizer="ste_sign", kernel_quantizer="ste_sign"
+        12, 3, strides=2, input_quantizer="ste_sign", kernel_quantizer="ste_sign"
     )(x)
     # Make sure the typical output is in the (-3, 3) range
     # by dividing by sqrt(filter_height * filter_width * input_channels)
@@ -133,7 +126,7 @@ def toy_model_int8(**kwargs):
     )(x)
     x = quant(x)
     x = lq.layers.QuantConv2D(
-        12, 3, input_quantizer="ste_sign", kernel_quantizer="ste_sign"
+        12, 3, strides=2, input_quantizer="ste_sign", kernel_quantizer="ste_sign"
     )(x)
     # Make sure the typical output is in the (-3, 3) range
     # by dividing by sqrt(filter_height * filter_width * input_channels)
@@ -152,13 +145,13 @@ def toy_model_int8(**kwargs):
 
 
 def preprocess(data):
-    return lqz.preprocess_input(data["image"])
+    return lqz.preprocess_input(data["image"]), data["label"]
 
 
 def assert_model_output(model_lce, inputs, outputs):
     interpreter = Interpreter(model_lce, num_threads=min(os.cpu_count(), 4))
     actual_outputs = interpreter.predict(inputs)
-    np.testing.assert_allclose(actual_outputs, outputs, rtol=0.001, atol=0.25)
+    np.testing.assert_allclose(actual_outputs, outputs, rtol=0.05, atol=0.125)
 
 
 @pytest.mark.parametrize(
@@ -166,21 +159,32 @@ def assert_model_output(model_lce, inputs, outputs):
     [toy_model, toy_model_sequential, toy_model_int8, lqz.sota.QuickNet],
 )
 def test_simple_model(model_cls):
-    model = model_cls(weights="imagenet")
-    model_lce = convert_keras_model(
-        model, experimental_enable_bitpacked_activations=True
-    )
-
-    # Test on the flowers dataset
+    # Test on the Oxford flowers dataset
     dataset = (
         tfds.load("tf_flowers", split="train", try_gcs=True)
         .map(preprocess)
         .shuffle(100)
         .batch(10)
-        .take(1)
     )
-    inputs = next(tfds.as_numpy(dataset))
 
+    model = model_cls(weights="imagenet")
+
+    # For the untrained models, do a very small amount of training so that the
+    # batch norm stats (and, less importantly, the weights) have sensible
+    # values.
+    if model_cls != lqz.sota.QuickNet:
+        model.compile(
+            optimizer=tf.keras.optimizers.Adam(1e-4),
+            loss="sparse_categorical_crossentropy",
+        )
+        model.fit(dataset, epochs=1, steps_per_epoch=10)
+
+    model_lce = convert_keras_model(
+        model, experimental_enable_bitpacked_activations=True
+    )
+
+    # Test on a single batch of images
+    inputs = next(tfds.as_numpy(dataset.map(lambda *data: data[0]).take(1)))
     outputs = model(inputs).numpy()
     assert_model_output(model_lce, inputs, outputs)
 

--- a/larq_compute_engine/tests/end2end_test.py
+++ b/larq_compute_engine/tests/end2end_test.py
@@ -1,4 +1,3 @@
-import math
 import os
 import sys
 

--- a/larq_compute_engine/tests/end2end_test.py
+++ b/larq_compute_engine/tests/end2end_test.py
@@ -144,7 +144,7 @@ def assert_model_output(model_lce, inputs, outputs, rtol, atol):
     [toy_model, toy_model_sequential, toy_model_int8, lqz.sota.QuickNet],
 )
 def test_simple_model(model_cls):
-    # Test on the OxfordFlowers dataset
+    # Test on the TF flowers dataset
     dataset = (
         tfds.load("tf_flowers", split="train", try_gcs=True)
         .map(preprocess)


### PR DESCRIPTION
## What do these changes do?

The default BatchNormalization moving-variance initialisation is `"ones"`, which makes sense for a full-precision convolution (because the weights are usually initialised with very small absolute value) but doesn't make sense for a binary convolution (where the absolute value of the weights is always 1). This causes instability in the end2end tests because it means that the magnitude of the convolution outputs is unrealistic. In places, we've attempted to correct for this by fiddling with the gamma/beta initialisation, but the real problem is the moving-variance statistics.

This PR adds ten steps of training with a low learning rate for each model in the e2e test (excluding QuickNet, which we load with trained weights). These few steps should result in more sensible values for the batch norm statistics, and regardless I think this makes the tests more relevent that using models with entirely random weights.

A nice benefit is that it appears that this allows us to reduce the absolute tolerance in the `np.allclose` comparison.

## How Has This Been Tested?

CI.

## Benchmark Results

N/A.

## Related issue number

N/A.