### PR TITLE
Run LCE optimize pass before and after TFLite optimize pass

### DIFF
--- a/larq_compute_engine/mlir/tf_tfl_passes.cc
+++ b/larq_compute_engine/mlir/tf_tfl_passes.cc
@@ -119,6 +119,7 @@ void AddTFToLCETFLConversionPasses(
   // Add a shape inference pass to optimize away the unnecessary casts.
   pass_manager->addPass(mlir::TF::CreateTFShapeInferencePass());
   pass_manager->addPass(mlir::TFL::CreateLegalizeTFPass(true));
+  pass_manager->addPass(mlir::TFL::CreateOptimizeLCEPass(false));
   pass_manager->addPass(mlir::TFL::CreateOptimizePass());
   pass_manager->addPass(mlir::TFL::CreateOptimizeLCEPass(
       experimental_enable_bitpacked_activations));


### PR DESCRIPTION
## What do these changes do?
This PR changes the converter to also run the LCE optimize pass before the TFLite optimiyations happen. This allows for transforming `bconv -> mul/add -> relu` to `bconv + mul/add -> relu` which would've been prevented by TFLite optimizations that already fuse `mul/add -> relu`.

master | PR 
--- | ---
![Screenshot 2020-10-07 at 15 46 26](https://user-images.githubusercontent.com/13285808/95347093-6ebdcc80-08b4-11eb-915f-17b1ca73a10a.png) | ![Screenshot 2020-10-07 at 15 46 10](https://user-images.githubusercontent.com/13285808/95347091-6e253600-08b4-11eb-8306-f880dc680572.png)

To make sure that all possible optimizations are applied, I kept the LCE optimize pass after all TFLite optimizations have been applied since they might enable further optimizations from our side (e.g. clipping might be converted to a relu op which could be fused by our transformations.

## How Has This Been Tested?
Manually verified that fusion is correctly handled for quicknet and some literature models