### PR TITLE
Add support for unipolar bconv2d inputs.

### DIFF
--- a/larq_compute_engine/mlir/transforms/optimize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns.td
@@ -172,3 +172,15 @@ def : Pat<(LQ_QuantizeOp (TFL_MaxPool2DOp: $pool_output $input,
                            $filter_width,
                            $filter_height),
           [(HasOneUse $pool_output)]>;
+
+// This transformation is sometimes useful when there is a bconv2d that takes
+// unipolar inputs, because the unipolar-bconv2d pattern (see
+// `prepare_patterns.td`) pushes a multiply-by-negative-1 op before the
+// LceQuantize, and the LceQuantize op is frequently preceeded by a subtraction
+// (e.g. to threshold the binary quantization at a given value).
+def : Pat<(TFL_MulOp
+              (TFL_SubOp: $sub_output $a, $b, TFL_AF_None),
+              (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "-1.0f">),
+              $act_fn),
+          (TFL_SubOp $b, $a, $act_fn),
+          [(HasOneUse $sub_output)], (addBenefit 10)>;

--- a/larq_compute_engine/mlir/transforms/prepare_patterns.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns.td
@@ -40,6 +40,8 @@ def GetNumChannels : NativeCodeCall<"GetNumChannels($_builder, $0)">;
 def IsDataFormatNHWC : ConstantAttr<TF_ConvnetDataFormatAttr, "NHWC">;
 def CreateNoneAttrValue : NativeCodeCall<"$_builder.getUnitAttr()">;
 
+// Match a binary convolution with bipolar (+1/-1) inputs, padded (if
+// applicable) with zeroes.
 def : Pat<(TF_Conv2DOp
               (LQ_DequantizeOp: $dequantized_input $input),
               (ConstantOp $filter),
@@ -77,6 +79,7 @@ def ConstFloatValueIsOne : Constraint<
 
 def SamePadding : Constraint<CPred<"IsSamePadding($0, $1, $2, $3)">>;
 
+// Match a binary convolution with bipolar (+1/-1) inputs, padded with ones.
 def : Pat<(TF_Conv2DOp:$output
               (TF_PadV2Op
                   (LQ_DequantizeOp: $dequantized_input $input),
@@ -109,4 +112,71 @@ def : Pat<(TF_Conv2DOp:$output
           [(BinaryFilter $filter),
            (ConstFloatValueIsOne $pad_values),
            (SamePadding $paddings, $input, $output, $strides)],
+          (addBenefit 90)>;
+
+// Match a binary convolution with unipolar (+1/0) inputs, padded (if
+// applicable) with zeroes. The weights are bipolar (+1/-1). We use the
+// following trick to perform this computation using the bconv2d op (which only
+// supports bipolar inputs).
+//     Suppose `a` is a unipolar (+1/0) activation and `w` is a bipolar (+1/-1)
+// weight. If we define `b` to be 1 if `a` is 1 and `-1` if `a` is 0, then
+// `a = 0.5 * b + 0.5`. This means that `a * w` can be computed with bipolar
+// multiplication followed by a non-binary multiplication and bias:
+//            `a * w = (0.5 * b + 0.5) * w = 0.5 * b * w + 0.5 * w`
+// Note that the bias `0.5 * w` is a constant at conversion-time. The
+// generalisation to more than a single activation/weight element is then:
+//         `dotprod(a, w) = 0.5 * dotprod(b, w) + 0.5 * reduce_sum(w)`
+// which is the form we use below.
+//     There is one final thing to note here. Because the unipolar input 1 is
+// represented by bipolar input 1 and unipolar input 0 by bipolar input -1, TF
+// zero-padding is equivalent to padding with -1 in LCE; however, the bconv2d op
+// only supports padding with 1. The solution is to multiply the (bipolar) input
+// by -1 and the weights by -1 -- this means that TF zero-padding is equivalent
+// to LCE bconv2d one-padding.
+def : Pat<(TF_Conv2DOp
+              (TF_AddV2Op
+                  (TF_MulOp
+                      (LQ_DequantizeOp (LQ_QuantizeOp $unquantized_input)),
+                      (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "0.5f">)),
+                  (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "0.5f">)),
+              (ConstantOp $filter),
+              IsIntList1XY1:$strides,
+              $use_cudnn,
+              $padding,
+              $explicit_padding,
+              IsDataFormatNHWC: $data_format,
+              IsIntList1XY1:$dilations),
+          (LQ_Bconv2dOp
+              (LQ_QuantizeOp
+                  (TF_MulOp
+                      $unquantized_input,
+                      (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "-1.0f">))),
+              (TF_TransposeOp
+                  (TF_MulOp
+                      (TF_DivOp
+                          (ConstantOp $filter),
+                          (ConstantOp (GetScaleVector $filter))),
+                      (ConstantOp (GetConstantVector<"-1.0f"> $filter))),
+                  (ConstantOp ConstantAttr<I32VectorElementsAttr<4>, "{3, 0, 1, 2}">)),
+              (TF_MulOp
+                  (ConstantOp (GetScaleVector $filter)),
+                  (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "0.5f">)),
+              (TF_MulOp
+                  (TF_SumOp
+                      (TF_DivOp
+                          (ConstantOp $filter),
+                          (ConstantOp (GetScaleVector $filter))),
+                      (ConstantOp ConstantAttr<I32VectorElementsAttr<3>, "{0, 1, 2}">),
+                      ConstBoolAttrFalse),
+                  (ConstantOp ConstantAttr<RankedF32ElementsAttr<[]>, "0.5f">)),
+              (ConstantOp (CreateNoneAttrValue)),
+              (GetNumChannels $unquantized_input),
+              ExtractI32At<1>:$dilations,
+              ExtractI32At<2>:$dilations,
+              TFL_AF_None,
+              ConstantAttr<I32Attr, "1">,
+              $padding,
+              ExtractI32At<1>:$strides,
+              ExtractI32At<2>:$strides),
+          [(BinaryFilter $filter)],
           (addBenefit 90)>;


### PR DESCRIPTION
*This is very much a draft PR.*

## What do these changes do?

This is a converter-only change that adds support for binary convolutions with unipolar inputs -- all credit is given to @jneeven who had the original idea for the trick that this PR takes advantage of and that allows this to be a converter-only change, i.e. that avoids the need to modify the kernels. I've tried to explain the method in the code comment above the pattern I've added in `prepare_patterns.td`.

Specifically, it adds support for models with the following input quantiser:

```python
class UnipolarSteSign(lq.quantizers.SteSign):
    def __init__(self, clip_value: float = 0.5, **kwargs):
        super().__init__(clip_value=clip_value, **kwargs)

    def call(self, inputs):
        return 0.5 * super().call(inputs - 0.5) + 0.5
```

The end2end test results seem to indicate that the method works.

I'm publishing this as an early draft because I am keen to solicit feedback on whether this is a sensible approach; if we want to progress further we will need to add the quantiser to Larq.

Still to do:

- [ ] Add file-check tests.
- [ ] Add a `UnipolarSteSign` quantiser to Larq.
- [ ] Do a validation run with a unipolar model and check that we get the expected accuracy.

## How Has This Been Tested?

The end2end tests have been modified to test unipolar inputs. These pass locally, and hopefully on CI too, with the much tighter ouput bounds introduced by #524.

## Benchmark Results

N/A.

## Related issue number

N/A.