### PR TITLE
Add macros to help GCC with branch prediction

### DIFF
--- a/larq_compute_engine/core/indirect_bgemm/kernel_4x2_portable.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_4x2_portable.h
@@ -87,7 +87,7 @@ void RunKernel(const std::int32_t block_num_pixels,
       } while (--c_in_index > 0);
     } while (--k_size_index > 0);
 
-    if (channels_out - c_out_index >= 4) {
+    if LCE_LIKELY (channels_out - c_out_index >= 4) {
       output_ptr_1[0] = output_transform.Run(acc_01, c_out_index);
       output_ptr_1[1] = output_transform.Run(acc_11, c_out_index + 1);
       output_ptr_1[2] = output_transform.Run(acc_21, c_out_index + 2);

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
@@ -327,7 +327,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1q_f32(output_ptr_3, results[3].val[0]);
     vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
     output_ptr_3 += 8;
@@ -505,7 +505,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
     output_ptr_3 += 8;
     vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
@@ -372,7 +372,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1q_f32(output_ptr_3, results[3].val[0]);
     vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
     output_ptr_3 += 8;
@@ -557,7 +557,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
     output_ptr_3 += 8;
     vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
@@ -425,7 +425,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1q_f32(output_ptr_3, results[3].val[0]);
     vst1q_f32(output_ptr_3 + 4, results[3].val[1]);
     output_ptr_3 += 8;
@@ -611,7 +611,7 @@ inline void OutputTransformAndLoadNextAndStore(
         [ indirection_buffer ] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
-  if (channels_out - c_out_index >= 8) {
+  if LCE_LIKELY (channels_out - c_out_index >= 8) {
     vst1_s8(output_ptr_3, vget_low_s8(results[3].val[0]));
     output_ptr_3 += 8;
     vst1_s8(output_ptr_2, vget_low_s8(results[2].val[0]));

--- a/larq_compute_engine/core/types.h
+++ b/larq_compute_engine/core/types.h
@@ -9,6 +9,14 @@
 namespace compute_engine {
 namespace core {
 
+#if defined(__GNUC__)
+#define LCE_LIKELY(condition) (__builtin_expect(!!(condition), 1))
+#define LCE_UNLIKELY(condition) (__builtin_expect(condition, 0))
+#else
+#define LCE_LIKELY(condition) (condition)
+#define LCE_UNLIKELY(condition) (condition)
+#endif
+
 // In our kernels we may occasionally read (but never write) beyond the end of
 // an array. This is the maximum number of extra bytes that will be read, and
 // should be added as padding to the end of tensor allocations.


### PR DESCRIPTION
## What do these changes do?
This PR adds macros to help GCC with branch prediction in cases where we know which branch is more likely to be taken. Both [TensorFlow](https://github.com/tensorflow/tensorflow/blob/fccc8b6179a24daf3d9779d236a4143b618a0a38/tensorflow/core/platform/macros.h#L105-L116) and [XNNPack](https://github.com/google/XNNPACK/blob/31677ad790d003ecfd94bbaf8ce88a2bc6847896/src/xnnpack/common.h#L171-L177) use similar macros which rely on [`__builtin_expect`](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html).

This also adds a [`FastBoundsCheck`](https://github.com/tensorflow/tensorflow/blob/fccc8b6179a24daf3d9779d236a4143b618a0a38/tensorflow/core/framework/bounds_check.h#L26-L37) check function to do comparisons like `0 <= x && x < bound` in a single instruction.

The actual impact of these helpers here is a bit questionable, but I would like to try them for some of our internal kernels and adding them here seems like the logical place.

## How Has This Been Tested?
CI

## Benchmark Results
I ran a quick benchmark with the indirect bgemm and didn't se any measurable impact