### PR TITLE
Prebuild the benchmark binary with -O3 on Android

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,11 +23,11 @@ build:windows --host_cxxopt=/std:c++14
 # These can be activated using --config=rpi3 and --config=aarch64
 build:rpi3 --crosstool_top=@local_config_arm_compiler//:toolchain
 build:rpi3 --cpu=armeabi
-build:rpi3 -c opt    --copt=-march=armv7-a --copt=-mfpu=neon-vfpv4   --copt=-std=gnu++11 --copt=-DS_IREAD=S_IRUSR --copt=-DS_IWRITE=S_IWUSR   --copt=-O3 --copt=-fno-tree-pre   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8   --define=raspberry_pi_with_neon=true   --define=framework_shared_object=false   --copt=-funsafe-math-optimizations --copt=-ftree-vectorize   --copt=-fomit-frame-pointer   --verbose_failures
+build:rpi3 --copt=-march=armv7-a --copt=-mfpu=neon-vfpv4 --copt=-std=gnu++11 --copt=-DS_IREAD=S_IRUSR --copt=-DS_IWRITE=S_IWUSR --copt=-fno-tree-pre --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 --define=raspberry_pi_with_neon=true --define=framework_shared_object=false --copt=-funsafe-math-optimizations --copt=-ftree-vectorize --copt=-fomit-frame-pointer --verbose_failures
 
 build:aarch64 --crosstool_top=@local_config_arm_compiler//:toolchain
 build:aarch64 --cpu=aarch64
-build:aarch64 -c opt    --copt=-march=armv8-a   --copt=-std=gnu++11 --copt=-DS_IREAD=S_IRUSR --copt=-DS_IWRITE=S_IWUSR   --copt=-O3 --copt=-fno-tree-pre   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8   --define=framework_shared_object=false   --copt=-funsafe-math-optimizations --copt=-ftree-vectorize   --copt=-fomit-frame-pointer   --verbose_failures
+build:aarch64 --copt=-march=armv8-a --copt=-std=gnu++11 --copt=-DS_IREAD=S_IRUSR --copt=-DS_IWRITE=S_IWUSR --copt=-fno-tree-pre --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 --define=framework_shared_object=false --copt=-funsafe-math-optimizations --copt=-ftree-vectorize --copt=-fomit-frame-pointer --verbose_failures
 
 # Options to build TensorFlow 1.x or 2.x.
 build:v1 --define=tf_api_version=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,15 @@ jobs:
       - run: mkdir benchmark-binaries
       - name: Build Benchmark utility for AArch64
         run: |
-          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=aarch64
+          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=aarch64 -c opt --copt=-O3
           cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_aarch64
       - name: Build Benchmark utility for AArch32
         run: |
-          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=rpi3
+          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=rpi3 -c opt --copt=-O3
           cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_aarch32
       - name: Build Benchmark utility for Android
         run: |
-          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model -c opt --config=android_arm64
+          bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=android_arm64 -c opt --copt=-O3
           cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_android_arm64
       - uses: actions/upload-artifact@v2.2.0
         with:

--- a/larq_compute_engine/core/bgemm/ruy_pack.h
+++ b/larq_compute_engine/core/bgemm/ruy_pack.h
@@ -45,10 +45,6 @@ struct LceRuyPackImpl<ThePath, FixedKernelLayout<Order::kColMajor, 4, 4>,
                   PMat<TBitpacked>* packed_matrix, int start_col, int end_col) {
     profiler::ScopeLabel label("Pack (ColMajor, 4x4)");
 
-    // Ruy supports collecting column sums during the packing process, which we
-    // have no need for.
-    RUY_DCHECK_EQ(packed_matrix->sums, nullptr);
-
     // Likewise, Ruy supports arbitrary zero points, but we only use true-zero.
     RUY_DCHECK_EQ(src_matrix.zero_point, 0);
 


### PR DESCRIPTION
## What do these changes do?
This PR makes sure that the Android benchmarking binary get's built with all optimizations enabled. Previously we also set `-O3` in the Raspberry PI configs, I moved this now the the release built in the hope to slightly speedup ARM CI.

## Benchmark Results
I didn't see any measurable difference on my system, but the generated binary has a slightly different size, so it is definitely doing something.
