### PR TITLE
Use test sharding to parallelise the tests.

### DIFF
--- a/larq_compute_engine/mlir/tests/lit_test.bzl
+++ b/larq_compute_engine/mlir/tests/lit_test.bzl
@@ -39,6 +39,7 @@ def lce_lit_test(
         srcs = [driver],
         size = size,
         data = data + [test_file],
+        shard_count = 2,
         args = ["$(location %s)" % (test_file,)],
         **kwargs
     )

--- a/larq_compute_engine/tests/qemu_test.bzl
+++ b/larq_compute_engine/tests/qemu_test.bzl
@@ -35,10 +35,11 @@ def lce_qemu_test_suite(
         # Finally create a new sh_test target
         native.sh_test(
             name = sh_name,
-            size = "medium",
+            size = "large",
             srcs = [src],
             args = [test_path],
             data = [test, qemu_data],
+            shard_count = 2,
         )
 
         # And add that sh_test target to the list


### PR DESCRIPTION
## What do these changes do?

Our CI runs on machines with two cores. Bazel supports [test sharding](larq_compute_engine/mlir/python/converter_test.py) which when enabled parallelises the tests over multiple processes. All we need to do is add a `shard_count` attribute to the test definition.

Note that the 'small' kernel tests which run on CI don't test multithreaded convolutions, so there's no problem testing two in parallel.