### PR TITLE
Add grouped binary convolution support (2/3): reference kernel.

### DIFF
--- a/larq_compute_engine/core/bconv2d/optimized_bgemm.h
+++ b/larq_compute_engine/core/bconv2d/optimized_bgemm.h
@@ -112,7 +112,7 @@ inline void BConv2DOptimizedBGEMM(
   // output tensor with zeroes in advance so that the BGEMM doesn't have to
   // worry about doing the padding.
   if (std::is_same<DstScalar, TBitpacked>::value &&
-      output_shape.Dims(3) % 32 != 0) {
+      output_shape.Dims(3) % bitpacking_bitwidth != 0) {
     std::fill(
         output_data,
         output_data + FlatSizeSkipDim(output_shape, 3) *

--- a/larq_compute_engine/core/bconv2d/params.h
+++ b/larq_compute_engine/core/bconv2d/params.h
@@ -15,6 +15,7 @@ struct BConv2DParams {
   std::int32_t filter_height;
   std::int32_t channels_in;
   std::int32_t channels_out;
+  std::int32_t groups;
 
   // Strides
   std::int32_t stride_height;

--- a/larq_compute_engine/tflite/tests/bconv2d_op_model.h
+++ b/larq_compute_engine/tflite/tests/bconv2d_op_model.h
@@ -42,9 +42,6 @@ class BaseBConv2DOpModel : public SingleOpModel {
 
     flexbuffers::Builder fbb;
     fbb.Map([&]() {
-      // This attribute is necessary because if the filters are bitpacked and
-      // we're reading bitpacked input then we don't have access to the original
-      // 'true' number of input channels.
       fbb.Int("channels_in", channels_in);
       fbb.Int("stride_height", stride_height);
       fbb.Int("stride_width", stride_width);


### PR DESCRIPTION
## What do these changes do?

This is second of a group of PRs to add support for grouped binary convolutions. I've split the work into three PRs to make review easier.

This PR adds support for grouped convolutions to the reference kernel.

## How Has This Been Tested?

The kernel tests have been extended to include grouped convolution test cases. This was more complicated than it seems, because the built-in Conv2D op doesn't support groups. To calculate the expected output, I therefore emulate a grouped convolution with multiple Conv2D ops and manual concatenation at the end.

## Benchmark Results

N/A.

## Related issue number

#549, #551.