### PR TITLE
:arrow_up: lint dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
           python-version: 3.8
       - name: Install Lint Dependencies
         run: |
-          pip install pyflakes==2.2.0 black==20.8b1
-          sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/3.4.0/buildifier
+          pip install pyflakes==2.2.0 black==20.8b1 --no-cache-dir
+          sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier
           sudo chmod +x /usr/local/bin/buildifier
       - name: Run PyFlakes
         run: pyflakes larq_compute_engine
@@ -27,5 +27,7 @@ jobs:
         run: black larq_compute_engine --check --target-version py36 --exclude 'build/|buck-out/|dzzist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|larq/snapshots/'
       - name: clang-format lint
         uses: DoozyX/clang-format-lint-action@v0.11
+        with:
+          clangFormatVersion: 11
       - name: Lint bazel files
         run: buildifier -mode=check -r ./

--- a/larq_compute_engine/core/bconv2d/output_transform.h
+++ b/larq_compute_engine/core/bconv2d/output_transform.h
@@ -17,7 +17,7 @@ namespace bconv2d {
 inline std::int8_t saturate(std::int32_t x) {
 #ifdef __arm__
   std::int8_t y;
-  asm("ssat %[y], #8, %[x]\n" : [ y ] "=r"(y) : [ x ] "r"(x));
+  asm("ssat %[y], #8, %[x]\n" : [y] "=r"(y) : [x] "r"(x));
   return y;
 #else
   x = std::min<std::int32_t>(x, std::numeric_limits<std::int8_t>::max());
@@ -35,8 +35,8 @@ inline std::int32_t round(float x) {
   std::int32_t y;
   asm("vcvtr.s32.f32 %[x], %[x] \n"
       "vmov %[y], %[x] \n"
-      : [ y ] "=r"(y)
-      : [ x ] "t"(x));  // The "t" means `x` will be in an FPU register
+      : [y] "=r"(y)
+      : [x] "t"(x));  // The "t" means `x` will be in an FPU register
   return y;
 #else
   return tflite::TfLiteRound(x);

--- a/larq_compute_engine/core/bitpacking/bitpack_aarch64.h
+++ b/larq_compute_engine/core/bitpacking/bitpack_aarch64.h
@@ -218,7 +218,7 @@ inline void bitpack_aarch64_4x32(const float* input, std::size_t num_blocks,
 
       "st1 {v0.4s}, [%[out_ptr]], #16\n"
 
-      : [ in_ptr ] "+r"(input), [ n ] "+r"(num_blocks), [ out_ptr ] "+r"(output)
+      : [in_ptr] "+r"(input), [n] "+r"(num_blocks), [out_ptr] "+r"(output)
       :
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
         "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18",
@@ -369,8 +369,8 @@ inline void bitpack_aarch64_4x32(const std::int8_t* input,
 
       "st1 {v8.4s}, [%[out_ptr]], #16\n"
 
-      : [ in_ptr ] "+r"(input), [ n ] "+r"(num_blocks), [ out_ptr ] "+r"(output)
-      : [ zero_byte ] "r"(zero_byte)
+      : [in_ptr] "+r"(input), [n] "+r"(num_blocks), [out_ptr] "+r"(output)
+      : [zero_byte] "r"(zero_byte)
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
         "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18",
         "v19", "v31");

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x1_aarch64.h
@@ -149,16 +149,16 @@ inline void AccumulationLoop_Depth2OrMore(
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
 
       "bgt 0b\n\t"  // Outer loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
-        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
-        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_), [a_ptr_0] "+r"(a_ptr_0),
+        [a_ptr_1] "+r"(a_ptr_1), [a_ptr_2] "+r"(a_ptr_2),
+        [a_ptr_3] "+r"(a_ptr_3)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3]), [kernel_size] "r"(conv_kernel_size),
+        [depth] "r"(depth)
       : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
         "v7");
 }
@@ -195,16 +195,16 @@ inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_32
 
       "bgt 0b\n\t"  // Loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
-        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
-        [ ks_index ] "+r"(conv_kernel_size)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_),
+        [a_ptr_0] "=&r"(a_ptr_0), [a_ptr_1] "=&r"(a_ptr_1),
+        [a_ptr_2] "=&r"(a_ptr_2), [a_ptr_3] "=&r"(a_ptr_3),
+        [ks_index] "+r"(conv_kernel_size)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3])
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7");
 }
 
@@ -306,25 +306,24 @@ inline void OutputTransformAndLoadNextAndStore(
       "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
       "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
       "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      : [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]),
+        [a_0] "=&w"(activations[0]), [a_1] "=&w"(activations[1]),
+        [a_2] "=&w"(activations[2]), [a_3] "=&w"(activations[3]),
+        [result_00] "=&w"(results[0].val[0]),
+        [result_01] "=&w"(results[0].val[1]),
+        [result_10] "=&w"(results[1].val[0]),
+        [result_11] "=&w"(results[1].val[1]),
+        [result_20] "=&w"(results[2].val[0]),
+        [result_21] "=&w"(results[2].val[1]),
+        [result_30] "=&w"(results[3].val[0]),
+        [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {
@@ -484,25 +483,24 @@ inline void OutputTransformAndLoadNextAndStore(
       "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
       "sqxtn %[result_10].8b, %[result_10].8h\n\t"
       "sqxtn %[result_00].8b, %[result_00].8h\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      : [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]),
+        [a_0] "=&w"(activations[0]), [a_1] "=&w"(activations[1]),
+        [a_2] "=&w"(activations[2]), [a_3] "=&w"(activations[3]),
+        [result_00] "=&w"(results[0].val[0]),
+        [result_01] "=&w"(results[0].val[1]),
+        [result_10] "=&w"(results[1].val[0]),
+        [result_11] "=&w"(results[1].val[1]),
+        [result_20] "=&w"(results[2].val[0]),
+        [result_21] "=&w"(results[2].val[1]),
+        [result_30] "=&w"(results[3].val[0]),
+        [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x2_aarch64.h
@@ -184,17 +184,17 @@ inline void AccumulationLoop_Depth2OrMore(
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
 
       "bgt 0b\n\t"  // Outer loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
-        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
-        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_), [a_ptr_0] "+r"(a_ptr_0),
+        [a_ptr_1] "+r"(a_ptr_1), [a_ptr_2] "+r"(a_ptr_2),
+        [a_ptr_3] "+r"(a_ptr_3)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [w_2] "w"(weights[2]),
+        [w_3] "w"(weights[3]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3]), [kernel_size] "r"(conv_kernel_size),
+        [depth] "r"(depth)
       : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
         "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15");
 }
@@ -231,17 +231,17 @@ inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_64
 
       "bgt 0b\n\t"  // Loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
-        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
-        [ ks_index ] "+r"(conv_kernel_size)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_),
+        [a_ptr_0] "=&r"(a_ptr_0), [a_ptr_1] "=&r"(a_ptr_1),
+        [a_ptr_2] "=&r"(a_ptr_2), [a_ptr_3] "=&r"(a_ptr_3),
+        [ks_index] "+r"(conv_kernel_size)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [w_2] "w"(weights[2]),
+        [w_3] "w"(weights[3]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3])
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
         "v9", "v10", "v11", "v12", "v13", "v14", "v15");
 }
@@ -350,26 +350,24 @@ inline void OutputTransformAndLoadNextAndStore(
       "fadd %[result_11].4s, %[result_11].4s, v5.4s\n\t"
       "fadd %[result_00].4s, %[result_00].4s, v4.4s\n\t"
       "fadd %[result_01].4s, %[result_01].4s, v5.4s\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      :
+      [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]), [w_2] "=&w"(weights[2]),
+      [w_3] "=&w"(weights[3]), [a_0] "=&w"(activations[0]),
+      [a_1] "=&w"(activations[1]), [a_2] "=&w"(activations[2]),
+      [a_3] "=&w"(activations[3]), [result_00] "=&w"(results[0].val[0]),
+      [result_01] "=&w"(results[0].val[1]),
+      [result_10] "=&w"(results[1].val[0]),
+      [result_11] "=&w"(results[1].val[1]),
+      [result_20] "=&w"(results[2].val[0]),
+      [result_21] "=&w"(results[2].val[1]),
+      [result_30] "=&w"(results[3].val[0]), [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {
@@ -535,26 +533,24 @@ inline void OutputTransformAndLoadNextAndStore(
       "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
       "sqxtn %[result_10].8b, %[result_10].8h\n\t"
       "sqxtn %[result_00].8b, %[result_00].8h\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      :
+      [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]), [w_2] "=&w"(weights[2]),
+      [w_3] "=&w"(weights[3]), [a_0] "=&w"(activations[0]),
+      [a_1] "=&w"(activations[1]), [a_2] "=&w"(activations[2]),
+      [a_3] "=&w"(activations[3]), [result_00] "=&w"(results[0].val[0]),
+      [result_01] "=&w"(results[0].val[1]),
+      [result_10] "=&w"(results[1].val[0]),
+      [result_11] "=&w"(results[1].val[1]),
+      [result_20] "=&w"(results[2].val[0]),
+      [result_21] "=&w"(results[2].val[1]),
+      [result_30] "=&w"(results[3].val[0]), [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {

--- a/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
+++ b/larq_compute_engine/core/indirect_bgemm/kernel_8x4x4_aarch64.h
@@ -231,19 +231,18 @@ inline void AccumulationLoop_Depth2OrMore(
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
 
       "bgt 0b\n\t"  // Outer loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "+r"(a_ptr_0), [ a_ptr_1 ] "+r"(a_ptr_1),
-        [ a_ptr_2 ] "+r"(a_ptr_2), [ a_ptr_3 ] "+r"(a_ptr_3)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
-        [ w_4 ] "w"(weights[4]), [ w_5 ] "w"(weights[5]),
-        [ w_6 ] "w"(weights[6]), [ w_7 ] "w"(weights[7]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3]),
-        [ kernel_size ] "r"(conv_kernel_size), [ depth ] "r"(depth)
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_), [a_ptr_0] "+r"(a_ptr_0),
+        [a_ptr_1] "+r"(a_ptr_1), [a_ptr_2] "+r"(a_ptr_2),
+        [a_ptr_3] "+r"(a_ptr_3)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [w_2] "w"(weights[2]),
+        [w_3] "w"(weights[3]), [w_4] "w"(weights[4]), [w_5] "w"(weights[5]),
+        [w_6] "w"(weights[6]), [w_7] "w"(weights[7]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3]), [kernel_size] "r"(conv_kernel_size),
+        [depth] "r"(depth)
       : "cc", "memory", "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
         "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15");
 }
@@ -280,19 +279,18 @@ inline void AccumulationLoop_Depth1(std::int32_t conv_kernel_size,
       XOR_POPCOUNT_ACCUM_LOAD_BLOCK_128
 
       "bgt 0b\n\t"  // Loop branch
-      : [ accum_0 ] "=&w"(accumulators[0]), [ accum_1 ] "=&w"(accumulators[1]),
-        [ accum_2 ] "=&w"(accumulators[2]), [ accum_3 ] "=&w"(accumulators[3]),
-        [ w_ptr ] "+r"(weights_ptr),
-        [ indirection_buffer ] "+r"(indirection_buffer_),
-        [ a_ptr_0 ] "=&r"(a_ptr_0), [ a_ptr_1 ] "=&r"(a_ptr_1),
-        [ a_ptr_2 ] "=&r"(a_ptr_2), [ a_ptr_3 ] "=&r"(a_ptr_3),
-        [ ks_index ] "+r"(conv_kernel_size)
-      : [ w_0 ] "w"(weights[0]), [ w_1 ] "w"(weights[1]),
-        [ w_2 ] "w"(weights[2]), [ w_3 ] "w"(weights[3]),
-        [ w_4 ] "w"(weights[4]), [ w_5 ] "w"(weights[5]),
-        [ w_6 ] "w"(weights[6]), [ w_7 ] "w"(weights[7]),
-        [ a_0 ] "w"(activations[0]), [ a_1 ] "w"(activations[1]),
-        [ a_2 ] "w"(activations[2]), [ a_3 ] "w"(activations[3])
+      : [accum_0] "=&w"(accumulators[0]), [accum_1] "=&w"(accumulators[1]),
+        [accum_2] "=&w"(accumulators[2]), [accum_3] "=&w"(accumulators[3]),
+        [w_ptr] "+r"(weights_ptr),
+        [indirection_buffer] "+r"(indirection_buffer_),
+        [a_ptr_0] "=&r"(a_ptr_0), [a_ptr_1] "=&r"(a_ptr_1),
+        [a_ptr_2] "=&r"(a_ptr_2), [a_ptr_3] "=&r"(a_ptr_3),
+        [ks_index] "+r"(conv_kernel_size)
+      : [w_0] "w"(weights[0]), [w_1] "w"(weights[1]), [w_2] "w"(weights[2]),
+        [w_3] "w"(weights[3]), [w_4] "w"(weights[4]), [w_5] "w"(weights[5]),
+        [w_6] "w"(weights[6]), [w_7] "w"(weights[7]), [a_0] "w"(activations[0]),
+        [a_1] "w"(activations[1]), [a_2] "w"(activations[2]),
+        [a_3] "w"(activations[3])
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
         "v9", "v10", "v11", "v12", "v13", "v14", "v15");
 }
@@ -401,28 +399,26 @@ inline void OutputTransformAndLoadNextAndStore(
       "fadd %[result_11].4s, %[result_11].4s, v1.4s\n\t"
       "fadd %[result_00].4s, %[result_00].4s, v0.4s\n\t"
       "fadd %[result_01].4s, %[result_01].4s, v1.4s\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
-        [ w_4 ] "=&w"(weights[4]), [ w_5 ] "=&w"(weights[5]),
-        [ w_6 ] "=&w"(weights[6]), [ w_7 ] "=&w"(weights[7]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      :
+      [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]), [w_2] "=&w"(weights[2]),
+      [w_3] "=&w"(weights[3]), [w_4] "=&w"(weights[4]), [w_5] "=&w"(weights[5]),
+      [w_6] "=&w"(weights[6]), [w_7] "=&w"(weights[7]),
+      [a_0] "=&w"(activations[0]), [a_1] "=&w"(activations[1]),
+      [a_2] "=&w"(activations[2]), [a_3] "=&w"(activations[3]),
+      [result_00] "=&w"(results[0].val[0]),
+      [result_01] "=&w"(results[0].val[1]),
+      [result_10] "=&w"(results[1].val[0]),
+      [result_11] "=&w"(results[1].val[1]),
+      [result_20] "=&w"(results[2].val[0]),
+      [result_21] "=&w"(results[2].val[1]),
+      [result_30] "=&w"(results[3].val[0]), [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {
@@ -587,28 +583,26 @@ inline void OutputTransformAndLoadNextAndStore(
       "sqxtn2 %[result_00].8h, %[result_01].4s\n\t"
       "sqxtn %[result_10].8b, %[result_10].8h\n\t"
       "sqxtn %[result_00].8b, %[result_00].8h\n\t"
-      : [ w_0 ] "=&w"(weights[0]), [ w_1 ] "=&w"(weights[1]),
-        [ w_2 ] "=&w"(weights[2]), [ w_3 ] "=&w"(weights[3]),
-        [ w_4 ] "=&w"(weights[4]), [ w_5 ] "=&w"(weights[5]),
-        [ w_6 ] "=&w"(weights[6]), [ w_7 ] "=&w"(weights[7]),
-        [ a_0 ] "=&w"(activations[0]), [ a_1 ] "=&w"(activations[1]),
-        [ a_2 ] "=&w"(activations[2]), [ a_3 ] "=&w"(activations[3]),
-        [ result_00 ] "=&w"(results[0].val[0]),
-        [ result_01 ] "=&w"(results[0].val[1]),
-        [ result_10 ] "=&w"(results[1].val[0]),
-        [ result_11 ] "=&w"(results[1].val[1]),
-        [ result_20 ] "=&w"(results[2].val[0]),
-        [ result_21 ] "=&w"(results[2].val[1]),
-        [ result_30 ] "=&w"(results[3].val[0]),
-        [ result_31 ] "=&w"(results[3].val[1])
-      : [ accum_0 ] "w"(accumulators[0]), [ accum_1 ] "w"(accumulators[1]),
-        [ accum_2 ] "w"(accumulators[2]), [ accum_3 ] "w"(accumulators[3]),
-        [ clamp_min_addr ] "r"(&output_transform.clamp_min),
-        [ clamp_max_addr ] "r"(&output_transform.clamp_max),
-        [ multiplier_addr ] "r"(output_transform.multiplier + c_out_index),
-        [ bias_addr ] "r"(output_transform.bias + c_out_index),
-        [ w_ptr ] "r"(weights_ptr),
-        [ indirection_buffer ] "r"(indirection_buffer)
+      :
+      [w_0] "=&w"(weights[0]), [w_1] "=&w"(weights[1]), [w_2] "=&w"(weights[2]),
+      [w_3] "=&w"(weights[3]), [w_4] "=&w"(weights[4]), [w_5] "=&w"(weights[5]),
+      [w_6] "=&w"(weights[6]), [w_7] "=&w"(weights[7]),
+      [a_0] "=&w"(activations[0]), [a_1] "=&w"(activations[1]),
+      [a_2] "=&w"(activations[2]), [a_3] "=&w"(activations[3]),
+      [result_00] "=&w"(results[0].val[0]),
+      [result_01] "=&w"(results[0].val[1]),
+      [result_10] "=&w"(results[1].val[0]),
+      [result_11] "=&w"(results[1].val[1]),
+      [result_20] "=&w"(results[2].val[0]),
+      [result_21] "=&w"(results[2].val[1]),
+      [result_30] "=&w"(results[3].val[0]), [result_31] "=&w"(results[3].val[1])
+      : [accum_0] "w"(accumulators[0]), [accum_1] "w"(accumulators[1]),
+        [accum_2] "w"(accumulators[2]), [accum_3] "w"(accumulators[3]),
+        [clamp_min_addr] "r"(&output_transform.clamp_min),
+        [clamp_max_addr] "r"(&output_transform.clamp_max),
+        [multiplier_addr] "r"(output_transform.multiplier + c_out_index),
+        [bias_addr] "r"(output_transform.bias + c_out_index),
+        [w_ptr] "r"(weights_ptr), [indirection_buffer] "r"(indirection_buffer)
       : "memory", "x0", "x1", "x2", "x3", "v0", "v1", "v2", "v3", "v4", "v5");
 
   if (LCE_LIKELY(channels_out - c_out_index >= 8)) {


### PR DESCRIPTION
This PR upgrade `buildifier` to v3.5.0 and clang-format from version 9 to 11