### PR TITLE
Cancel workflows of outdated commits

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -59,6 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.3
         with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
-      - name: Cancel Previous Runs
+      - name: Cancel Outdated Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ github.token }}


### PR DESCRIPTION
This PR adds a GitHub action that will cancel outdated workflows. E.g. when pushing a sceond commit to a PR, the workflow for the first commit should be canceled to save CI time.