### PR TITLE
Remove unused dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ common --experimental_repo_remote_exec
 
 build --copt=-DTFLITE_WITH_RUY
 
+# Disable MKL
+build --define=enable_mkl=false --define=build_with_mkl=false --define=tensorflow_mkldnn_contraction_kernel=0
+
 # By default, build TF in C++ 14 mode.
 build:android --cxxopt=-std=c++14
 build:android --host_cxxopt=-std=c++14

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -235,7 +235,6 @@ cc_library(
         ":larq_compute_engine_optimize",
         ":larq_compute_engine_prepare",
         ":larq_compute_engine_quantize",
-        "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:QuantOps",


### PR DESCRIPTION
## What do these changes do?
This PR removes unused MLIR pass and dialect registrations and disables MKL when building TensorFlow (not sure why this wasn't the case by default). For some reason we still build some unused XLA targets but changing the config setting had no effect.

This should slightly speedup build times and reduces the macOS wheel size from 49MB to 48MB.

## How Has This Been Tested?
Locally built pip package and tested the converter.