### PR TITLE
Set --linkopt=-dead_strip when building mac wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
 
           ./configure.sh
 
-          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13 --distinct_host_configuration=false
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13 --linkopt=-dead_strip --distinct_host_configuration=false
           bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_13_x86_64
 
           for f in artifacts/*.whl; do


### PR DESCRIPTION
## What do these changes do?

This PR strips dead symbols from the built wheel which together with #565 reduces the wheel size from 48MB to 44MB.

See 
https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/CompilerOptions.html

## How Has This Been Tested?
Locally built pip package and tested the converter..