### PR TITLE
Do not pin official GitHub actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.1.4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install Lint Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - uses: actions/cache@v2
@@ -47,7 +47,7 @@ jobs:
         run: |
           bazelisk build //larq_compute_engine/tflite/benchmark:lce_benchmark_model --config=android_arm64 -c opt --copt=-O3
           cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model benchmark-binaries/lce_benchmark_model_android_arm64
-      - uses: actions/upload-artifact@v2.2.1
+      - uses: actions/upload-artifact@v2
         with:
           name: Benchmark-Binaries
           path: benchmark-binaries
@@ -57,30 +57,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            upload_url: ${{ github.event.release.upload_url }}
-            asset_path: benchmark-binaries/lce_benchmark_model_aarch64
-            asset_name: lce_benchmark_model_aarch64
-            asset_content_type: application/octet-stream
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: benchmark-binaries/lce_benchmark_model_aarch64
+          asset_name: lce_benchmark_model_aarch64
+          asset_content_type: application/octet-stream
       - name: Upload Release Asset AArch32
         if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            upload_url: ${{ github.event.release.upload_url }}
-            asset_path: benchmark-binaries/lce_benchmark_model_aarch32
-            asset_name: lce_benchmark_model_aarch32
-            asset_content_type: application/octet-stream
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: benchmark-binaries/lce_benchmark_model_aarch32
+          asset_name: lce_benchmark_model_aarch32
+          asset_content_type: application/octet-stream
       - name: Upload Release Asset Android
         if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            upload_url: ${{ github.event.release.upload_url }}
-            asset_path: benchmark-binaries/lce_benchmark_model_android_arm64
-            asset_name: lce_benchmark_model_android_arm64
-            asset_content_type: application/octet-stream
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: benchmark-binaries/lce_benchmark_model_android_arm64
+          asset_name: lce_benchmark_model_android_arm64
+          asset_content_type: application/octet-stream
 
   android-aar:
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - uses: actions/cache@v2
@@ -106,7 +106,7 @@ jobs:
         run: ./third_party/install_android.sh
       - name: Build LCE AAR
         run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh
-      - uses: actions/upload-artifact@v2.2.1
+      - uses: actions/upload-artifact@v2
         with:
           name: Android-AAR
           path: lce-lite-*.aar
@@ -119,7 +119,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build macOS wheels
@@ -149,7 +149,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build manylinux2010 wheels
@@ -166,7 +166,7 @@ jobs:
           done
 
           ls -al wheelhouse/
-      - uses: actions/upload-artifact@v2.2.1
+      - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-wheels
           path: wheelhouse
@@ -179,7 +179,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build Windows wheels
@@ -196,7 +196,7 @@ jobs:
           bazel-bin/build_pip_pkg wheelhouse
 
         shell: bash
-      - uses: actions/upload-artifact@v2.2.1
+      - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-wheels
           path: wheelhouse

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-user
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Configure Bazel
@@ -91,7 +91,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2.1.4
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - uses: actions/cache@v2


### PR DESCRIPTION
This makes sure that we are always on the latest stable version of the official GitHub actions and will reduce the amount of dependabot PRs.