### PR TITLE
Add zero-padding support to the reference kernel

### DIFF
--- a/larq_compute_engine/tests/end2end_test.py
+++ b/larq_compute_engine/tests/end2end_test.py
@@ -134,7 +134,9 @@ def preprocess(data):
 
 
 def assert_model_output(model_lce, inputs, outputs, rtol, atol):
-    interpreter = Interpreter(model_lce, num_threads=min(os.cpu_count(), 4))
+    interpreter = Interpreter(
+        model_lce, num_threads=min(os.cpu_count(), 4), use_reference_bconv=False
+    )
     actual_outputs = interpreter.predict(inputs)
     np.testing.assert_allclose(actual_outputs, outputs, rtol=rtol, atol=atol)
 

--- a/larq_compute_engine/tflite/kernels/bconv2d.cc
+++ b/larq_compute_engine/tflite/kernels/bconv2d.cc
@@ -124,14 +124,6 @@ void* Init(TfLiteContext* context, const char* buffer, std::size_t length) {
 
   op_data->fused_activation_function = ConvertActivation(
       (ActivationFunctionType)m["fused_activation_function"].AsInt32());
-  if (bconv2d_params->padding_type == kTfLitePaddingSame &&
-      bconv2d_params->pad_value != 1 &&
-      op_data->fused_activation_function != kTfLiteActNone) {
-    TF_LITE_KERNEL_LOG(
-        context,
-        "Fused activations are only supported with valid or one-padding.");
-    return op_data;
-  }
 
   // It's not possible to return an error code in this method. If we get to here
   // without returning early, initialisation has succeeded without error, and so
@@ -211,10 +203,11 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE_EQ(context, SizeOfDimension(thresholds, 0),
                       bconv2d_params->channels_out);
     TF_LITE_ENSURE_MSG(context,
-                       bconv2d_params->padding_type != kTfLitePaddingSame ||
+                       kernel_type == KernelType::kReference ||
+                           bconv2d_params->padding_type != kTfLitePaddingSame ||
                            bconv2d_params->pad_value == 1,
-                       "Writing bitpacked output is only supported with "
-                       "valid or one-padding.");
+                       "Writing bitpacked output is only supported by the "
+                       "reference kernel, or with valid or one-padding.");
   } else {
     TF_LITE_ENSURE_EQ(context, post_activation_multiplier->type,
                       kTfLiteFloat32);
@@ -231,14 +224,13 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE_EQ(context, output->quantization.type,
                       kTfLiteAffineQuantization);
 
-    if (kernel_type != KernelType::kReference ||
-        bconv2d_params->channels_in % 2 != 0) {
-      TF_LITE_ENSURE_MSG(
-          context,
-          bconv2d_params->padding_type != kTfLitePaddingSame ||
-              bconv2d_params->pad_value == 1,
-          "8-bit quantization is only supported with valid or one-padding");
-    }
+    TF_LITE_ENSURE_MSG(context,
+                       (kernel_type == KernelType::kReference &&
+                        bconv2d_params->channels_in % 2 == 0) ||
+                           bconv2d_params->padding_type != kTfLitePaddingSame ||
+                           bconv2d_params->pad_value == 1,
+                       "8-bit quantization is only supported by the reference "
+                       "kernel, or with valid or one-padding");
   }
 
   if (kernel_type == KernelType::kOptimizedIndirectBGEMM) {
@@ -246,6 +238,15 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
         context, input->allocation_type != kTfLiteDynamic,
         "The input tensor must not have dynamic allocation type");
   }
+
+  TF_LITE_ENSURE_MSG(context,
+                     (kernel_type == KernelType::kReference &&
+                      bconv2d_params->channels_in % 2 == 0) ||
+                         bconv2d_params->padding_type != kTfLitePaddingSame ||
+                         bconv2d_params->pad_value == 1 ||
+                         op_data->fused_activation_function == kTfLiteActNone,
+                     "Fused activations are only supported by the reference "
+                     "kernel, or with valid or one-padding.");
 
   // Determine the output dimensions and allocate the output buffer
   TfLiteIntArray* output_shape = TfLiteIntArrayCreate(4);
@@ -331,8 +332,7 @@ inline void GetConvParamsType(const OpData* op_data,
   conv2d_params.quantized_activation_max = op_data->output_transform_clamp_max;
 }
 
-void OneTimeSetup(TfLiteContext* context, TfLiteNode* node, OpData* op_data,
-                  KernelType kernel_type) {
+void OneTimeSetup(TfLiteContext* context, TfLiteNode* node, OpData* op_data) {
   const auto* bconv2d_params = &op_data->params;
 
   const auto* filter = GetInput(context, node, 1);
@@ -377,25 +377,13 @@ void OneTimeSetup(TfLiteContext* context, TfLiteNode* node, OpData* op_data,
     const double output_zero_point =
         output->type == kTfLiteInt8 ? output->params.zero_point : 0.0;
 
-    // For zero-padding, the backtransform is pixel-dependent, and therefore
-    // done by the kernel
-    // We still require the normal `backtransform_add` below in the
-    // `nominal_clamp`
-    const std::int32_t fused_backtransform_add =
-        (bconv2d_params->padding_type == kTfLitePaddingSame &&
-         bconv2d_params->pad_value == 0 &&
-         kernel_type == KernelType::kReference)
-            ? 0
-            : backtransform_add;
-
     for (int i = 0; i < bconv2d_params->channels_out; ++i) {
       const double post_mul =
           GetTensorData<float>(post_activation_multiplier)[i];
       const double post_bias = GetTensorData<float>(post_activation_bias)[i];
       op_data->output_transform_multiplier.at(i) = -1 * post_mul / output_scale;
       op_data->output_transform_bias.at(i) =
-          (post_bias +
-           static_cast<double>(fused_backtransform_add) * post_mul) /
+          (post_bias + static_cast<double>(backtransform_add) * post_mul) /
               output_scale +
           output_zero_point;
     }
@@ -406,9 +394,9 @@ void OneTimeSetup(TfLiteContext* context, TfLiteNode* node, OpData* op_data,
     nominal_clamp_min = std::max(nominal_clamp_min, -1 * backtransform_add);
     nominal_clamp_max = std::min(nominal_clamp_max, backtransform_add);
     op_data->output_transform_clamp_min =
-        -1 * nominal_clamp_max + fused_backtransform_add;
+        -1 * nominal_clamp_max + backtransform_add;
     op_data->output_transform_clamp_max =
-        -1 * nominal_clamp_min + fused_backtransform_add;
+        -1 * nominal_clamp_min + backtransform_add;
   }
 
   op_data->one_time_setup_complete = true;
@@ -439,7 +427,7 @@ void GetOutputTransform(OutputTransform<TBitpacked>& output_transform,
 template <typename AccumScalar, typename DstScalar>
 void EvalOptBGEMM(TfLiteContext* context, TfLiteNode* node, OpData* op_data) {
   if (!op_data->one_time_setup_complete) {
-    OneTimeSetup(context, node, op_data, KernelType::kOptimizedBGEMM);
+    OneTimeSetup(context, node, op_data);
   }
 
   auto* bconv2d_params = &op_data->params;
@@ -487,7 +475,7 @@ void EvalOptIndirectBGEMM(TfLiteContext* context, TfLiteNode* node,
                           OpData* op_data) {
   bool kernel_is_initialized = true;
   if (!op_data->one_time_setup_complete) {
-    OneTimeSetup(context, node, op_data, KernelType::kOptimizedIndirectBGEMM);
+    OneTimeSetup(context, node, op_data);
     kernel_is_initialized = false;
   }
 
@@ -527,7 +515,7 @@ void EvalOptIndirectBGEMM(TfLiteContext* context, TfLiteNode* node,
 template <typename DstScalar>
 void EvalRef(TfLiteContext* context, TfLiteNode* node, OpData* op_data) {
   if (!op_data->one_time_setup_complete) {
-    OneTimeSetup(context, node, op_data, KernelType::kReference);
+    OneTimeSetup(context, node, op_data);
   }
 
   const auto* input = GetInput(context, node, 0);

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -26,10 +26,10 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
                       compute_engine::tflite::Register_DEQUANTIZE());
   if (use_reference_bconv) {
     resolver->AddCustom("LceBconv2d",
-                        compute_engine::tflite::Register_BCONV_2D());
+                        compute_engine::tflite::Register_BCONV_2D_REF());
   } else {
     resolver->AddCustom("LceBconv2d",
-                        compute_engine::tflite::Register_BCONV_2D_REF());
+                        compute_engine::tflite::Register_BCONV_2D());
   }
   resolver->AddCustom("LceBMaxPool2d",
                       compute_engine::tflite::Register_BMAXPOOL_2D());

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -13,17 +13,24 @@ namespace tflite {
 TfLiteRegistration* Register_QUANTIZE();
 TfLiteRegistration* Register_DEQUANTIZE();
 TfLiteRegistration* Register_BCONV_2D();
+TfLiteRegistration* Register_BCONV_2D_REF();
 TfLiteRegistration* Register_BMAXPOOL_2D();
 
 // By calling this function on TF lite mutable op resolver, all LCE custom ops
 // will be registerd to the op resolver.
-inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver) {
+inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
+                                 const bool use_reference_bconv = false) {
   resolver->AddCustom("LceQuantize",
                       compute_engine::tflite::Register_QUANTIZE());
   resolver->AddCustom("LceDequantize",
                       compute_engine::tflite::Register_DEQUANTIZE());
-  resolver->AddCustom("LceBconv2d",
-                      compute_engine::tflite::Register_BCONV_2D());
+  if (use_reference_bconv) {
+    resolver->AddCustom("LceBconv2d",
+                        compute_engine::tflite::Register_BCONV_2D());
+  } else {
+    resolver->AddCustom("LceBconv2d",
+                        compute_engine::tflite::Register_BCONV_2D_REF());
+  }
   resolver->AddCustom("LceBMaxPool2d",
                       compute_engine::tflite::Register_BMAXPOOL_2D());
 };

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -43,6 +43,7 @@ class Interpreter:
     # Arguments
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
         num_threads: The number of threads used by the interpreter.
+        use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
 
     # Attributes
         input_types: Returns a list of input types.
@@ -51,9 +52,14 @@ class Interpreter:
         output_shapes: Returns a list of output shapes.
     """
 
-    def __init__(self, flatbuffer_model: bytes, num_threads: int = 1):
+    def __init__(
+        self,
+        flatbuffer_model: bytes,
+        num_threads: int = 1,
+        use_reference_bconv: bool = False,
+    ):
         self.interpreter = interpreter_wrapper_lite.LiteInterpreter(
-            flatbuffer_model, num_threads
+            flatbuffer_model, num_threads, use_reference_bconv
         )
 
     @property

--- a/larq_compute_engine/tflite/tests/bconv2d_test.cc
+++ b/larq_compute_engine/tflite/tests/bconv2d_test.cc
@@ -498,7 +498,10 @@ void runTest(const TestParam& param) {
 
   if (padding == Padding_SAME) {
     if (is_reference_registration) {
-      if (input_depth % 2 != 0) GTEST_SKIP();
+      if (input_depth % 2 != 0) {
+        GTEST_SKIP();
+        return;
+      }
     } else {
       if (!float_output || activation == ActivationFunctionType_RELU) {
         // We could use `EXPECT_DEATH` here but it is


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This PR adds zero-padding support to the reference kernel, for all output types, group sizes, and activation functions.
(Previously we only supported zero-padding for the regular float kernel with no activation functions and no groups.)

Furthermore the `LiteInterpreter` now has an extra argument to choose the reference kernel, in order to be able to test against zero-padding.

## How Has This Been Tested?
The bconv2d tests have been updated.
