### PR TITLE
Fix windows build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,6 +63,11 @@ build:windows --host_copt=-DWIN32_LEAN_AND_MEAN
 build:windows --copt=-DNOGDI
 build:windows --host_copt=-DNOGDI
 
+# MSVC (Windows): Standards-conformant preprocessor mode
+# See https://docs.microsoft.com/en-us/cpp/build/reference/zc-preprocessor
+build:windows --copt=/Zc:preprocessor
+build:windows --host_copt=/Zc:preprocessor
+
 # Misc build options we need for windows.
 build:windows --linkopt=/DEBUG
 build:windows --host_linkopt=/DEBUG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,12 +187,14 @@ jobs:
           export PYTHON_BIN_PATH=$(which python)
           export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
 
+          mkdir C:/bazel_cache
+
           python --version
           python -m pip install wheel setuptools numpy six --no-cache-dir
 
           ./configure.sh
 
-          bazelisk --output_base=cache build :build_pip_pkg --copt=/arch:AVX --enable_runfiles --define=override_eigen_strong_inline=true
+          bazelisk --output_base=C:/bazel_cache build :build_pip_pkg --copt=/arch:AVX --enable_runfiles --define=override_eigen_strong_inline=true
           bazel-bin/build_pip_pkg wheelhouse
 
         shell: bash

--- a/larq_compute_engine/core/bgemm/kernels.h
+++ b/larq_compute_engine/core/bgemm/kernels.h
@@ -97,7 +97,7 @@ struct BGemmKernel<ruy::Path::kStandardCpp, TBitpacked, MulParams> {
     RUY_DCHECK_LE(clamped_end_col, end_col);
     RUY_DCHECK_LE(end_col - clamped_end_col, RhsLayout::kCols);
 
-    RUY_DCHECK_EQ(dst->layout.order, Order::kColMajor);
+    RUY_DCHECK_EQ(dst->layout.order, ruy::Order::kColMajor);
 
     ruy::profiler::ScopeLabel label(
         "Binary Kernel (Standard Cpp), Bitpacked Output.");
@@ -145,8 +145,8 @@ template <typename DstScalar>
 struct BGemmKernel<ruy::Path::kNeon, DstScalar,
                    BinaryMulParams<std::int32_t, DstScalar>> {
   Tuning tuning = Tuning::kAuto;
-  using LhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
-  using RhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
+  using LhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 4>;
+  using RhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 4>;
   explicit BGemmKernel(Tuning tuning_) : tuning(tuning_) {}
   void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const BinaryMulParams<std::int32_t, DstScalar>& mul_params,
@@ -176,8 +176,8 @@ template <typename DstScalar>
 struct BGemmKernel<ruy::Path::kNeon, DstScalar,
                    BinaryMulParams<std::int16_t, DstScalar>> {
   Tuning tuning = Tuning::kAuto;
-  using LhsLayout = FixedKernelLayout<Order::kColMajor, 4, 8>;
-  using RhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
+  using LhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 8>;
+  using RhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 4>;
   explicit BGemmKernel(Tuning tuning_) : tuning(tuning_) {}
   void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const BinaryMulParams<std::int16_t, DstScalar>& mul_params,
@@ -200,8 +200,8 @@ template <typename DstScalar>
 struct BGemmKernel<ruy::Path::kNeon, DstScalar,
                    BinaryMulParams<std::int32_t, DstScalar>> {
   Tuning tuning = Tuning::kAuto;
-  using LhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
-  using RhsLayout = FixedKernelLayout<Order::kColMajor, 4, 4>;
+  using LhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 4>;
+  using RhsLayout = FixedKernelLayout<ruy::Order::kColMajor, 4, 4>;
   explicit BGemmKernel(Tuning tuning_) : tuning(tuning_) {}
   void Run(const ruy::PMat<TBitpacked>& lhs, const ruy::PMat<TBitpacked>& rhs,
            const BinaryMulParams<std::int32_t, DstScalar>& mul_params,

--- a/larq_compute_engine/core/bgemm/kernels_common.h
+++ b/larq_compute_engine/core/bgemm/kernels_common.h
@@ -10,6 +10,7 @@ namespace core {
 namespace bgemm {
 
 using namespace ruy;
+using ruy::Order;  // To fix Windows build
 
 using namespace bitpacking;
 using bconv2d::OutputTransform;

--- a/larq_compute_engine/core/bgemm/ruy_pack.h
+++ b/larq_compute_engine/core/bgemm/ruy_pack.h
@@ -32,6 +32,8 @@ namespace core {
 namespace bgemm {
 
 using namespace ruy;
+using ruy::Order;  // To fix Windows build
+
 template <Path ThePath, typename FixedKernelLayout, Order SrcOrder>
 struct LceRuyPackImpl : PackImpl<ThePath, FixedKernelLayout, TBitpacked,
                                  TBitpacked, TBitpacked, SrcOrder> {};


### PR DESCRIPTION
This PR fixes a few Windows build issues that we've been ignoring for a while:
- 78bbc03d01319b0b1da326a26731ddf69d2e9ee9 prevents
   ```
   error C2872: 'Order': ambiguous symbol
   could be 'ruy::Order' or 'tflite::cpu_backend_gemm::Order'
   ```
- 8382945f3c6bb2ea712075cf094f8eb6749e021e adds compiler flags required for TF 2.4
- 5e806b0d5b0d2ededaffb97a4519193c2107a1cd moves the bazel cache to `C:/` to prevent running out of disk space on GitHub actions.

Unfortunately the builds on GitHub Actions still fail with `fatal error C1060: compiler is out of heap space` while trying to compile some Eigen kernels, but this PR should at least make it possible to manually build for Windows on a larger machine.