### PR TITLE
Add preliminary support for the xcore target.

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -36,12 +36,29 @@ gentbl(
 )
 
 gentbl(
-    name = "prepare_lce_inc_gen",
+    name = "prepare_lce_target_arm_inc_gen",
     tbl_outs = [
-        ("-gen-rewriters", "transforms/generated_prepare.inc"),
+        ("-gen-rewriters", "transforms/generated_prepare_target_arm.inc"),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "transforms/prepare_patterns.td",
+    td_file = "transforms/prepare_patterns_target_arm.td",
+    td_srcs = [
+        "ir/lce_ops.td",
+        "transforms/op_removal_patterns.td",
+        "transforms/prepare_patterns_common.td",
+        "@llvm-project//mlir:StdOpsTdFiles",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_ops_td_files",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
+    ],
+)
+
+gentbl(
+    name = "prepare_lce_target_other_inc_gen",
+    tbl_outs = [
+        ("-gen-rewriters", "transforms/generated_prepare_target_other.inc"),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "transforms/prepare_patterns_common.td",
     td_srcs = [
         "ir/lce_ops.td",
         "transforms/op_removal_patterns.td",
@@ -52,12 +69,27 @@ gentbl(
 )
 
 gentbl(
-    name = "optimize_lce_inc_gen",
+    name = "optimize_lce_target_arm_inc_gen",
     tbl_outs = [
-        ("-gen-rewriters", "transforms/generated_optimize.inc"),
+        ("-gen-rewriters", "transforms/generated_optimize_target_arm.inc"),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "transforms/optimize_patterns.td",
+    td_file = "transforms/optimize_patterns_target_arm.td",
+    td_srcs = [
+        "ir/lce_ops.td",
+        "transforms/optimize_patterns_common.td",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
+        "@llvm-project//mlir:StdOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "optimize_lce_target_other_inc_gen",
+    tbl_outs = [
+        ("-gen-rewriters", "transforms/generated_optimize_target_other.inc"),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "transforms/optimize_patterns_common.td",
     td_srcs = [
         "ir/lce_ops.td",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
@@ -136,7 +168,8 @@ cc_library(
 cc_library(
     name = "larq_compute_engine_prepare",
     srcs = [
-        "transforms/generated_prepare.inc",
+        "transforms/generated_prepare_target_arm.inc",
+        "transforms/generated_prepare_target_other.inc",
         "transforms/prepare_tf.cc",
     ],
     hdrs = [
@@ -157,7 +190,8 @@ cc_library(
 cc_library(
     name = "larq_compute_engine_optimize",
     srcs = [
-        "transforms/generated_optimize.inc",
+        "transforms/generated_optimize_target_arm.inc",
+        "transforms/generated_optimize_target_other.inc",
         "transforms/optimize.cc",
     ],
     hdrs = [

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -55,6 +55,7 @@ def convert_keras_model(
     *,  # Require remaining arguments to be keyword-only.
     inference_input_type: tf.DType = tf.float32,
     inference_output_type: tf.DType = tf.float32,
+    target: str = "arm",
     experimental_default_int8_range: Optional[Tuple[float, float]] = None,
     experimental_enable_bitpacked_activations: bool = False,
 ) -> bytes:
@@ -73,6 +74,7 @@ def convert_keras_model(
             must be either `tf.float32` or `tf.int8`.
         inference_output_type: Data type of the output layer. Defaults to `tf.float32`,
             must be either `tf.float32` or `tf.int8`.
+        target: Target hardware platform. Must be "arm" or "xcore".
         experimental_default_int8_range: Tuple of integers representing `(min, max)`
             range values for all arrays without a specified range. Intended for
             experimenting with quantization via "dummy quantization". (default None)
@@ -98,6 +100,8 @@ def convert_keras_model(
             "Expected `inference_output_type` to be either `tf.float32` or `tf.int8`, "
             f"got {inference_output_type}."
         )
+    if target not in ("arm", "xcore"):
+        raise ValueError(f'Expected `target` to be "arm" or "xcore", but got {target}.')
 
     if not tf.executing_eagerly():
         raise RuntimeError(
@@ -147,6 +151,7 @@ def convert_keras_model(
         [tensor.shape.as_list() for tensor in input_tensors],
         [get_tensor_name(tensor) for tensor in output_tensors],
         should_quantize,
+        target,
         experimental_default_int8_range,
         experimental_enable_bitpacked_activations,
     )

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -31,6 +31,7 @@ class TestConverter(unittest.TestCase):
             [[1, 224, 224, 3]],
             ["Identity"],
             False,
+            "arm",
             None,
             False,
         )
@@ -38,6 +39,20 @@ class TestConverter(unittest.TestCase):
     def test_wrong_arg(self):
         with self.assertRaises(ValueError):
             convert_keras_model("./model.h5")
+
+    def test_target_arg(self):
+        with context.eager_mode():
+            model = lqz.sota.QuickNet(weights=None)
+
+            # These should work
+            convert_keras_model(model, target="arm")
+            convert_keras_model(model, target="xcore")
+
+            # Anything else shouldn't
+            with self.assertRaises(
+                ValueError, msg='Expected `target` to be "arm" or "xcore"'
+            ):
+                convert_keras_model(model, target="x86")
 
 
 if __name__ == "__main__":

--- a/larq_compute_engine/mlir/tests/prepare-tf.mlir
+++ b/larq_compute_engine/mlir/tests/prepare-tf.mlir
@@ -1,4 +1,5 @@
-// RUN: lce-tf-opt %s -tfl-prepare-lce -verify-diagnostics | FileCheck %s
+// RUN: lce-tf-opt %s -tfl-prepare-lce=target=arm -verify-diagnostics | FileCheck %s --check-prefixes CHECK,CHECK-ARM
+// RUN: lce-tf-opt %s -tfl-prepare-lce=target=xcore -verify-diagnostics | FileCheck %s --check-prefixes CHECK,CHECK-XCORE
 
 // CHECK-LABEL: @fuse_bsign
 func @fuse_bsign(%arg0: tensor<8x16xf32>) -> tensor<8x16xf32> {
@@ -13,64 +14,83 @@ func @fuse_bsign(%arg0: tensor<8x16xf32>) -> tensor<8x16xf32> {
   // CHECK-NEXT: return %1
 }
 
-// CHECK-LABEL: @fuse_bconv2d
-func @fuse_bconv2d(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32> {
-  %cst = "tf.Const"() { value = dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32> } : () -> tensor<1x2x2x2xf32>
+// CHECK-LABEL: @fuse_bconv2d_valid_padding
+func @fuse_bconv2d_valid_padding(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x110x2xf32> {
+  %cst = "tf.Const"() { value = dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]], [[-1.0, -1.0], [-1.0, 1.0]]]]> : tensor<1x3x2x2xf32> } : () -> tensor<1x3x2x2xf32>
   %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32>
-  %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>
-  return %1 : tensor<1x112x112x2xf32>
+  %1 = "tf.Conv2D"(%0, %cst) {padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x3x2x2xf32>) -> tensor<1x112x110x2xf32>
+  return %1 : tensor<1x112x110x2xf32>
 
   // CHECK: %cst = constant
   // CHECK: %[[post_activation_multiplier:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
   // CHECK: %[[post_activation_bias:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
   // CHECK: %[[output_threshold:.*]] = constant unit
   // CHECK: %[[transpose:.*]] = "tf.Transpose"
-  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 2 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "SAME", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x1xi32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>, none) -> tensor<1x112x112x2xf32>
+  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 2 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x1xi32>, tensor<2x1x3x2xf32>, tensor<2xf32>, tensor<2xf32>, none) -> tensor<1x112x110x2xf32>
   // CHECK-NEXT: return %[[conv]]
 }
 
+// CHECK-LABEL: @target_specific_fuse_bconv2d_same_zero_padding
+func @target_specific_fuse_bconv2d_same_zero_padding(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32> {
+  %cst = "tf.Const"() { value = dense<[[[[1.0, -1.0], [1.0, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32> } : () -> tensor<1x2x2x2xf32>
+  %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32>
+  %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>
+  return %1 : tensor<1x112x112x2xf32>
+
+  // CHECK-ARM: %cst = constant
+  // CHECK-ARM: %[[post_activation_multiplier:.*]] = constant dense<1.000000e+00> : tensor<2xf32>
+  // CHECK-ARM: %[[post_activation_bias:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
+  // CHECK-ARM: %[[output_threshold:.*]] = constant unit
+  // CHECK-ARM: %[[transpose:.*]] = "tf.Transpose"
+  // CHECK-ARM-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 2 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "SAME", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x1xi32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>, none) -> tensor<1x112x112x2xf32>
+  // CHECK-ARM-NEXT: return %[[conv]]
+
+  // CHECK-XCORE: %0 = "lq.Dequantize"
+  // CHECK-XCORE-NEXT: %1 = "tf.Conv2D"
+}
+
 // CHECK-LABEL: @fuse_bconv2d_grouped_convolution
-func @fuse_bconv2d_grouped_convolution(%arg0: tensor<1x112x112x4xi32>) -> tensor<1x112x112x16xf32> {
+func @fuse_bconv2d_grouped_convolution(%arg0: tensor<1x112x112x4xi32>) -> tensor<1x110x110x16xf32> {
   // A 3x3 filter with 128 input channels (64 per-group) and 16 output channels (8 per-group).
   %cst = "tf.Const"() { value = dense<1.0> : tensor<3x3x64x16xf32>} : () -> tensor<3x3x64x16xf32>
   %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x4xi32>) -> tensor<1x112x112x128xf32>
-  %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x128xf32>, tensor<3x3x64x16xf32>) -> tensor<1x112x112x16xf32>
-  return %1 : tensor<1x112x112x16xf32>
+  %1 = "tf.Conv2D"(%0, %cst) {padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<1x112x112x128xf32>, tensor<3x3x64x16xf32>) -> tensor<1x110x110x16xf32>
+  return %1 : tensor<1x110x110x16xf32>
 
   // CHECK: %cst = constant
   // CHECK: %[[post_activation_multiplier:.*]] = constant dense<1.000000e+00> : tensor<16xf32>
   // CHECK: %[[post_activation_bias:.*]] = constant dense<0.000000e+00> : tensor<16xf32>
   // CHECK: %[[output_threshold:.*]] = constant unit
   // CHECK: %[[transpose:.*]] = "tf.Transpose"
-  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 128 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "SAME", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x4xi32>, tensor<16x3x3x64xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<1x112x112x16xf32>
+  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 128 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x4xi32>, tensor<16x3x3x64xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<1x110x110x16xf32>
   // CHECK-NEXT: return %[[conv]]
 }
 
 // CHECK-LABEL: @do_not_fuse_bconv2d_grouped_convolution_group_size_not_mul_32
-func @do_not_fuse_bconv2d_grouped_convolution_group_size_not_mul_32(%arg0: tensor<1x56x56x4xi32>) -> tensor<1x56x56x128xf32> {
+func @do_not_fuse_bconv2d_grouped_convolution_group_size_not_mul_32(%arg0: tensor<1x56x56x4xi32>) -> tensor<1x54x54x128xf32> {
   // A 3x3 filter with 128 input channels (4 per-group) and 128 output channels
   // (4 per-group). We expect an error to be raised:
   //
   // expected-error @+1 {{Invalid binary grouped convolution: the number of input channels per-group must be a multiple of 32, but is 4}}
   %cst = "tf.Const"() { value = dense<1.0> : tensor<3x3x4x128xf32>} : () -> tensor<3x3x4x128xf32>
   %0 = "lq.Dequantize"(%arg0) : (tensor<1x56x56x4xi32>) -> tensor<1x56x56x128xf32>
-  %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x56x56x128xf32>, tensor<3x3x4x128xf32>) -> tensor<1x56x56x128xf32>
-  return %1 : tensor<1x56x56x128xf32>
+  %1 = "tf.Conv2D"(%0, %cst) {padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<1x56x56x128xf32>, tensor<3x3x4x128xf32>) -> tensor<1x54x54x128xf32>
+  return %1 : tensor<1x54x54x128xf32>
 }
 
 // CHECK-LABEL: @fuse_scaled_bconv2d
-func @fuse_scaled_bconv2d(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32> {
-  %cst = constant dense<[[[[0.3, -0.1], [0.3, 0.1]], [[-0.3, 0.1], [-0.3, 0.1]]]]> : tensor<1x2x2x2xf32>
+func @fuse_scaled_bconv2d(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x110x2xf32> {
+  %cst = constant dense<[[[[0.3, -0.1], [0.3, 0.1]], [[-0.3, 0.1], [-0.3, 0.1]], [[-0.3, -0.1], [0.3, 0.1]]]]> : tensor<1x3x2x2xf32>
   %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32>
-  %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>
-  return %1 : tensor<1x112x112x2xf32>
+  %1 = "tf.Conv2D"(%0, %cst) {padding = "VALID", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x3x2x2xf32>) -> tensor<1x112x110x2xf32>
+  return %1 : tensor<1x112x110x2xf32>
 
   // CHECK: %cst = constant
   // CHECK: %[[post_activation_multiplier:.*]] = constant dense<[3.000000e-01, 1.000000e-01]> : tensor<2xf32>
   // CHECK: %[[post_activation_bias:.*]] = constant dense<0.000000e+00> : tensor<2xf32>
   // CHECK: %[[output_threshold:.*]] = constant unit
   // CHECK: %[[transpose:.*]] = "tf.Transpose"
-  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 2 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "SAME", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x1xi32>, tensor<2x1x2x2xf32>, tensor<2xf32>, tensor<2xf32>, none) -> tensor<1x112x112x2xf32>
+  // CHECK-NEXT: %[[conv:.*]] = "lq.Bconv2d"(%arg0, %[[transpose]], %[[post_activation_multiplier]], %[[post_activation_bias]], %[[output_threshold:.*]]) {channels_in = 2 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 0 : i32, padding = "VALID", stride_height = 1 : i32, stride_width = 1 : i32} : (tensor<1x112x112x1xi32>, tensor<2x1x3x2xf32>, tensor<2xf32>, tensor<2xf32>, none) -> tensor<1x112x110x2xf32>
   // CHECK-NEXT: return %[[conv]]
 }
 
@@ -91,9 +111,8 @@ func @fuse_dilated_bconv(%arg0: tensor<1x128x128x1xi32>) -> tensor<1x128x128x8xf
   // CHECK-NEXT: return %[[conv]] : tensor<1x128x128x8xf32>
 }
 
-
-// CHECK-LABEL: @do_not_fuse_bconv2d
-func @do_not_fuse_bconv2d(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32> {
+// CHECK-LABEL: @do_not_fuse_bconv2d_non_binary_weights
+func @do_not_fuse_bconv2d_non_binary_weights(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32> {
   %cst = constant dense<[[[[3.0, -1.0], [0.1, 1.0]], [[-1.0, 1.0], [-1.0, 1.0]]]]> : tensor<1x2x2x2xf32>
   %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x2xf32>
   %1 = "tf.Conv2D"(%0, %cst) {padding = "SAME", strides = [1, 1, 1, 1]} : (tensor<1x112x112x2xf32>, tensor<1x2x2x2xf32>) -> tensor<1x112x112x2xf32>
@@ -118,8 +137,8 @@ func @do_not_fuse_bconv2d_zero_weight(%arg0: tensor<1x112x112x1xi32>) -> tensor<
   // CHECK-NEXT: return %1
 }
 
-// CHECK-LABEL: @fuse_bconv2d_padding
-func @fuse_bconv2d_padding(%arg0: tensor<256x32x32x1xi32>) -> tensor<256x16x16x16xf32> {
+// CHECK-LABEL: @fuse_bconv2d_same_one_padding
+func @fuse_bconv2d_same_one_padding(%arg0: tensor<256x32x32x1xi32>) -> tensor<256x16x16x16xf32> {
   %cst = constant dense<1.0> : tensor<3x3x3x16xf32>
   %cst0 = constant dense<1.0> : tensor<f32>
   %cst1 = constant dense<[[0, 0], [1, 1], [1, 1], [0, 0]]> : tensor<4x2xi32>
@@ -135,8 +154,8 @@ func @fuse_bconv2d_padding(%arg0: tensor<256x32x32x1xi32>) -> tensor<256x16x16x1
   // CHECK:  %[[CONV:.*]] = "lq.Bconv2d"(%arg0, %[[TRP]], %[[CST1]], %[[CST2]], %[[CST3:.*]]) {channels_in = 3 : i32, dilation_height_factor = 1 : i32, dilation_width_factor = 1 : i32, fused_activation_function = "NONE", pad_values = 1 : i32, padding = "SAME", stride_height = 2 : i32, stride_width = 2 : i32} : (tensor<256x32x32x1xi32>, tensor<16x3x3x3xf32>, tensor<16xf32>, tensor<16xf32>, none) -> tensor<256x16x16x16xf32>
 }
 
-// CHECK-LABEL: @do_not_fuse_bconv2d_padding_same
-func @do_not_fuse_bconv2d_padding_same(%arg0: tensor<256x32x32x1xi32>) -> tensor<256x34x34x16xf32> {
+// CHECK-LABEL: @do_not_fuse_bconv2d_padding_same_twice
+func @do_not_fuse_bconv2d_padding_same_twice(%arg0: tensor<256x32x32x1xi32>) -> tensor<256x34x34x16xf32> {
   %cst = constant dense<1.0> : tensor<3x3x3x16xf32>
   %cst0 = constant dense<1.0> : tensor<f32>
   %cst1 = constant dense<[[0, 0], [1, 1], [1, 1], [0, 0]]> : tensor<4x2xi32>

--- a/larq_compute_engine/mlir/tf_tfl_passes.h
+++ b/larq_compute_engine/mlir/tf_tfl_passes.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 
+#include "larq_compute_engine/mlir/transforms/passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "tensorflow/compiler/mlir/lite/quantization/quantization_config.h"
 
@@ -11,8 +12,8 @@ namespace tensorflow {
 // Add the TF to TFLite passes into a pass_manager.
 void AddTFToLCETFLConversionPasses(
     const mlir::TFL::QuantizationSpecs& quant_specs,
-    mlir::OpPassManager* pass_manager,
-    bool experimental_enable_bitpacked_activations = false);
+    mlir::OpPassManager* pass_manager, const LCETarget target = LCETarget::ARM,
+    const bool experimental_enable_bitpacked_activations = false);
 
 }  // namespace tensorflow
 

--- a/larq_compute_engine/mlir/transforms/optimize_patterns_common.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns_common.td
@@ -9,6 +9,8 @@ def F32ElementsAttr : ElementsAttrBase<
 // Checks if the value has only one user.
 def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
+class ConstantValue<string val> : AttrConstraint<CPred<"IsConstantValue($_self, " # val # ")">>;
+
 // TODO: Check shapes before fusing
 multiclass FuseAddOrSubWithBConv2D<dag binaryOp> {
   def : Pat<(binaryOp
@@ -83,13 +85,11 @@ multiclass FuseMulOrDivWithBConv2D<dag binaryOp> {
                 $stride_width),
             [(HasOneUse $conv_output)], (addBenefit 100)>;
 }
-
 foreach binaryOp = [TFL_DivOp, TFL_MulOp] in
   defm : FuseMulOrDivWithBConv2D<binaryOp>;
 
-class ConstantValue<string val> : AttrConstraint<CPred<"IsConstantValue($_self, " # val # ")">>;
 
-// Fuse activation function into BConv2D
+// Fuse an activation function into the BConv2D.
 multiclass FuseActFnIntoConvOpPat<dag ActFnOp, dag ActFnAttr> {
   def : Pat<(ActFnOp
                 (LQ_Bconv2dOp:$conv_output
@@ -152,23 +152,7 @@ multiclass FuseActFnIntoConvOpPat<dag ActFnOp, dag ActFnAttr> {
                 $stride_width),
             [(HasOneUse $conv_output)], (addBenefit 100)>;
 }
-
 foreach actFnPair = [[TFL_ReluOp, TFL_AF_Relu],
                      [TFL_Relu1Op, TFL_AF_Relu1],
                      [TFL_Relu6Op, TFL_AF_Relu6]] in
   defm : FuseActFnIntoConvOpPat<actFnPair[0], actFnPair[1]>;
-
-def : Pat<(LQ_QuantizeOp (TFL_MaxPool2DOp: $pool_output $input,
-                                           $padding,
-                                           $stride_w,
-                                           $stride_h,
-                                           $filter_width,
-                                           $filter_height,
-                                           $fused_activation_function)),
-          (LQ_BMaxPool2dOp (LQ_QuantizeOp $input),
-                           $padding,
-                           $stride_w,
-                           $stride_h,
-                           $filter_width,
-                           $filter_height),
-          [(HasOneUse $pool_output)]>;

--- a/larq_compute_engine/mlir/transforms/optimize_patterns_target_arm.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns_target_arm.td
@@ -1,0 +1,20 @@
+include "larq_compute_engine/mlir/transforms/optimize_patterns_common.td"
+
+// Insert a binary maxpool if a maxpool is followed by a sign op.
+def : Pat<(LQ_QuantizeOp
+              (TFL_MaxPool2DOp:$pool_output
+                  $input,
+                  $padding,
+                  $stride_w,
+                  $stride_h,
+                  $filter_width,
+                  $filter_height,
+                  $fused_activation_function)),
+          (LQ_BMaxPool2dOp
+              (LQ_QuantizeOp $input),
+              $padding,
+              $stride_w,
+              $stride_h,
+              $filter_width,
+              $filter_height),
+          [(HasOneUse $pool_output)]>;

--- a/larq_compute_engine/mlir/transforms/passes.h
+++ b/larq_compute_engine/mlir/transforms/passes.h
@@ -3,6 +3,8 @@
 
 #include "mlir/Pass/Pass.h"
 
+enum LCETarget { ARM = 0, XCORE = 1 };
+
 namespace mlir {
 namespace TFL {
 
@@ -10,11 +12,11 @@ namespace TFL {
 std::unique_ptr<OperationPass<FuncOp>> CreateOpRemovalPass();
 
 // Creates an instance of the TensorFlow dialect PrepareLCE pass.
-std::unique_ptr<OperationPass<FuncOp>> CreatePrepareLCEPass();
+std::unique_ptr<OperationPass<FuncOp>> CreatePrepareLCEPass(LCETarget target);
 
 // Creates an instance of the TensorFlow dialect OptimizeLCE pass.
 std::unique_ptr<OperationPass<FuncOp>> CreateOptimizeLCEPass(
-    bool experimental_enable_bitpacked_activations);
+    LCETarget target, bool experimental_enable_bitpacked_activations);
 
 // Creates an instance of the TensorFlow dialect BitpackWeightsLCE pass.
 std::unique_ptr<OperationPass<FuncOp>> CreateBitpackWeightsLCEPass();

--- a/larq_compute_engine/mlir/transforms/prepare_patterns_common.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns_common.td
@@ -41,14 +41,17 @@ def ValidFilterShape : Constraint<CPred<"HasValidFilterShape($0, $1)">>;
 def IsDataFormatNHWC : ConstantAttr<TF_ConvnetDataFormatAttr, "NHWC">;
 def CreateNoneAttrValue : NativeCodeCall<"$_builder.getUnitAttr()">;
 
-def : Pat<(TF_Conv2DOp
-              (LQ_DequantizeOp: $dequantized_input $input),
-              (ConstantOp: $filter_op $filter),
+// All targets support this pattern with "VALID" padding, but only the "arm"
+// target supports it with "SAME" padding.
+class PrepareBConvPadValue0Pat<string padding_type> :
+      Pat<(TF_Conv2DOp
+              (LQ_DequantizeOp:$dequantized_input $input),
+              (ConstantOp:$filter_op $filter),
               IsIntList1XY1:$strides,
               $use_cudnn,
-              $padding,
+              ConstantAttr<StrAttr, padding_type>:$padding,
               $explicit_padding,
-              IsDataFormatNHWC: $data_format,
+              IsDataFormatNHWC:$data_format,
               IsIntList1XY1:$dilations),
           (LQ_Bconv2dOp
               $input,
@@ -71,6 +74,7 @@ def : Pat<(TF_Conv2DOp
           [(BinaryFilter $filter),
            (ValidFilterShape $dequantized_input, $filter_op)],
           (addBenefit 90)>;
+def : PrepareBConvPadValue0Pat<"VALID">;
 
 def ConstFloatValueIsOne : Constraint<
   CPred<"$0.isa<DenseElementsAttr>() && "
@@ -81,10 +85,10 @@ def SamePadding : Constraint<CPred<"IsSamePadding($0, $1, $2, $3)">>;
 
 def : Pat<(TF_Conv2DOp:$output
               (TF_PadV2Op
-                  (LQ_DequantizeOp: $dequantized_input $input),
+                  (LQ_DequantizeOp:$dequantized_input $input),
                   (ConstantOp $paddings),
                   (ConstantOp $pad_values)),
-              (ConstantOp: $filter_op $filter),
+              (ConstantOp:$filter_op $filter),
               IsIntList1XY1:$strides,
               $use_cudnn,
               ConstantAttr<StrAttr, "VALID">,

--- a/larq_compute_engine/mlir/transforms/prepare_patterns_target_arm.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns_target_arm.td
@@ -1,0 +1,4 @@
+include "larq_compute_engine/mlir/transforms/prepare_patterns_common.td"
+
+// On ARM we support 'same-zero' padding.
+def : PrepareBConvPadValue0Pat<"SAME">;


### PR DESCRIPTION
## What do these changes do?

This PR adds support for a 'target' flag to the LCE converter, with two values: "arm" (the default), and "xcore" (the XMOS xcore.ai board). For the time being, the only difference between the two is that the "arm" target supports 'same zero' padding, and the binary maxpool op, but the "xcore" target does not.

## How Has This Been Tested?

I added a small test case to the Python converter test, but it's not possible to use the end2end tests with the xcore target because the converted models are not compatible with the LCE interpreter (and indeed are not meant to be). Need to work out what to do here.

## Benchmark Results

N/A.

## Related issue number

N/A.