### PR TITLE
Minor update to release workflow version number prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version of the form 1.0.0(.devYYYY.MM.DD)'
+        description: 'Version of the form 1.0.0(.devYYYYMMDD)'
         required: true
 
 env:


### PR DESCRIPTION
For a version number to be [Pep 440 compliant](https://www.python.org/dev/peps/pep-0440/#developmental-releases), there cannot be a full-stop after the `dev`:

> The developmental release segment consists of the string .dev, followed by a non-negative integer value. 