### PR TITLE
Fix Windows release builds.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,15 @@ build:macos --config=noaws --config=nogcp --config=nohdfs --config=nonccl
 build:windows --copt=/D_USE_MATH_DEFINES
 build:windows --host_copt=/D_USE_MATH_DEFINES
 
+# Config to use a mostly-static build and disable modular op registration
+# support (this will revert to loading TensorFlow with RTLD_GLOBAL in Python).
+# By default, TensorFlow will build with a dependence on
+# //tensorflow:libtensorflow_framework.so.
+build:monolithic --define framework_shared_object=false
+
+# On windows, we still link everything into a single DLL.
+build:windows --config=monolithic
+
 # Make sure to include as little of windows.h as possible
 build:windows --copt=-DWIN32_LEAN_AND_MEAN
 build:windows --host_copt=-DWIN32_LEAN_AND_MEAN
@@ -75,15 +84,15 @@ build:windows --linkopt=/OPT:REF
 build:windows --host_linkopt=/OPT:REF
 build:windows --linkopt=/OPT:ICF
 build:windows --host_linkopt=/OPT:ICF
-
 build:windows --copt=/d2ReducedOptimizeHugeFunctions
 build:windows --host_copt=/d2ReducedOptimizeHugeFunctions
+build:windows --experimental_strict_action_env=true
 
 # Verbose failure logs when something goes wrong
 build:windows --verbose_failures
 
 # Suppress C++ compiler warnings, otherwise build logs become 10s of MBs.
-build:windows --copt=/w
+build:windows --copt=/W0
 
 # On windows, we never cross compile
 build:windows --distinct_host_configuration=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
           docker run -e PYTHON_VERSION=${{ matrix.python-version }} \
             -e LCE_RELEASE_VERSION=${{ github.event.inputs.version }} \
             -v ${PWD}:/compute-engine -w /compute-engine \
-            tensorflow/tensorflow:custom-op-ubuntu16 \
+            tensorflow/tensorflow:2.2.0-custom-op-ubuntu16 \
             .github/tools/release_linux.sh
 
           sudo apt-get -y -qq install patchelf --no-install-recommends
@@ -184,27 +184,33 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 4GB
+      - name: Pagefile size
+        run: |
+          (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize
+        shell: pwsh
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build Windows wheels
         run: |
-          export LCE_RELEASE_VERSION=${{ github.event.inputs.version }}
-          export PYTHON_BIN_PATH=$(which python)
-          export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
-
-          mkdir C:/bazel_cache
+          $Env:BAZEL_VC = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
+          set PreferredToolArchitecture=x64
 
           python --version
           python -m pip install wheel setuptools numpy six --no-cache-dir
 
-          ./configure.py
+          "" | python configure.py
 
-          bazelisk --output_base=C:/bazel_cache build :build_pip_pkg --copt=/arch:AVX --enable_runfiles --define=override_eigen_strong_inline=true
+          bazelisk --output_base=C:\build_output build :build_pip_pkg --enable_runfiles --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build --nouse_action_cache --local_ram_resources=4096
           bazel-bin/build_pip_pkg wheelhouse
-
-        shell: bash
+        env:
+          LCE_RELEASE_VERSION: ${{ github.event.inputs.version }}
+        shell: pwsh
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-wheels
@@ -213,7 +219,7 @@ jobs:
   upload-wheels:
     name: Publish wheels to PyPi
     if: github.event_name == 'release'
-    needs: [manylinux-release-wheel, macos-release-wheel]
+    needs: [manylinux-release-wheel, macos-release-wheel, windows-release-wheel]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     container:
-      image: tensorflow/tensorflow:custom-op-ubuntu16
+      image: tensorflow/tensorflow:2.2.0-custom-op-ubuntu16
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
## What do these changes do?

This PR (hopefully) fixes the Windows release builds, by copying in the most recent Windows build config from TensorFlow, using some extra commands that reduce memory usage, and increasing the size of the pagefile (swapfile).

## How Has This Been Tested?

I will trigger a nightly release from this branch.

## Benchmark Results

N/A.

## Related issue number

Relies on #589.