### PR TITLE
Fix release version number for non-manual releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,6 @@ jobs:
           python --version
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
-          export LCE_RELEASE_VERSION=${{ github.event.inputs.version }}
-
           ./configure.py
 
           bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13 --linkopt=-dead_strip --distinct_host_configuration=false
@@ -139,6 +137,8 @@ jobs:
           for f in artifacts/*.whl; do
             delocate-wheel -w wheelhouse $f
           done
+        env:
+          LCE_RELEASE_VERSION: ${{ github.event.inputs.version }}
         shell: bash
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,19 @@ class BinaryDistribution(dist.Distribution):
         return True
 
 
+def get_version_number(default):
+    # The `or default` is because on CI the `getenv` can return the empty string.
+    version = os.getenv("LCE_RELEASE_VERSION", default) or default
+    if "." not in version:
+        raise ValueError(f"Invalid version: {version}")
+    return version
+
+
 ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") else []
 
 setup(
     name="larq-compute-engine",
-    version=os.getenv("LCE_RELEASE_VERSION", "0.5.0"),
+    version=get_version_number(default="0.5.0"),
     python_requires=">=3.6",
     description="Highly optimized inference engine for binarized neural networks.",
     long_description=readme(),


### PR DESCRIPTION
## What do these changes do?

The v0.5.0 release action silently failed to generate valid wheel files: specifically, for macOS and Windows the version number was set as v0.0.0 - this can be seen in the logs: https://github.com/larq/compute-engine/actions/runs/520610384.

I manually cancelled the run just before the PyPI upload step - had I not, I think we would have ended up accidentally publishing v0.0.0 wheels for Mac and Windows.

For some reason (and I didn't realise this was possible) this `os.getenv` call was returning the empty string: https://github.com/larq/compute-engine/blob/aa7ea1b1d4051f4a8b10702f7273d18552df0bbe/setup.py#L24

This PR makes a small change to the way the version number is calculated, and adds a sanity check that throws if the empty string is returned.

## How Has This Been Tested?

Manually generating the package.

## Benchmark Results

N/A.

## Related issue number

N/A.
