### PR TITLE
Update release.yml to actually push Windows wheels.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,11 +230,16 @@ jobs:
         with:
           name: macOS-wheels
           path: macOS-wheels
+      - uses: actions/download-artifact@v2
+        with:
+          name: Windows-wheels
+          path: Windows-wheels
       - run: |
           set -e -x
           mkdir -p dist
           cp Linux-wheels/*.whl dist/
           cp macOS-wheels/*.whl dist/
+          cp Windows-wheels/*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
🤦 https://github.com/larq/compute-engine/actions/runs/522141342 successfully ran and build Linux/Mac/Windows wheels, but only published the Linux/Mac ones. This should fix it. For the v0.5.0 release I will manually upload the built Windows wheels.