### PR TITLE
Automatically upload AAR package to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,21 @@ jobs:
         with:
           name: Android-AAR
           path: lce-lite-*.aar
+      - name: Get Name of Artifact
+        if: github.event_name == 'release'
+        run: |
+          ASSET_NAME=$(ls lce-lite-*.aar | head -n 1)
+          echo "ASSET_NAME=${ASSET_NAME}" >> $GITHUB_ENV
+      - name: Upload Release Asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ASSET_NAME }}
+          asset_name: ${{ env.ASSET_NAME }}
+          asset_content_type: application/octet-stream
 
   macos-release-wheel:
     name: Build release wheels for macOS


### PR DESCRIPTION
This should partially address #602

I manually uploaded the package to the 0.5 release, and this PR should automate it for all future releases