### PR TITLE
Raise an error if mixed-precision models are being converted

### DIFF
--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -113,6 +113,12 @@ def convert_keras_model(
             "Using `experimental_default_int8_range` as fallback quantization stats. "
             "This should only be used for latency tests."
         )
+    if hasattr(model, "dtype_policy") and model.dtype_policy.name == "mixed_float16":
+        raise RuntimeError(
+            "Mixed precision float16 models are not supported by the TFLite converted, "
+            "please convert them to float32 first. See also: "
+            "https://github.com/tensorflow/tensorflow/issues/46380"
+        )
     func = concrete_function_from_keras_model(model)
     if version.parse(tf.__version__) >= version.parse("1.15"):
         frozen_func = convert_variables_to_constants_v2(func, lower_control_flow=False)

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -113,7 +113,7 @@ def convert_keras_model(
             "Using `experimental_default_int8_range` as fallback quantization stats. "
             "This should only be used for latency tests."
         )
-    if hasattr(model, "dtype_policy") and model.dtype_policy.name == "mixed_float16":
+    if hasattr(model, "dtype_policy") and model.dtype_policy.name != "float32":
         raise RuntimeError(
             "Mixed precision float16 models are not supported by the TFLite converted, "
             "please convert them to float32 first. See also: "

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -115,7 +115,7 @@ def convert_keras_model(
         )
     if hasattr(model, "dtype_policy") and model.dtype_policy.name != "float32":
         raise RuntimeError(
-            "Mixed precision float16 models are not supported by the TFLite converted, "
+            "Mixed precision float16 models are not supported by the TFLite converter, "
             "please convert them to float32 first. See also: "
             "https://github.com/tensorflow/tensorflow/issues/46380"
         )


### PR DESCRIPTION
Mixed precision models are not supported by the TFLite conversion step yet (https://github.com/tensorflow/tensorflow/issues/46380), this could in some cases lead to segfaults. This guard prevents that and raises a proper error message before trying to convert such a model.