### PR TITLE
Run AAR build on Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           asset_content_type: application/octet-stream
 
   android-aar:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -106,7 +106,7 @@ jobs:
         run: PYTHONPATH=./ python larq_compute_engine/mlir/python/converter_test.py
 
   Android_AAR:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
 
     steps:


### PR DESCRIPTION
`ubuntu-latest` now points to `ubuntu-20.04` which seems to break the  AAR build. This PR reverts the environment to `ubuntu-18.04` to see whether this makes CI pass again.