### PR TITLE
Add -lm link option to lce_benchmark_model

### DIFF
--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -18,7 +18,9 @@ cc_binary(
             "-pie",  # Android 5.0 and later supports only PIE
             "-lm",  # some builtin ops, e.g., tanh, need -lm
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "-lm",
+        ],
     }),
     deps = [
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?

In a private CI job, the build of the benchmark utility for Aarch32 failed with a linking error:

```
/lib/libstdc++.a(hashtable_c++0x.o): In function `std::__detail::_Prime_rehash_policy::_M_next_bkt(unsigned int) const':
(.text._ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEj+0x74): undefined reference to `ceil'
```

This PR attempts to fix that.