### PR TITLE
Fix lce_benchmark_model linking on Aarch32

### DIFF
--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -19,6 +19,7 @@ cc_binary(
             "-lm",  # some builtin ops, e.g., tanh, need -lm
         ],
         "//conditions:default": [
+            "-lstdc++",
             "-lm",
         ],
     }),


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This is the same as https://github.com/larq/compute-engine/pull/622 but this time actually tested.
The problem was that the unresolved reference to `ceil` did not come from compiled code but from `libstdc++` which appeared all the way at the end of the link list. We had to add `-lm` *after* it which is now accomplished by explicitly adding `libstdc++`.
(Note that the problem only happens for static linking which we enabled recently)