### PR TITLE
Configure the Android SDK/NDK interactively in configure.py.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -123,15 +123,6 @@ build:android_x86_64 --config=android
 build:android_x86_64 --cpu=x86_64
 build:android_x86_64 --fat_apk_cpu=x86_64
 
-# The default android SDK/NDK paths are hardcoded here and the user needs
-# to change the paths according to the local configuration or
-# the "install_android.sh" script
-build --action_env ANDROID_NDK_HOME="/tmp/lce_android/ndk/18.1.5063045"
-build --action_env ANDROID_NDK_API_LEVEL="21"
-build --action_env ANDROID_BUILD_TOOLS_VERSION="28.0.3"
-build --action_env ANDROID_SDK_API_LEVEL="29"
-build --action_env ANDROID_SDK_HOME="/tmp/lce_android"
-
 # Default options should come above this line
 
 # Options from ./configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ jobs:
         with:
           path: /tmp/lce_android
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
-      - name: Configure Bazel
-        run: ./configure.py
-        shell: bash
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
+      - name: Configure Bazel
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/18.1.5063045" ./configure.py
+        shell: bash
       - run: mkdir benchmark-binaries
       - name: Build Benchmark utility for AArch64
         run: |
@@ -98,14 +98,14 @@ jobs:
         with:
           path: /tmp/lce_android
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
-      - name: Configure Bazel
-        run: ./configure.py
-        shell: bash
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
+      - name: Configure Bazel
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/18.1.5063045" ./configure.py
+        shell: bash
       - name: Build LCE AAR
         run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -128,13 +128,13 @@ jobs:
         with:
           path: /tmp/lce_android
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
-      - name: Configure Bazel
-        run: ./configure.py
-        shell: bash
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
+      - name: Configure Bazel
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/18.1.5063045" ./configure.py
+        shell: bash
       - name: Build LCE AAR
         run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh

--- a/configure.py
+++ b/configure.py
@@ -18,10 +18,19 @@
 
 import os
 import platform
+import re
 import subprocess
 import sys
 
 _LCE_BAZELRC = ".lce_configure.bazelrc"
+
+_SUPPORTED_ANDROID_NDK_VERSIONS = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+
+_DEFAULT_PROMPT_ASK_ATTEMPTS = 10
+
+
+class UserInputError(Exception):
+    pass
 
 
 def is_windows():
@@ -96,7 +105,7 @@ def get_var(
     response is empty, use the default.
     Args:
       environ_cp: copy of the os.environ.
-      var_name: string for name of environment variable, e.g. "TF_NEED_CUDA".
+      var_name: string for name of environment variable, e.g. "LCE_NEED_CUDA".
       query_item: string for feature related to the variable, e.g. "CUDA for
         Nvidia GPUs".
       enabled_by_default: boolean for default behavior.
@@ -167,6 +176,70 @@ def get_var(
         else:
             print("Invalid selection: {}".format(user_input_origin))
     return var
+
+
+def prompt_loop_or_load_from_env(
+    environ_cp,
+    var_name,
+    var_default,
+    ask_for_var,
+    check_success,
+    error_msg,
+    suppress_default_error=False,
+    resolve_symlinks=False,
+    n_ask_attempts=_DEFAULT_PROMPT_ASK_ATTEMPTS,
+):
+    """Loop over user prompts for an ENV param until receiving a valid response.
+    For the env param var_name, read from the environment or verify user input
+    until receiving valid input. When done, set var_name in the environ_cp to its
+    new value.
+    Args:
+      environ_cp: (Dict) copy of the os.environ.
+      var_name: (String) string for name of environment variable, e.g. "LCE_MYVAR".
+      var_default: (String) default value string.
+      ask_for_var: (String) string for how to ask for user input.
+      check_success: (Function) function that takes one argument and returns a
+        boolean. Should return True if the value provided is considered valid. May
+        contain a complex error message if error_msg does not provide enough
+        information. In that case, set suppress_default_error to True.
+      error_msg: (String) String with one and only one '%s'. Formatted with each
+        invalid response upon check_success(input) failure.
+      suppress_default_error: (Bool) Suppress the above error message in favor of
+        one from the check_success function.
+      resolve_symlinks: (Bool) Translate symbolic links into the real filepath.
+      n_ask_attempts: (Integer) Number of times to query for valid input before
+        raising an error and quitting.
+    Returns:
+      [String] The value of var_name after querying for input.
+    Raises:
+      UserInputError: if a query has been attempted n_ask_attempts times without
+        success, assume that the user has made a scripting error, and will
+        continue to provide invalid input. Raise the error to avoid infinitely
+        looping.
+    """
+    default = environ_cp.get(var_name) or var_default
+    full_query = "%s [Default is %s]: " % (
+        ask_for_var,
+        default,
+    )
+
+    for _ in range(n_ask_attempts):
+        val = get_from_env_or_user_or_default(environ_cp, var_name, full_query, default)
+        if check_success(val):
+            break
+        if not suppress_default_error:
+            print(error_msg % val)
+        environ_cp[var_name] = ""
+    else:
+        raise UserInputError(
+            "Invalid %s setting was provided %d times in a row. "
+            "Assuming to be a scripting mistake." % (var_name, n_ask_attempts)
+        )
+
+    if resolve_symlinks and os.path.islink(val):
+        val = os.path.realpath(val)
+    environ_cp[var_name] = val
+    return val
 
 
 def run_shell(cmd, allow_non_zero=False, stderr=None):
@@ -359,7 +432,7 @@ def set_windows_build_flags(environ_cp):
 
     if get_var(
         environ_cp,
-        "TF_OVERRIDE_EIGEN_STRONG_INLINE",
+        "LCE_OVERRIDE_EIGEN_STRONG_INLINE",
         "Eigen strong inline",
         True,
         (
@@ -376,6 +449,163 @@ def set_windows_build_flags(environ_cp):
         # conv_grad_ops_3d.cc and conv_ops_3d.cc by 20 minutes,
         # but this also hurts the performance. Let users decide what they want.
         write_to_bazelrc("build --define=override_eigen_strong_inline=true")
+
+
+def create_android_ndk_rule(environ_cp):
+    """Set ANDROID_NDK_HOME and write Android NDK WORKSPACE rule."""
+    if is_windows() or is_cygwin():
+        default_ndk_path = cygpath("%s/Android/Sdk/ndk-bundle" % environ_cp["APPDATA"])
+    elif is_macos():
+        default_ndk_path = "%s/library/Android/Sdk/ndk-bundle" % environ_cp["HOME"]
+    else:
+        default_ndk_path = "%s/Android/Sdk/ndk-bundle" % environ_cp["HOME"]
+
+    def valid_ndk_path(path):
+        return os.path.exists(path) and os.path.exists(
+            os.path.join(path, "source.properties")
+        )
+
+    android_ndk_home_path = prompt_loop_or_load_from_env(
+        environ_cp,
+        var_name="ANDROID_NDK_HOME",
+        var_default=default_ndk_path,
+        ask_for_var="Please specify the home path of the Android NDK to use.",
+        check_success=valid_ndk_path,
+        error_msg='The path %s or its child file "source.properties" does not exist.',
+    )
+    write_action_env_to_bazelrc("ANDROID_NDK_HOME", android_ndk_home_path)
+    write_action_env_to_bazelrc(
+        "ANDROID_NDK_API_LEVEL", get_ndk_api_level(environ_cp, android_ndk_home_path)
+    )
+
+
+def create_android_sdk_rule(environ_cp):
+    """Set Android variables and write Android SDK WORKSPACE rule."""
+    if is_windows() or is_cygwin():
+        default_sdk_path = cygpath("%s/Android/Sdk" % environ_cp["APPDATA"])
+    elif is_macos():
+        default_sdk_path = "%s/library/Android/Sdk" % environ_cp["HOME"]
+    else:
+        default_sdk_path = "%s/Android/Sdk" % environ_cp["HOME"]
+
+    def valid_sdk_path(path):
+        return (
+            os.path.exists(path)
+            and os.path.exists(os.path.join(path, "platforms"))
+            and os.path.exists(os.path.join(path, "build-tools"))
+        )
+
+    android_sdk_home_path = prompt_loop_or_load_from_env(
+        environ_cp,
+        var_name="ANDROID_SDK_HOME",
+        var_default=default_sdk_path,
+        ask_for_var="Please specify the home path of the Android SDK to use.",
+        check_success=valid_sdk_path,
+        error_msg=(
+            "Either %s does not exist, or it does not contain the "
+            'subdirectories "platforms" and "build-tools".'
+        ),
+    )
+
+    platforms = os.path.join(android_sdk_home_path, "platforms")
+    api_levels = sorted(os.listdir(platforms))
+    api_levels = [x.replace("android-", "") for x in api_levels]
+
+    def valid_api_level(api_level):
+        return os.path.exists(
+            os.path.join(android_sdk_home_path, "platforms", "android-" + api_level)
+        )
+
+    android_api_level = prompt_loop_or_load_from_env(
+        environ_cp,
+        var_name="ANDROID_API_LEVEL",
+        var_default=api_levels[-1],
+        ask_for_var=(
+            "Please specify the Android SDK API level to use. " "[Available levels: %s]"
+        )
+        % api_levels,
+        check_success=valid_api_level,
+        error_msg="Android-%s is not present in the SDK path.",
+    )
+
+    build_tools = os.path.join(android_sdk_home_path, "build-tools")
+    versions = sorted(os.listdir(build_tools))
+
+    def valid_build_tools(version):
+        return os.path.exists(
+            os.path.join(android_sdk_home_path, "build-tools", version)
+        )
+
+    android_build_tools_version = prompt_loop_or_load_from_env(
+        environ_cp,
+        var_name="ANDROID_BUILD_TOOLS_VERSION",
+        var_default=versions[-1],
+        ask_for_var=(
+            "Please specify an Android build tools version to use. "
+            "[Available versions: %s]"
+        )
+        % versions,
+        check_success=valid_build_tools,
+        error_msg="The selected SDK does not have build-tools version %s available.",
+    )
+
+    write_action_env_to_bazelrc(
+        "ANDROID_BUILD_TOOLS_VERSION", android_build_tools_version
+    )
+    write_action_env_to_bazelrc("ANDROID_SDK_API_LEVEL", android_api_level)
+    write_action_env_to_bazelrc("ANDROID_SDK_HOME", android_sdk_home_path)
+
+
+def get_ndk_api_level(environ_cp, android_ndk_home_path):
+    """Gets the appropriate NDK API level to use for the provided Android NDK path."""
+
+    # First check to see if we're using a blessed version of the NDK.
+    properties_path = "%s/source.properties" % android_ndk_home_path
+    if is_windows() or is_cygwin():
+        properties_path = cygpath(properties_path)
+    with open(properties_path, "r") as f:
+        filedata = f.read()
+
+    revision = re.search(r"Pkg.Revision = (\d+)", filedata)
+    if revision:
+        ndk_version = revision.group(1)
+    else:
+        raise Exception("Unable to parse NDK revision.")
+    if int(ndk_version) not in _SUPPORTED_ANDROID_NDK_VERSIONS:
+        print(
+            "WARNING: The NDK version in %s is %s, which is not "
+            "supported by Bazel (officially supported versions: %s). Please use "
+            "another version. Compiling Android targets may result in confusing "
+            "errors.\n"
+            % (android_ndk_home_path, ndk_version, _SUPPORTED_ANDROID_NDK_VERSIONS)
+        )
+
+    # Now grab the NDK API level to use. Note that this is different from the
+    # SDK API level, as the NDK API level is effectively the *min* target SDK
+    # version.
+    platforms = os.path.join(android_ndk_home_path, "platforms")
+    api_levels = sorted(os.listdir(platforms))
+    api_levels = [x.replace("android-", "") for x in api_levels if "android-" in x]
+
+    def valid_api_level(api_level):
+        return os.path.exists(
+            os.path.join(android_ndk_home_path, "platforms", "android-" + api_level)
+        )
+
+    android_ndk_api_level = prompt_loop_or_load_from_env(
+        environ_cp,
+        var_name="ANDROID_NDK_API_LEVEL",
+        var_default="21",  # 21 is required for ARM64 support.
+        ask_for_var=(
+            "Please specify the (min) Android NDK API level to use. "
+            "[Available levels: %s]"
+        )
+        % api_levels,
+        check_success=valid_api_level,
+        error_msg="Android-%s is not present in the NDK path.",
+    )
+
+    return android_ndk_api_level
 
 
 def reset_lce_configure_bazelrc():
@@ -399,6 +629,21 @@ def main():
 
     if is_linux():
         maybe_set_manylinux_toolchain(environ_cp)
+
+    if get_var(
+        environ_cp,
+        "LCE_SET_ANDROID_WORKSPACE",
+        "android workspace",
+        False,
+        (
+            "Would you like to interactively configure ./WORKSPACE for "
+            "Android builds?"
+        ),
+        "Searching for NDK and SDK installations.",
+        "Not configuring the WORKSPACE for Android builds.",
+    ):
+        create_android_ndk_rule(environ_cp)
+        create_android_sdk_rule(environ_cp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This means we don't have to hard-code paths, and Android only needs to be configured when necessary (it won't be configured by default). Configuration code taken from TF.

Hopefully closes #598, which is a prerequisite for upgrading to Bazel 3.7, which is a prerequisite for upgrading to TF 2.5.