### PR TITLE
Enable TensorFlow mobile build config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # Import TensorFlow's configuration first.
 try-import %workspace%/.tensorflow.bazelrc
 
+# Just testing
+build --define mobile=true
+
 # Prevent invalid caching if input files are modified during a build.
 build --experimental_guard_against_concurrent_changes
 


### PR DESCRIPTION
## What do these changes do?
This PR overwrites the [TensorFlow `mobile` build flag](https://github.com/tensorflow/tensorflow/blob/61f439768f2a6b6117e0fbf355365c52332bed74/tensorflow/BUILD#L682-L692). This reduces the amount of targets built by TensorFlow which makes our [Windows wheel builds pass on CI](https://github.com/larq/compute-engine/runs/2550485113).

## How Has This Been Tested?
Let's see what CI thinks about this first. I am not sure if this actually removes some required build targets. This needs a bit more manual testing since usually this is only enabled on operating systems like Android or ChromiumOS...
