### PR TITLE
Add check for float32 in IsBinaryTensor

### DIFF
--- a/larq_compute_engine/mlir/transforms/prepare_tf.cc
+++ b/larq_compute_engine/mlir/transforms/prepare_tf.cc
@@ -63,7 +63,10 @@ bool IsBinaryFilter(Attribute filter_attr) {
   if (!filter_attr.isa<DenseElementsAttr>()) return false;
   auto filter = filter_attr.cast<DenseElementsAttr>();
 
-  auto shape = filter_attr.getType().cast<ShapedType>().getShape();
+  auto filter_type = filter_attr.getType().cast<ShapedType>();
+  auto element_type = filter_type.getElementType();
+  if (!element_type.isF32()) return false;
+  auto shape = filter_type.getShape();
   if (shape.size() != 4) return false;
 
   for (std::size_t h = 0; h < shape[0]; ++h) {


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/master/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
When we try to convert a float16 model, the MLIR converter crashes in `IsBinaryTensor` which assumes the type is float32.
With this fix, float16 models will still fail to convert but that's due to tensorflow not supporting it: it causes an assertion failure somewhere in a pattern in `prepare_tf.cc`.

Alternatively we could try to support bitpacking float16. I did not see a simple way of automatically getting float32 values from a float16 `DenseElementsAttr`, so I think that in order to support that we'd have to explicitly have `if ( float16 ) { ... }` blocks in the code here and also in several other functions that access the filter data (the bitpacking functions).

In any case that won't help us yet since the non-bconv parts of the network will still crash in the tensorflow part of the code.

## How Has This Been Tested?
Tested on a float16 model: still crashes but in TF code and not in our code.

## Related issue number
@lgeiger already commented on a TF issue about this long ago: https://github.com/tensorflow/tensorflow/issues/46380
