### PR TITLE
Fuse `tfl.Quantize(lq.Dequantize(x))` -> `lq.Dequantize(x)`

### DIFF
--- a/larq_compute_engine/mlir/tests/quantize.mlir
+++ b/larq_compute_engine/mlir/tests/quantize.mlir
@@ -27,3 +27,13 @@ func @quantize_bitpacked_bconv2d(%arg0: tensor<1x224x224x1xi32>, %arg1: tensor<3
 // CHECK-NEXT: %0 = "lq.Bconv2d"(%arg0, %arg1, %arg2, %arg3, %arg4)
 // CHECK-NEXT: return %0 : tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>
 }
+
+// CHECK-LABEL: quantize_lce_dequantize
+func @quantize_lce_dequantize(%arg0: tensor<1x112x112x1xi32>) -> tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>> {
+  %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x32xf32>
+  %1 = "tfl.quantize"(%0) {qtype = tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>} : (tensor<1x112x112x32xf32>) -> tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>
+  return %1 : tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>
+
+// CHECK-NEXT: %0 = "lq.Dequantize"(%arg0) : (tensor<1x112x112x1xi32>) -> tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>
+// CHECK-NEXT: return %0 : tensor<1x112x112x32x!quant.uniform<u8:f32, 0.023528476789885875>>
+}

--- a/larq_compute_engine/mlir/transforms/quantize_patterns.td
+++ b/larq_compute_engine/mlir/transforms/quantize_patterns.td
@@ -65,3 +65,7 @@ def : Pat<(TFL_QuantizeOp
               $stride_height,
               $stride_width),
           [(HasOneUse $output)]>;
+
+def : Pat<(TFL_QuantizeOp (LQ_DequantizeOp:$output $input), $qtype),
+          (LQ_DequantizeOp $input),
+          [(HasOneUse $output)]>;


### PR DESCRIPTION
## What do these changes do?
`lq.Dequantize` supports `int8` output, so we can fuse `tfl.Quantize(lq.Dequantize(x))` -> `lq.Dequantize(x)` to remove an unnecessary `tfl.Quantize` op.

## How Has This Been Tested?
Added a MLIR filecheck test.

## Related issue number
I think this will be required to eventually make the unittests of #611 pass. /cc @simonmaurer
