### PR TITLE
Prevent spurious int8 Quantize/Dequantize ops

### DIFF
--- a/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
@@ -98,8 +98,8 @@ pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
     quant_specs.inference_type = tensorflow::DT_QINT8;
     for (auto input_array : input_arrays) {
       // Input inference type is DT_FLOAT, so set the default input ranges
-      // which default to mean=0.0 and std=1.0.
-      quant_specs.input_ranges.push_back({-128.0, 127.0});
+      // to llvm::None.
+      quant_specs.input_ranges.push_back({llvm::None, llvm::None});
     }
     if (!default_ranges.is_none()) {
       quant_specs.default_ranges =


### PR DESCRIPTION
## What do these changes do?

This PR is a bit subtle and changes the input quantization ranges to `None` which is now consistent with the float input type we use. This prevent the [TF quantization pass from adding unnecessary quantize dequantize ops](https://github.com/tensorflow/tensorflow/blob/6d62fcdecedc38f024338662b01240d18dc6f311/tensorflow/compiler/mlir/lite/transforms/prepare_quantize.cc#L201-L215) at the beginning of the network which will not be removed again later.

## How Has This Been Tested?
CI and manually verified  the example of #637

## Related issue number
Fixes #637
