### PR TITLE
Pin flatbuffers to <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ext_modules=ext_modules,
     url="https://larq.dev/",
     install_requires=[
-        "flatbuffers>=1.12",
+        "flatbuffers>=1.12,<2.0",
         "packaging>=19",
         "tqdm>=4",
         "importlib-metadata ~= 2.0 ; python_version<'3.8'",


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
The converter is incompatible with `flatbuffers==2.0` (specifically the re-serialization of a flatbuffer is broken, when we remove the Quantize/Dequantize ops in python) so in this PR we pin `flatbuffers<2.0` just as tensorflow has.