### PR TITLE
Add support for saved model conversion

### DIFF
--- a/larq_compute_engine/__init__.py
+++ b/larq_compute_engine/__init__.py
@@ -1,4 +1,7 @@
-from larq_compute_engine.mlir.python.converter import convert_keras_model
+from larq_compute_engine.mlir.python.converter import (
+    convert_keras_model,
+    convert_saved_model,
+)
 from larq_compute_engine.tflite.python import interpreter as testing
 
 try:
@@ -9,4 +12,4 @@ except ImportError:
 
 __version__ = metadata.version("larq_compute_engine")
 
-__all__ = ["convert_keras_model", "testing"]
+__all__ = ["convert_keras_model", "convert_saved_model", "testing"]

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -335,13 +335,19 @@ tf_cc_binary(
 )
 
 pybind_extension(
-    name = "_graphdef_tfl_flatbuffer",
-    srcs = ["python/graphdef_tfl_flatbuffer.cc"],
-    module_name = "graphdef_tfl_flatbuffer",
+    name = "_tf_tfl_flatbuffer",
+    srcs = [
+        "python/graphdef_tfl_flatbuffer.cc",
+        "python/pybind_export.cc",
+        "python/saved_model_tfl_flatbuffer.cc",
+    ],
+    module_name = "tf_tfl_flatbuffer",
     deps = [
         ":lce_tfl_passes",
         ":tf_to_tfl_flatbuffer",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite:tf_to_tfl_flatbuffer",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite/python:tf_tfl_flatbuffer_helpers",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:convert_graphdef",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:import_utils",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:mlir_roundtrip_flags",
@@ -366,7 +372,7 @@ py_library(
         ":tflite_schema_py",
     ],
     deps = [
-        ":_graphdef_tfl_flatbuffer",
+        ":_tf_tfl_flatbuffer",
     ],
 )
 

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -117,7 +117,8 @@ def convert_saved_model(
             must be either `tf.float32` or `tf.int8`.
         inference_output_type: Data type of the output layer. Defaults to `tf.float32`,
             must be either `tf.float32` or `tf.int8`.
-        target: Target hardware platform. Must be "arm", or "xcore".
+        target: Target hardware platform. Defaults to "arm", must be either "arm"
+            or "xcore".
         experimental_default_int8_range: Tuple of integers representing `(min, max)`
             range values for all arrays without a specified range. Intended for
             experimenting with quantization via "dummy quantization". (default None)
@@ -198,7 +199,8 @@ def convert_keras_model(
             must be either `tf.float32` or `tf.int8`.
         inference_output_type: Data type of the output layer. Defaults to `tf.float32`,
             must be either `tf.float32` or `tf.int8`.
-        target: Target hardware platform. Must be "arm" or "xcore".
+        target: Target hardware platform. Defaults to "arm", must be either "arm"
+            or "xcore".
         experimental_default_int8_range: Tuple of integers representing `(min, max)`
             range values for all arrays without a specified range. Intended for
             experimenting with quantization via "dummy quantization". (default None)

--- a/larq_compute_engine/mlir/python/converter.py
+++ b/larq_compute_engine/mlir/python/converter.py
@@ -1,11 +1,15 @@
+import os
 from packaging import version
 import warnings
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import tensorflow as tf
+import tempfile
 
-from larq_compute_engine.mlir._graphdef_tfl_flatbuffer import (
+from larq_compute_engine.mlir._tf_tfl_flatbuffer import (
     convert_graphdef_to_tflite_flatbuffer,
+    convert_saved_model_to_tflite_flatbuffer,
 )
+
 from larq_compute_engine.mlir.python.util import modify_integer_quantized_model_io_type
 
 from tensorflow.core.framework.types_pb2 import DataType
@@ -55,6 +59,81 @@ def _contains_training_quant_op(graph_def):
             if node_def.op in training_quant_ops:
                 return True
     return False
+
+
+def convert_saved_model(
+    saved_model_dir: Union[str, os.PathLike],
+    *,  # Require remaining arguments to be keyword-only.
+    inference_input_type: tf.DType = tf.float32,
+    inference_output_type: tf.DType = tf.float32,
+    target: str = "arm",
+    experimental_default_int8_range: Optional[Tuple[float, float]] = None,
+    experimental_enable_bitpacked_activations: bool = False,
+) -> bytes:
+    """Converts a SavedModel to TFLite flatbuffer.
+
+    !!! example
+        ```python
+        tflite_model = convert_saved_model(saved_model_dir)
+        with open("/tmp/my_model.tflite", "wb") as f:
+            f.write(tflite_model)
+        ```
+
+    # Arguments
+        saved_model_dir: SavedModel directory to convert.
+        inference_input_type: Data type of the input layer. Defaults to `tf.float32`,
+            must be either `tf.float32` or `tf.int8`.
+        inference_output_type: Data type of the output layer. Defaults to `tf.float32`,
+            must be either `tf.float32` or `tf.int8`.
+        target: Target hardware platform. Must be "arm", or "xcore".
+        experimental_default_int8_range: Tuple of integers representing `(min, max)`
+            range values for all arrays without a specified range. Intended for
+            experimenting with quantization via "dummy quantization". (default None)
+        experimental_enable_bitpacked_activations: Enable an experimental
+            converter optimisation that attempts to reduce intermediate
+            activation memory usage by bitpacking the activation tensor between
+            consecutive binary convolutions where possible.
+
+    # Returns
+        The converted data in serialized format.
+    """
+    if version.parse(tf.__version__) < version.parse("2.2"):
+        raise RuntimeError(
+            "TensorFlow 2.2 or newer is required for saved model conversion."
+        )
+
+    saved_model_dir = str(saved_model_dir)
+    saved_model_tags = [tf.saved_model.SERVING]
+    saved_model_exported_names = [tf.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+
+    from tensorflow.python.saved_model import loader_impl
+
+    saved_model_pb, _ = loader_impl.parse_saved_model_with_debug_info(saved_model_dir)
+
+    saved_model_version = saved_model_pb.saved_model_schema_version
+    if saved_model_version not in (1, 2):
+        raise ValueError(
+            f"SavedModel file format({saved_model_version}) is not supported"
+        )
+
+    tflite_buffer = convert_saved_model_to_tflite_flatbuffer(
+        saved_model_dir,
+        saved_model_tags,
+        saved_model_exported_names,
+        saved_model_version,
+        target,
+        experimental_default_int8_range,
+        experimental_enable_bitpacked_activations,
+    )
+
+    if inference_input_type != tf.float32 or inference_output_type != tf.float32:
+        tflite_buffer = modify_integer_quantized_model_io_type(
+            tflite_buffer,
+            inference_input_type=inference_input_type,
+            inference_output_type=inference_output_type,
+        )
+
+    return tflite_buffer
 
 
 def convert_keras_model(
@@ -121,11 +200,30 @@ def convert_keras_model(
             "This should only be used for latency tests."
         )
     if hasattr(model, "dtype_policy") and model.dtype_policy.name != "float32":
-        raise RuntimeError(
+        raise ValueError(
             "Mixed precision float16 models are not supported by the TFLite converter, "
             "please convert them to float32 first. See also: "
             "https://github.com/tensorflow/tensorflow/issues/46380"
         )
+
+    # First attempt conversion as saved model
+    try:
+        with tempfile.TemporaryDirectory() as saved_model_dir:
+            model.save(saved_model_dir, save_format="tf")
+
+            return convert_saved_model(
+                saved_model_dir,
+                inference_input_type=inference_input_type,
+                inference_output_type=inference_output_type,
+                experimental_default_int8_range=experimental_default_int8_range,
+                experimental_enable_bitpacked_activations=experimental_enable_bitpacked_activations,
+                target=target,
+            )
+    except Exception:
+        warnings.warn(
+            "Saved-model conversion failed, falling back to graphdef-based conversion."
+        )
+
     func = concrete_function_from_keras_model(model)
     if version.parse(tf.__version__) >= version.parse("1.15"):
         frozen_func = convert_variables_to_constants_v2(func, lower_control_flow=False)
@@ -168,6 +266,7 @@ def convert_keras_model(
         experimental_default_int8_range,
         experimental_enable_bitpacked_activations,
     )
+
     if should_quantize and (
         inference_input_type != tf.float32 or inference_output_type != tf.float32
     ):

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -7,14 +7,14 @@ from tensorflow.python.eager import context
 
 sys.modules["importlib.metadata"] = mock.MagicMock()
 sys.modules["importlib_metadata"] = mock.MagicMock()
-sys.modules["larq_compute_engine.mlir._graphdef_tfl_flatbuffer"] = mock.MagicMock()
+sys.modules["larq_compute_engine.mlir._tf_tfl_flatbuffer"] = mock.MagicMock()
 sys.modules[
     "larq_compute_engine.tflite.python.interpreter_wrapper_lite"
 ] = mock.MagicMock()
 sys.modules["larq_compute_engine.mlir.python.tflite_schema"] = mock.MagicMock()
 
 from larq_compute_engine.mlir.python.converter import convert_keras_model
-from larq_compute_engine.mlir._graphdef_tfl_flatbuffer import (
+from larq_compute_engine.mlir._tf_tfl_flatbuffer import (
     convert_graphdef_to_tflite_flatbuffer as mocked_converter,
 )
 

--- a/larq_compute_engine/mlir/python/converter_test.py
+++ b/larq_compute_engine/mlir/python/converter_test.py
@@ -1,7 +1,9 @@
 import sys
 import unittest
+from packaging import version
 from unittest import mock
 
+import tensorflow as tf
 import larq_zoo as lqz
 from tensorflow.python.eager import context
 
@@ -15,7 +17,8 @@ sys.modules["larq_compute_engine.mlir.python.tflite_schema"] = mock.MagicMock()
 
 from larq_compute_engine.mlir.python.converter import convert_keras_model
 from larq_compute_engine.mlir._tf_tfl_flatbuffer import (
-    convert_graphdef_to_tflite_flatbuffer as mocked_converter,
+    convert_graphdef_to_tflite_flatbuffer as mocked_graphdef_converter,
+    convert_saved_model_to_tflite_flatbuffer as mocked_saved_model_converter,
 )
 
 
@@ -24,17 +27,22 @@ class TestConverter(unittest.TestCase):
         with context.eager_mode():
             model = lqz.sota.QuickNet(weights=None)
             convert_keras_model(model)
-        mocked_converter.assert_called_once_with(
-            mock.ANY,
-            ["input_1"],
-            ["DT_FLOAT"],
-            [[1, 224, 224, 3]],
-            ["Identity"],
-            False,
-            "arm",
-            None,
-            False,
-        )
+        if version.parse(tf.__version__) < version.parse("2.2"):
+            mocked_graphdef_converter.assert_called_once_with(
+                mock.ANY,
+                ["input_1"],
+                ["DT_FLOAT"],
+                [[1, 224, 224, 3]],
+                ["Identity"],
+                False,
+                "arm",
+                None,
+                False,
+            )
+        else:
+            mocked_saved_model_converter.assert_called_once_with(
+                mock.ANY, ["serve"], ["serving_default"], 1, "arm", None, False
+            )
 
     def test_wrong_arg(self):
         with self.assertRaises(ValueError):

--- a/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/graphdef_tfl_flatbuffer.cc
@@ -12,7 +12,6 @@
 #include "pybind11/stl.h"
 #include "tensorflow/compiler/mlir/lite/quantization/quantization_config.h"
 #include "tensorflow/compiler/mlir/lite/transforms/passes.h"
-#include "tensorflow/compiler/mlir/op_or_arg_name_mapper.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/import_model.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/mlir_roundtrip_flags.h"
 #include "tensorflow/compiler/mlir/tensorflow/utils/dump_mlir_util.h"
@@ -118,8 +117,3 @@ pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
 }
 
 }  // namespace tensorflow
-
-PYBIND11_MODULE(_graphdef_tfl_flatbuffer, m) {
-  m.def("convert_graphdef_to_tflite_flatbuffer",
-        &tensorflow::ConvertGraphDefToTFLiteFlatBuffer);
-};

--- a/larq_compute_engine/mlir/python/pybind_export.cc
+++ b/larq_compute_engine/mlir/python/pybind_export.cc
@@ -1,0 +1,32 @@
+#include "pybind11/pybind11.h"
+#include "pybind11/pytypes.h"
+#include "pybind11/stl.h"
+
+namespace tensorflow {
+
+using std::string;
+
+pybind11::bytes ConvertGraphDefToTFLiteFlatBuffer(
+    const pybind11::bytes& graphdef_bytes,
+    const std::vector<string>& input_arrays,
+    const std::vector<string>& input_dtypes,
+    const std::vector<std::vector<int>>& input_shapes,
+    const std::vector<string>& output_arrays, const bool should_quantize,
+    const std::string& target_str, const pybind11::object& default_ranges,
+    const bool experimental_enable_bitpacked_activations);
+
+pybind11::bytes ConvertSavedModelToTFLiteFlatBuffer(
+    const std::string& saved_model_dir,
+    const std::vector<std::string>& saved_model_tags,
+    const std::vector<std::string>& exported_names,
+    const int saved_model_version, const std::string& target_str,
+    const pybind11::object& default_ranges,
+    const bool experimental_enable_bitpacked_activations);
+}  // namespace tensorflow
+
+PYBIND11_MODULE(_tf_tfl_flatbuffer, m) {
+  m.def("convert_graphdef_to_tflite_flatbuffer",
+        &tensorflow::ConvertGraphDefToTFLiteFlatBuffer);
+  m.def("convert_saved_model_to_tflite_flatbuffer",
+        &tensorflow::ConvertSavedModelToTFLiteFlatBuffer);
+};

--- a/larq_compute_engine/mlir/python/saved_model_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/saved_model_tfl_flatbuffer.cc
@@ -1,3 +1,19 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright (C) 2021 Larq Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <exception>
 #include <utility>
 

--- a/larq_compute_engine/mlir/python/saved_model_tfl_flatbuffer.cc
+++ b/larq_compute_engine/mlir/python/saved_model_tfl_flatbuffer.cc
@@ -1,0 +1,162 @@
+#include <exception>
+#include <utility>
+
+#include "absl/types/span.h"
+#include "larq_compute_engine/mlir/tf_tfl_passes.h"
+#include "larq_compute_engine/mlir/tf_to_tfl_flatbuffer.h"
+#include "llvm/ADT/None.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Transforms/ViewOpGraph.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/pytypes.h"
+#include "pybind11/stl.h"
+#include "tensorflow/compiler/mlir/lite/python/tf_tfl_flatbuffer_helpers.h"
+#include "tensorflow/compiler/mlir/lite/tf_to_tfl_flatbuffer.h"
+#include "tensorflow/compiler/mlir/lite/transforms/passes.h"
+#include "tensorflow/compiler/mlir/tensorflow/translate/import_model.h"
+#include "tensorflow/compiler/mlir/tensorflow/translate/mlir_roundtrip_flags.h"
+#include "tensorflow/compiler/mlir/tensorflow/utils/dump_mlir_util.h"
+#include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/protobuf/graph_debug_info.pb.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+
+namespace tensorflow {
+
+Status GetNumInputs(mlir::OwningModuleRef* module, int* num_inputs) {
+  *num_inputs = 0;
+  mlir::FuncOp entry_function = nullptr;
+  for (auto func : module->get().getOps<mlir::FuncOp>()) {
+    if (auto tf_attrs =
+            func->getAttrOfType<mlir::DictionaryAttr>("tf.entry_function")) {
+      // TODO(jaesung): There could be multiple entry functions. Let's handle
+      // such cases if there are any needs for that.
+      if (entry_function != nullptr) {
+        return errors::InvalidArgument(
+            "There should be only one tf.entry_function");
+      }
+      entry_function = func;
+    }
+  }
+  if (entry_function == nullptr) {
+    return errors::InvalidArgument("no tf.entry_function found");
+  }
+
+  // Get the list of input Op names from the function attribute.
+  mlir::DictionaryAttr tf_attrs =
+      entry_function->getAttrOfType<mlir::DictionaryAttr>("tf.entry_function");
+  llvm::SmallVector<llvm::StringRef, 4> function_input_names;
+  auto input_attr = tf_attrs.get("inputs");
+  if (!input_attr) {
+    return errors::InvalidArgument("no inputs attribute found");
+  }
+  auto input_names = input_attr.cast<mlir::StringAttr>().getValue();
+  input_names.split(function_input_names, ",");
+  *num_inputs = function_input_names.size();
+  return Status::OK();
+}
+
+pybind11::bytes ConvertSavedModelToTFLiteFlatBuffer(
+    const std::string& saved_model_dir,
+    const std::vector<std::string>& saved_model_tags,
+    const std::vector<std::string>& exported_names,
+    const int saved_model_version, const std::string& target_str,
+    const pybind11::object& default_ranges,
+    const bool experimental_enable_bitpacked_activations) {
+  mlir::MLIRContext context;
+  Status status;
+
+  LCETarget target;
+  if (target_str == "arm") {
+    target = LCETarget::ARM;
+  } else if (target_str == "xcore") {
+    target = LCETarget::XCORE;
+  } else {
+    throw std::runtime_error("Invalid target.");
+  }
+
+  if (exported_names.size() != 1) {
+    throw std::runtime_error("Only a single exported name is supported.");
+  }
+
+  tensorflow::GraphImportConfig specs;
+  specs.upgrade_legacy = true;
+
+  absl::Span<const std::string> custom_opdefs;
+
+  // Register all custom ops, including user-specified custom ops.
+  const toco::TocoFlags toco_flags;
+  status = internal::RegisterAllCustomOps(toco_flags);
+  if (!status.ok()) {
+    throw std::runtime_error(status.error_message());
+  }
+
+  // Some weirdness required to convert the vector<string> to an
+  // absl::Span<std::string>
+  auto exported_names_vector =
+      std::vector<std::string>(exported_names.begin(), exported_names.end());
+  absl::Span<std::string> exported_names_span(exported_names_vector);
+
+  std::unordered_set<std::string> tags(saved_model_tags.begin(),
+                                       saved_model_tags.end());
+
+  auto module =
+      ImportSavedModel(saved_model_dir, saved_model_version, tags,
+                       custom_opdefs, exported_names_span, specs, &context);
+
+  if (!module.ok()) {
+    throw std::runtime_error("Could not import SavedModel.");
+  }
+
+  int num_inputs = 0;
+  status = GetNumInputs(&module.ValueOrDie(), &num_inputs);
+  if (!status.ok()) {
+    throw std::runtime_error(status.error_message());
+  }
+
+  mlir::TFL::QuantizationSpecs quant_specs;
+  // Normally we'd only set `inference_type` to QINT8 when there are fake_quant
+  // nodes in the graph. However this did not work reliably, and even for float
+  // models it is fine to set the inference type to QINT8, so we do that by
+  // default.
+  quant_specs.inference_type = tensorflow::DT_QINT8;
+  for (int i = 0; i < num_inputs; ++i) {
+    // Input inference type is DT_FLOAT, so set the default input ranges
+    // to llvm::None.
+    quant_specs.input_ranges.push_back({llvm::None, llvm::None});
+  }
+  if (!default_ranges.is_none()) {
+    quant_specs.default_ranges =
+        default_ranges.cast<std::pair<double, double>>();
+  }
+
+  mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+  tensorflow::SetCrashReproducer(pm);
+
+  tensorflow::AddTFToLCETFLConversionPasses(
+      quant_specs, &pm, target, experimental_enable_bitpacked_activations);
+
+  // Convert back to outlined while format for export back to flatbuffer.
+  pm.addPass(mlir::TFL::CreateWhileOutlinePass());
+  pm.addPass(mlir::TFL::CreateRuntimeVerifyPass());
+
+  std::string result;
+  status = ConvertTFExecutorToFlatbuffer(
+      module->get(), /*export_to_mlir=*/false, &result, &pm);
+
+  if (!status.ok()) {
+    throw std::runtime_error("Could not translate to flatbuffer.");
+  }
+
+  return pybind11::bytes(result);
+}
+
+}  // namespace tensorflow


### PR DESCRIPTION
## What do these changes do?
This PR enables support for directly converting saved models in TensorFlow.

## How Has This Been Tested?
We've been using this code internally for a while now and added some test cases to the end2end tests

## Related issue number
Closes #407

Co-Authored-By: Tom Bannink <Tombana@users.noreply.github.com>