### PR TITLE
Support for macos_arm64 platform

### DIFF
--- a/larq_compute_engine/core/bitpacking/BUILD
+++ b/larq_compute_engine/core/bitpacking/BUILD
@@ -11,6 +11,9 @@ cc_library(
         "@org_tensorflow//tensorflow:android_arm64": [
             "bitpack_aarch64.h",
         ],
+        "@org_tensorflow//tensorflow:macos_arm64": [
+            "bitpack_aarch64.h",
+        ],
         "//conditions:default": [],
     }),
     deps = [


### PR DESCRIPTION
## What do these changes do?
With the latest LCE release [v0.6](https://github.com/larq/compute-engine/releases/tag/v0.6.0) the TensorFlow dependency has been upgraded to `2.5.0` including relevant changes to support compilation for the `macos_arm64` platform using the recent Apple M1 ARM processor.
This also included upstream dependencies on `XNNPACK` and `pthreadpool` as needed by the LCE (`lce_benchmark_model`/`lce_minimal`) build process.

Starting with latest bazel versions for `arm64` this small PR (given all upstream changes in TF) allows building LCE for Apple M1.

Feel free to check out the discussions here: [XNNPACK](https://github.com/google/XNNPACK/pull/1327)/[pthreadpool](https://github.com/Maratyszcza/pthreadpool/pull/14)/[TF pip package](https://github.com/tensorflow/tensorflow/pull/47639)/[TFLite](https://github.com/tensorflow/tensorflow/pull/47437)

## How Has This Been Tested?
```
bazel-3.7.2-arm64 build -c opt --config=macos_arm64 --macos_cpus=arm64 //larq_compute_engine/tflite/benchmark:lce_benchmark_model`
```
or with a more recent version of bazel (as of [bazel@492829](https://github.com/bazelbuild/bazel/commit/492829))
```
bazel-4.0.0-arm64 build -c opt --macos_cpus=arm64 //larq_compute_engine/tflite/benchmark:lce_benchmark_model`
```
## Benchmark Results
<!-- Please provide new benchmark results on supported platforms if you believe these changes affect the LCE latency performance. -->

The table below presents **single-/multi-threaded** performance of Larq Compute Engine [v0.6](https://github.com/larq/compute-engine/releases/tag/v0.6.0) on
different versions of QuickNet (trained on ImageNet dataset, released on [Larq Zoo](https://docs.larq.dev/zoo/))
on an [Apple mac mini 2020 (M1)](https://www.apple.com/uk/mac-mini/):

| Model                                                                                                                                                                      | Top-1 Accuracy | mac mini M1, ms (1 thread) | mac mini M1, ms (1 thread w/ XNNPACK) |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :--------------------: | :--------------------: |
| [QuickNetSmall](https://docs.larq.dev/zoo/api/sota/#quicknetsmall) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_small_weights.h5))                        |     59.4 %     |          4.0          |          3.5          |
| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_weights.h5)) |     63.3 %     |          5.8          |          5.4          |
| [QuickNetLarge](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_large_weights.h5))             |     66.9 %     |          9.9          |          9.5          |

| Model                                                                                                                                                                      | Top-1 Accuracy | mac mini M1, ms (4 threads) | mac mini M1, ms (4 threads w/ XNNPACK) |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :--------------------: | :--------------------: |
| [QuickNetSmall](https://docs.larq.dev/zoo/api/sota/#quicknetsmall) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_small_weights.h5))                        |     59.4 %     |          1.8          |          1.9          |
| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_weights.h5)) |     63.3 %     |          2.5          |          2.6          |
| [QuickNetLarge](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v1.0/quicknet_large_weights.h5))             |     66.9 %     |          3.9          |          4.1          |


## Related issue number
#604 
