### PR TITLE
Disable mkl for windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,9 @@ jobs:
           $Env:BAZEL_VC = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
           set PreferredToolArchitecture=x64
 
+          # The default is "/arch:AVX", which we don't want.
+          $Env:CC_OPT_FLAGS = "/O2"
+
           python --version
           python -m pip install wheel setuptools numpy six --no-cache-dir
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,10 @@ http_archive(
     name = "org_tensorflow",
     patch_args = ["-p1"],
     patch_tool = "patch",
-    patches = ["//third_party/tensorflow_patches:tf_pr_48546.patch"],
+    patches = [
+        "//third_party/tensorflow_patches:tf_pr_48546.patch",
+        "//third_party/tensorflow_patches:disable_forced_mkl.patch",
+    ],
     sha256 = "233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c",
     strip_prefix = "tensorflow-2.5.0",
     urls = [

--- a/third_party/tensorflow_patches/disable_forced_mkl.patch
+++ b/third_party/tensorflow_patches/disable_forced_mkl.patch
@@ -1,0 +1,27 @@
+diff --git a/third_party/mkl/build_defs.bzl b/third_party/mkl/build_defs.bzl
+index 806b157bad6..6c9f0172b97 100644
+--- a/third_party/mkl/build_defs.bzl
++++ b/third_party/mkl/build_defs.bzl
+@@ -33,8 +33,9 @@ def if_mkl(if_true, if_false = []):
+     """
+     return select({
+         "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64": if_true,
+-        "@org_tensorflow//tensorflow:linux_x86_64": if_true,
+-        "@org_tensorflow//tensorflow:windows": if_true,
++        "@org_tensorflow//third_party/mkl:build_with_mkl_lnx_x64": if_true,
++        "@org_tensorflow//third_party/mkl:build_with_mkl_lnx_openmp": if_true,
++        "@org_tensorflow//third_party/mkl:build_with_mkl_windows_openmp": if_true,
+         "//conditions:default": if_false,
+     })
+
+@@ -102,8 +103,9 @@ def mkl_deps():
+     """
+     return select({
+         "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64": ["@mkl_dnn_acl_compatible//:mkl_dnn_acl"],
+-        "@org_tensorflow//tensorflow:linux_x86_64": ["@mkl_dnn_v1//:mkl_dnn"],
+-        "@org_tensorflow//tensorflow:windows": ["@mkl_dnn_v1//:mkl_dnn"],
++        "@org_tensorflow//third_party/mkl:build_with_mkl_lnx_x64":  ["@mkl_dnn_v1//:mkl_dnn"],
++        "@org_tensorflow//third_party/mkl:build_with_mkl_lnx_openmp":  ["@mkl_dnn_v1//:mkl_dnn"],
++        "@org_tensorflow//third_party/mkl:build_with_mkl_windows_openmp": ["@mkl_dnn_v1//:mkl_dnn"],
+         "//conditions:default": [],
+     })


### PR DESCRIPTION
This PR adds a Bazel patch to the TF repo that disables MKL for Windows and Linux (unless the `build_with_mkl`/`enable_mkl` Bazel flags are provided).

It also removes the `/arch:AVX` build flag, which hopefully makes codegen a bit faster.

The goal is to get our Windows release builds to successfully complete within the 6 hour time limit of GitHubActions.

A test release from this branch passes (with Windows build durations of 5h40, 5h28, 5h12, 4h50): https://github.com/larq/compute-engine/actions/runs/943927532.

The variance on these Windows build times does seem to be pretty high, and those times are still quite close to the 6 hour limit, so I'm not convinced that even after doing this we could rely on these builds passing.