### PR TITLE
Extend quantiser support so as to accelerate more binary models.

### DIFF
--- a/larq_compute_engine/core/bitpacking/bitpack_aarch64.h
+++ b/larq_compute_engine/core/bitpacking/bitpack_aarch64.h
@@ -9,12 +9,20 @@
 
 #include "larq_compute_engine/core/types.h"
 #include "ruy/profiler/instrumentation.h"
+#include "tensorflow/lite/kernels/op_macros.h"
 
 namespace compute_engine {
 namespace core {
 namespace bitpacking {
 
+template <typename T>
+inline void bitpack_aarch64_4x32(const T* input, std::size_t num_blocks,
+                                 TBitpacked* output, const T zero_point) {
+  TFLITE_ASSERT_FALSE;
+}
+
 // Bitpack an array of `4 * 32 * num_blocks` floats.
+template <>
 inline void bitpack_aarch64_4x32(const float* input, std::size_t num_blocks,
                                  TBitpacked* output,
                                  const float zero_point /*ignored*/) {
@@ -227,6 +235,7 @@ inline void bitpack_aarch64_4x32(const float* input, std::size_t num_blocks,
 }
 
 // Bitpack an array of `4 * 32 * num_blocks` int8 bytes.
+template <>
 inline void bitpack_aarch64_4x32(const std::int8_t* input,
                                  std::size_t num_blocks, TBitpacked* output,
                                  const std::int8_t zero_byte) {

--- a/larq_compute_engine/mlir/ir/lce_ops.td
+++ b/larq_compute_engine/mlir/ir/lce_ops.td
@@ -70,11 +70,11 @@ def LQ_QuantizeOp : LQ_Op<"Quantize", [NoSideEffect]> {
   let summary = "Binary quantize operator";
 
   let description = [{
-Converts floating point or integer tensors to binarized bitpacked tensors.
+Converts floating point, integer, or boolean tensors to binarized bitpacked tensors.
   }];
 
   let arguments = (ins
-    TensorOf<[BF16, F16, F32, F64, I32, I64, QI8, QI16]>:$x
+    TensorOf<[BF16, F16, F32, F64, I32, I64, QI8, QI16, I1]>:$x
   );
 
   let results = (outs
@@ -90,7 +90,7 @@ def LQ_DequantizeOp : LQ_Op<"Dequantize", [NoSideEffect]> {
   let summary = "Binary dequantize operator";
 
   let description = [{
-Converts binarized bitpacked tensors to floating point or integer tensors.
+Converts binarized bitpacked tensors to floating point, integer, or boolean tensors.
   }];
 
   let arguments = (ins
@@ -98,7 +98,7 @@ Converts binarized bitpacked tensors to floating point or integer tensors.
   );
 
   let results = (outs
-    TensorOf<[BF16, F16, F32, F64, I32, I64, QI8, QI16]>:$y
+    TensorOf<[BF16, F16, F32, F64, I32, I64, QI8, QI16, I1]>:$y
   );
 
   let hasFolder = 1;

--- a/larq_compute_engine/mlir/transforms/optimize_patterns_common.td
+++ b/larq_compute_engine/mlir/transforms/optimize_patterns_common.td
@@ -11,6 +11,30 @@ def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
 class ConstantValue<string val> : AttrConstraint<CPred<"IsConstantValue($_self, " # val # ")">>;
 
+def : Pat<(LQ_QuantizeOp
+              (TFL_GreaterEqualOp:$ge_op
+                  $input,
+                  (ConstantOp ConstantValue<"0.0f">))),
+          (LQ_QuantizeOp $input),
+          [(HasOneUse $ge_op)],
+          (addBenefit 150)>;
+
+def : Pat<(LQ_QuantizeOp
+              (TFL_GreaterEqualOp:$ge_op
+                  $input,
+                  $threshold)),
+          (LQ_QuantizeOp
+              (TFL_SubOp $input, $threshold, TFL_AF_None)),
+          [(HasOneUse $ge_op)],
+          (addBenefit 100)>;
+
+def : Pat<(LQ_QuantizeOp
+              (TFL_LessEqualOp:$ge_op $lhs, $rhs)),
+          (LQ_QuantizeOp
+              (TFL_GreaterEqualOp $rhs, $lhs)),
+          [(HasOneUse $ge_op)],
+          (addBenefit 100)>;
+
 // TODO: Check shapes before fusing
 multiclass FuseAddOrSubWithBConv2D<Op binaryOp> {
   def : Pat<(binaryOp

--- a/larq_compute_engine/mlir/transforms/prepare_patterns_common.td
+++ b/larq_compute_engine/mlir/transforms/prepare_patterns_common.td
@@ -4,9 +4,56 @@ include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.td"
 include "larq_compute_engine/mlir/ir/lce_ops.td"
 include "larq_compute_engine/mlir/transforms/op_removal_patterns.td"
 
+class ConstantValue<string val> : AttrConstraint<CPred<"IsConstantValue($_self, " # val # ")">>;
 
-// This relies on implementation details of larq.math.sign. We should make
-// this more general in the future
+def CreateTFBroadcastToOp : NativeCodeCall<
+    "$_builder.create<TF::BroadcastToOp>("
+        "$0.getLoc(),"
+        "RankedTensorType::get("
+            "$0.getType().cast<RankedTensorType>().getShape(),"
+            "getElementTypeOrSelf($1.getType())),"
+        "$1,"
+        "$2)">;
+
+def CreateTFShapeOp : NativeCodeCall<
+    "$_builder.create<TF::ShapeOp>($0.getLoc(), $1, $2)">;
+
+// Base quantiser patterns that match the `tf.where` implementation of `ste_sign`.
+multiclass QuantDequantPatterns<Op SelectOp> {
+  def : Pat<(SelectOp:$select_op
+                $cond,
+                (ConstantOp ConstantValue<"1.0f">),
+                (ConstantOp ConstantValue<"-1.0f">)),
+            (LQ_DequantizeOp
+                (LQ_QuantizeOp
+                    (CreateTFBroadcastToOp
+                        $select_op,
+                        $cond,
+                        (CreateTFShapeOp
+                            $select_op,
+                            $select_op,
+                            /*use 32bit*/ConstBoolAttrFalse)))),
+            [], (addBenefit 100)>;
+  def : Pat<(SelectOp:$select_op
+                $cond,
+                (ConstantOp ConstantValue<"-1.0f">),
+                (ConstantOp ConstantValue<"1.0f">)),
+            (LQ_DequantizeOp
+                (LQ_QuantizeOp
+                    (CreateTFBroadcastToOp
+                        $select_op,
+                        (TF_LogicalNotOp $cond),
+                        (CreateTFShapeOp
+                            $select_op,
+                            $select_op,
+                            /*use 32bit*/ConstBoolAttrFalse)))),
+            [], (addBenefit 100)>;
+}
+foreach SelectOp = [TF_SelectOp, TF_SelectV2Op]<Op> in
+  defm : QuantDequantPatterns<SelectOp>;
+
+// A fallback for the old version of `ste_sign` that uses a specific `tf.sign`
+// based implementation of `larq.math.sign`.
 def : Pat<(TF_SignOp (TF_AddV2Op (TF_SignOp $arg), $c)),
           (LQ_DequantizeOp (LQ_QuantizeOp $arg)), [], (addBenefit 100)>;
 def : Pat<(TF_SignOp (TF_AddV2Op $c, (TF_SignOp $arg))),

--- a/larq_compute_engine/mlir/transforms/prepare_tf.cc
+++ b/larq_compute_engine/mlir/transforms/prepare_tf.cc
@@ -36,6 +36,14 @@ struct PrepareLCE : public PassWrapper<PrepareLCE, FunctionPass> {
                        clEnumValN(LCETarget::XCORE, "xcore", "XCORE target"))};
 };
 
+bool IsConstantValue(Attribute values, float expected_value) {
+  if (!values.isa<DenseElementsAttr>()) return false;
+
+  for (auto value : values.cast<DenseElementsAttr>().getValues<float>()) {
+    if (value != expected_value) return false;
+  }
+  return true;
+}
 DenseElementsAttr GetConstantVector(Attribute filter, float val) {
   auto filter_type = filter.getType().cast<ShapedType>();
   auto filter_shape = filter_type.getShape();

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -41,6 +41,7 @@ cc_library(
         "//larq_compute_engine/core/indirect_bgemm:kernels",
         "@flatbuffers",
         "@org_tensorflow//tensorflow/lite:framework",
+        "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
         "@ruy//ruy/profiler:instrumentation",

--- a/larq_compute_engine/tflite/kernels/quantization.cc
+++ b/larq_compute_engine/tflite/kernels/quantization.cc
@@ -1,9 +1,12 @@
+#include <type_traits>
+
 #include "larq_compute_engine/core/bitpacking/utils.h"
 #include "ruy/profiler/instrumentation.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/cppmath.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/portable_type_to_tflitetype.h"
 
 using namespace tflite;
 
@@ -20,8 +23,9 @@ TfLiteStatus QuantizePrepare(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteTensor* input = GetInput(context, node, 0);
   TfLiteTensor* output = GetOutput(context, node, 0);
 
-  TF_LITE_ENSURE(context,
-                 input->type == kTfLiteFloat32 || input->type == kTfLiteInt8);
+  TF_LITE_ENSURE(context, input->type == kTfLiteFloat32 ||
+                              input->type == kTfLiteInt8 ||
+                              input->type == kTfLiteBool);
   TF_LITE_ENSURE_EQ(context, output->type, kTfLiteInt32);
 
   int num_dims = NumDimensions(input);
@@ -44,8 +48,9 @@ TfLiteStatus DequantizePrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = GetOutput(context, node, 0);
 
   TF_LITE_ENSURE_EQ(context, input->type, kTfLiteInt32);
-  TF_LITE_ENSURE(context,
-                 output->type == kTfLiteFloat32 || output->type == kTfLiteInt8);
+  TF_LITE_ENSURE(context, output->type == kTfLiteFloat32 ||
+                              output->type == kTfLiteInt8 ||
+                              output->type == kTfLiteBool);
 
   int num_dims = NumDimensions(input);
 
@@ -80,6 +85,27 @@ TfLiteStatus QuantizeEval(TfLiteContext* context, TfLiteNode* node) {
   } else if (input->type == kTfLiteInt8) {
     bitpack_tensor(GetTensorShape(input), GetTensorData<std::int8_t>(input),
                    input->params.zero_point, GetTensorData<TBitpacked>(output));
+  } else if (input->type == kTfLiteBool) {
+    // The strategy here is to interpret the input data as an unsigned integer
+    // (of the same width as the bool type for the target). We then call
+    // bitpacking, with a 'zero point' of 1. This means that the value with all
+    // zero bits will be bitpacked as bit 1, and all other values will be
+    // bitpacked as bit 0. Assuming that `false` is represented by a value with
+    // all zero bits, this gives the correct result of bitpacking `false` as bit
+    // 1 and `true` as bit 0.
+
+    static_assert(std::is_same<::tflite::TfLiteTypeToType<kTfLiteBool>::Type,
+                               bool>::value,
+                  "");
+    using BOOL_UINT = std::conditional<
+        sizeof(bool) == 1, std::uint8_t,
+        std::conditional<sizeof(bool) == 2, std::uint16_t,
+                         std::conditional<sizeof(bool) == 4, std::uint32_t,
+                                          std::uint64_t>::type>::type>::type;
+    static_assert(sizeof(bool) == sizeof(BOOL_UINT), "");
+
+    bitpack_tensor(GetTensorShape(input), GetTensorData<BOOL_UINT>(input),
+                   BOOL_UINT(1), GetTensorData<TBitpacked>(output));
   } else {
     return kTfLiteError;
   }
@@ -110,6 +136,9 @@ TfLiteStatus DequantizeEval(TfLiteContext* context, TfLiteNode* node) {
     unpack_matrix(GetTensorData<TBitpacked>(input), num_rows, num_cols,
                   GetTensorData<std::int8_t>(output), zero_bit_result,
                   one_bit_result);
+  } else if (output->type == kTfLiteBool) {
+    unpack_matrix(GetTensorData<TBitpacked>(input), num_rows, num_cols,
+                  GetTensorData<bool>(output), true, false);
   } else {
     return kTfLiteError;
   }

--- a/larq_compute_engine/tflite/tests/quantization_test.cc
+++ b/larq_compute_engine/tflite/tests/quantization_test.cc
@@ -116,6 +116,8 @@ TEST_P(QuantizationOpTest, Float) { TestQuantization<float>(GetParam()); }
 
 TEST_P(QuantizationOpTest, Int8) { TestQuantization<std::int8_t>(GetParam()); }
 
+TEST_P(QuantizationOpTest, Bool) { TestQuantization<bool>(GetParam()); }
+
 INSTANTIATE_TEST_SUITE_P(AllCombinations, QuantizationOpTest,
                          ::testing::Values(std::array<int, 4>{1, 1, 1, 1},
                                            std::array<int, 4>{1, 4, 4, 1},


### PR DESCRIPTION
## What do these changes do?

This PR extends the LCE converter with patterns that support converting `tf.where`-style binary quantisers. It also adds support for binary input/output of `LceQuantize`/`LceDequantize`.

Note that in https://github.com/larq/larq/pull/677 we are moving towards having the Larq quantisers implemented with `tf.where` instead of the current `tf.sign` implementation. The main change is that this PR adds support for converting `tf.where`-style quantisers.

The second change to add support for boolean input, meaning that a wider variety of binary quantisers will be accelerated by LCE. For example, the following wacky quantiser will now convert successfully:
```python
lambda x: tf.where(tf.logical_or(tf.abs(x) < 0.5, tf.abs(x) > 1.0), 1.0, -1.0)
```
![image](https://user-images.githubusercontent.com/7688302/122781493-c87def80-d2a7-11eb-93fb-945591edfa0d.png)

With these changes _any_ binary quantiser that can be implemented with `tf.where(boolean_condition, 1, -1)` can be converted into an `LceQuantize` op (and consequently, a subsequent convolution can be converted to a `BConv2D` and thus accelerated). The `boolean_condition` will be implemented with TFL ops, as in the example above, but since the quantisation in general is so quick compared to the binary convolution this doesn't present much of a performance issue.

## How Has This Been Tested?

MLIR test cases have been added; the end2end tests have been extended.

## Benchmark Results

N/A.

## Related issue number

https://github.com/larq/larq/pull/677