### PR TITLE
Split Python interpreter in two classes

### DIFF
--- a/larq_compute_engine/tflite/python/BUILD
+++ b/larq_compute_engine/tflite/python/BUILD
@@ -30,12 +30,21 @@ pybind_extension(
 )
 
 py_library(
+    name = "interpreter_base",
+    srcs = [
+        "__init__.py",
+        "interpreter_base.py",
+    ],
+)
+
+py_library(
     name = "interpreter",
     srcs = [
         "__init__.py",
         "interpreter.py",
     ],
     deps = [
+        ":interpreter_base",
         ":interpreter_wrapper_lite",
     ],
 )

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -1,4 +1,3 @@
-from larq_compute_engine.tflite.python import interpreter_wrapper_lite
 from larq_compute_engine.tflite.python.interpreter_base import InterpreterBase
 
 __all__ = ["Interpreter"]
@@ -34,7 +33,10 @@ class Interpreter(InterpreterBase):
         num_threads: int = 1,
         use_reference_bconv: bool = False,
     ):
-        interpreter = interpreter_wrapper_lite.LiteInterpreter(
-            flatbuffer_model, num_threads, use_reference_bconv
+        from larq_compute_engine.tflite.python import interpreter_wrapper_lite
+
+        super().__init__(
+            interpreter_wrapper_lite.LiteInterpreter(
+                flatbuffer_model, num_threads, use_reference_bconv
+            )
         )
-        super().__init__(interpreter)

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -20,18 +20,12 @@ class Interpreter(InterpreterBase):
         interpreter.predict(input_data, verbose=1)
         ```
 
-    See the base class `InterpreterBase` for the interface.
+    See the base class `InterpreterBase` for the full interface.
 
     # Arguments
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
         num_threads: The number of threads used by the interpreter.
         use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
-
-    # Attributes
-        input_types: Returns a list of input types.
-        input_shapes: Returns a list of input shapes.
-        output_types: Returns a list of output types.
-        output_shapes: Returns a list of output shapes.
     """
 
     def __init__(

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -1,36 +1,10 @@
-from typing import Iterator, List, Tuple, Union, Optional
-
-import numpy as np
-from tqdm import tqdm
-
 from larq_compute_engine.tflite.python import interpreter_wrapper_lite
+from larq_compute_engine.tflite.python.interpreter_base import InterpreterBase
 
 __all__ = ["Interpreter"]
 
-Data = Union[np.ndarray, List[np.ndarray]]
 
-
-def data_generator(x: Union[Data, Iterator[Data]]) -> Iterator[List[np.ndarray]]:
-    if isinstance(x, np.ndarray):
-        for inputs in x:
-            yield [np.expand_dims(inputs, axis=0)]
-    elif isinstance(x, list):
-        for inputs in zip(*x):
-            yield [np.expand_dims(inp, axis=0) for inp in inputs]
-    elif hasattr(x, "__next__") and hasattr(x, "__iter__"):
-        for inputs in x:
-            if isinstance(inputs, np.ndarray):
-                yield [np.expand_dims(inputs, axis=0)]
-            else:
-                yield [np.expand_dims(inp, axis=0) for inp in inputs]
-    else:
-        raise ValueError(
-            "Expected either a list of inputs or a Numpy array with implicit initial "
-            f"batch dimension or an iterator yielding one of the above. Received: {x}"
-        )
-
-
-class Interpreter:
+class Interpreter(InterpreterBase):
     """Interpreter interface for Larq Compute Engine Models.
 
     !!! warning
@@ -45,6 +19,8 @@ class Interpreter:
         interpreter = Interpreter(lce_model)
         interpreter.predict(input_data, verbose=1)
         ```
+
+    See the base class `InterpreterBase` for the interface.
 
     # Arguments
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
@@ -64,69 +40,7 @@ class Interpreter:
         num_threads: int = 1,
         use_reference_bconv: bool = False,
     ):
-        self.interpreter = interpreter_wrapper_lite.LiteInterpreter(
+        interpreter = interpreter_wrapper_lite.LiteInterpreter(
             flatbuffer_model, num_threads, use_reference_bconv
         )
-
-    @property
-    def input_types(self) -> list:
-        """Returns a list of input types."""
-        return self.interpreter.input_types
-
-    @property
-    def input_shapes(self) -> List[Tuple[int]]:
-        """Returns a list of input shapes."""
-        return self.interpreter.input_shapes
-
-    @property
-    def input_scales(self) -> List[Optional[Union[float, List[float]]]]:
-        """Returns a list of input scales."""
-        return self.interpreter.input_scales
-
-    @property
-    def input_zero_points(self) -> List[Optional[int]]:
-        """Returns a list of input zero points."""
-        return self.interpreter.input_zero_points
-
-    @property
-    def output_types(self) -> list:
-        """Returns a list of output types."""
-        return self.interpreter.output_types
-
-    @property
-    def output_shapes(self) -> List[Tuple[int]]:
-        """Returns a list of output shapes."""
-        return self.interpreter.output_shapes
-
-    @property
-    def output_scales(self) -> List[Optional[Union[float, List[float]]]]:
-        """Returns a list of input scales."""
-        return self.interpreter.output_scales
-
-    @property
-    def output_zero_points(self) -> List[Optional[int]]:
-        """Returns a list of input zero points."""
-        return self.interpreter.output_zero_points
-
-    def predict(self, x: Union[Data, Iterator[Data]], verbose: int = 0) -> Data:
-        """Generates output predictions for the input samples.
-
-        # Arguments
-            x: Input samples. A Numpy array, or a list of arrays in case the model has
-                multiple inputs.
-            verbose: Verbosity mode, 0 or 1.
-
-        # Returns
-            Numpy array(s) of output predictions.
-        """
-
-        data_iterator = data_generator(x)
-        if verbose >= 1:
-            data_iterator = tqdm(data_iterator)
-
-        prediction_iter = (self.interpreter.predict(inputs) for inputs in data_iterator)
-        outputs = [np.concatenate(batches) for batches in zip(*prediction_iter)]
-
-        if len(self.output_shapes) == 1:
-            return outputs[0]
-        return outputs
+        super().__init__(interpreter)

--- a/larq_compute_engine/tflite/python/interpreter_base.py
+++ b/larq_compute_engine/tflite/python/interpreter_base.py
@@ -1,0 +1,110 @@
+from typing import Iterator, List, Tuple, Union, Optional
+
+import numpy as np
+from tqdm import tqdm
+
+Data = Union[np.ndarray, List[np.ndarray]]
+
+
+def data_generator(x: Union[Data, Iterator[Data]]) -> Iterator[List[np.ndarray]]:
+    if isinstance(x, np.ndarray):
+        for inputs in x:
+            yield [np.expand_dims(inputs, axis=0)]
+    elif isinstance(x, list):
+        for inputs in zip(*x):
+            yield [np.expand_dims(inp, axis=0) for inp in inputs]
+    elif hasattr(x, "__next__") and hasattr(x, "__iter__"):
+        for inputs in x:
+            if isinstance(inputs, np.ndarray):
+                yield [np.expand_dims(inputs, axis=0)]
+            else:
+                yield [np.expand_dims(inp, axis=0) for inp in inputs]
+    else:
+        raise ValueError(
+            "Expected either a list of inputs or a Numpy array with implicit initial "
+            f"batch dimension or an iterator yielding one of the above. Received: {x}"
+        )
+
+
+class InterpreterBase:
+    """Interpreter interface for Larq Compute Engine Models.
+
+    !!! example
+        ```python
+        lce_model = convert_keras_model(model)
+        interpreter = Interpreter(lce_model)
+        interpreter.predict(input_data, verbose=1)
+        ```
+
+    # Attributes
+        input_types: Returns a list of input types.
+        input_shapes: Returns a list of input shapes.
+        output_types: Returns a list of output types.
+        output_shapes: Returns a list of output shapes.
+    """
+
+    def __init__(self, interpreter):
+        self.interpreter = interpreter
+
+    @property
+    def input_types(self) -> list:
+        """Returns a list of input types."""
+        return self.interpreter.input_types
+
+    @property
+    def input_shapes(self) -> List[Tuple[int]]:
+        """Returns a list of input shapes."""
+        return self.interpreter.input_shapes
+
+    @property
+    def input_scales(self) -> List[Optional[Union[float, List[float]]]]:
+        """Returns a list of input scales."""
+        return self.interpreter.input_scales
+
+    @property
+    def input_zero_points(self) -> List[Optional[int]]:
+        """Returns a list of input zero points."""
+        return self.interpreter.input_zero_points
+
+    @property
+    def output_types(self) -> list:
+        """Returns a list of output types."""
+        return self.interpreter.output_types
+
+    @property
+    def output_shapes(self) -> List[Tuple[int]]:
+        """Returns a list of output shapes."""
+        return self.interpreter.output_shapes
+
+    @property
+    def output_scales(self) -> List[Optional[Union[float, List[float]]]]:
+        """Returns a list of input scales."""
+        return self.interpreter.output_scales
+
+    @property
+    def output_zero_points(self) -> List[Optional[int]]:
+        """Returns a list of input zero points."""
+        return self.interpreter.output_zero_points
+
+    def predict(self, x: Union[Data, Iterator[Data]], verbose: int = 0) -> Data:
+        """Generates output predictions for the input samples.
+
+        # Arguments
+            x: Input samples. A Numpy array, or a list of arrays in case the model has
+                multiple inputs.
+            verbose: Verbosity mode, 0 or 1.
+
+        # Returns
+            Numpy array(s) of output predictions.
+        """
+
+        data_iterator = data_generator(x)
+        if verbose >= 1:
+            data_iterator = tqdm(data_iterator)
+
+        prediction_iter = (self.interpreter.predict(inputs) for inputs in data_iterator)
+        outputs = [np.concatenate(batches) for batches in zip(*prediction_iter)]
+
+        if len(self.output_shapes) == 1:
+            return outputs[0]
+        return outputs

--- a/larq_compute_engine/tflite/python/interpreter_base.py
+++ b/larq_compute_engine/tflite/python/interpreter_base.py
@@ -29,18 +29,15 @@ def data_generator(x: Union[Data, Iterator[Data]]) -> Iterator[List[np.ndarray]]
 class InterpreterBase:
     """Interpreter interface for Larq Compute Engine Models.
 
-    !!! example
-        ```python
-        lce_model = convert_keras_model(model)
-        interpreter = Interpreter(lce_model)
-        interpreter.predict(input_data, verbose=1)
-        ```
-
     # Attributes
         input_types: Returns a list of input types.
         input_shapes: Returns a list of input shapes.
+        input_scales: Returns a list of input scales.
+        input_zero_points: Returns a list of input zero points.
         output_types: Returns a list of output types.
         output_shapes: Returns a list of output shapes.
+        output_scales: Returns a list of input scales.
+        output_zero_points: Returns a list of input zero points.
     """
 
     def __init__(self, interpreter):


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This splits the `Interpreter` python class in `InterpreterBase` (python-only) and `Interpreter` (including the C++ module). The base class is also used by our private interpreters, and this split avoids their dependency on the full LCE interpreter.

## How Has This Been Tested?
CI covers this.
