### PR TITLE
Fix docstring of Python interpreter

### DIFF
--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -19,12 +19,20 @@ class Interpreter(InterpreterBase):
         interpreter.predict(input_data, verbose=1)
         ```
 
-    See the base class `InterpreterBase` for the full interface.
-
     # Arguments
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
         num_threads: The number of threads used by the interpreter.
         use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
+
+    # Attributes
+        input_types: Returns a list of input types.
+        input_shapes: Returns a list of input shapes.
+        input_scales: Returns a list of input scales.
+        input_zero_points: Returns a list of input zero points.
+        output_types: Returns a list of output types.
+        output_shapes: Returns a list of output shapes.
+        output_scales: Returns a list of input scales.
+        output_zero_points: Returns a list of input zero points.
     """
 
     def __init__(

--- a/larq_compute_engine/tflite/python/interpreter_base.py
+++ b/larq_compute_engine/tflite/python/interpreter_base.py
@@ -27,19 +27,6 @@ def data_generator(x: Union[Data, Iterator[Data]]) -> Iterator[List[np.ndarray]]
 
 
 class InterpreterBase:
-    """Interpreter interface for Larq Compute Engine Models.
-
-    # Attributes
-        input_types: Returns a list of input types.
-        input_shapes: Returns a list of input shapes.
-        input_scales: Returns a list of input scales.
-        input_zero_points: Returns a list of input zero points.
-        output_types: Returns a list of output types.
-        output_shapes: Returns a list of output shapes.
-        output_scales: Returns a list of input scales.
-        output_zero_points: Returns a list of input zero points.
-    """
-
     def __init__(self, interpreter):
         self.interpreter = interpreter
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
In https://github.com/larq/compute-engine/pull/675 the interpreter was split into a baseclass and subclass. The docs on larq.dev do not read the docs from the baseclass, so this PR moves everything to the subclass so that it will show up on the website.