### PR TITLE
Add td_library target to be able to include lce_ops.td

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -12,8 +12,8 @@ td_library(
         "ir/lce_ops.td",
     ],
     deps = [
-        "@org_tensorflow//tensorflow/compiler/mlir/lite/quantization:quantization_td_files",
         "@llvm-project//mlir:SideEffectTdFiles",
+        "@org_tensorflow//tensorflow/compiler/mlir/lite/quantization:quantization_td_files",
     ],
 )
 
@@ -29,7 +29,7 @@ gentbl(
     td_file = "ir/lce_ops.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        ":lce_ops_td_file"
+        ":lce_ops_td_file",
     ],
 )
 

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -11,8 +11,10 @@ td_library(
     srcs = [
         "ir/lce_ops.td",
     ],
-    includes = ["include"],
-    deps = [],
+    deps = [
+        "@org_tensorflow//tensorflow/compiler/mlir/lite/quantization:quantization_td_files",
+        "@llvm-project//mlir:SideEffectTdFiles",
+    ],
 )
 
 gentbl(
@@ -27,8 +29,7 @@ gentbl(
     td_file = "ir/lce_ops.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "@org_tensorflow//tensorflow/compiler/mlir/lite/quantization:quantization_td_files",
-        "@llvm-project//mlir:SideEffectTdFiles",
+        ":lce_ops_td_file"
     ],
 )
 
@@ -55,7 +56,7 @@ gentbl(
     td_file = "transforms/prepare_patterns_target_arm.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "transforms/op_removal_patterns.td",
         "transforms/prepare_patterns_common.td",
         "@llvm-project//mlir:StdOpsTdFiles",
@@ -73,7 +74,7 @@ gentbl(
     td_file = "transforms/prepare_patterns_common.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "transforms/op_removal_patterns.td",
         "@llvm-project//mlir:StdOpsTdFiles",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_ops_td_files",
@@ -90,7 +91,7 @@ gentbl(
     td_file = "transforms/optimize_patterns_target_arm.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "transforms/optimize_patterns_common.td",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
         "@llvm-project//mlir:StdOpsTdFiles",
@@ -106,7 +107,7 @@ gentbl(
     td_file = "transforms/optimize_patterns_common.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
         "@llvm-project//mlir:StdOpsTdFiles",
     ],
@@ -121,7 +122,7 @@ gentbl(
     td_file = "transforms/bitpack_weights_patterns.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "transforms/op_removal_patterns.td",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_ops_td_files",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
@@ -138,7 +139,7 @@ gentbl(
     td_file = "transforms/quantize_patterns.td",
     td_includes = ["external/org_tensorflow"],
     td_srcs = [
-        "ir/lce_ops.td",
+        ":lce_ops_td_file",
         "@org_tensorflow//tensorflow/compiler/mlir/lite:tensorflow_lite_ops_td_files",
     ],
 )

--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -1,9 +1,18 @@
-load("@org_tensorflow//third_party/mlir:tblgen.bzl", "gentbl")
+load("@org_tensorflow//third_party/mlir:tblgen.bzl", "gentbl", "td_library")
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "pybind_extension", "tf_cc_binary")
 
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
+)
+
+td_library(
+    name = "lce_ops_td_file",
+    srcs = [
+        "ir/lce_ops.td",
+    ],
+    includes = ["include"],
+    deps = [],
 )
 
 gentbl(
@@ -146,6 +155,7 @@ cc_library(
         "//larq_compute_engine/core:types",
         "//larq_compute_engine/core/bitpacking:bitpack",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:QuantOps",
     ],
 )
 


### PR DESCRIPTION
There are two changes :
- Adds a new td_library target to be able to include lce_ops.td externally. In current MLIR and Tensorflow upstream, all td files are defined as part of td_library targets. This will probably need to be done for all td files when compute-engine is upgraded to Tensorflow 2.7
- Adds a missing dependency to @llvm-project//mlir:QuantOps. Missing header dependencies are enforced when building with later bazel versions.