### PR TITLE
Switch to `google-github-actions/auth`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -62,6 +62,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: google-github-actions/auth@v0
+        continue-on-error: true
         with:
           credentials_json: ${{ secrets.gcs_bazel_cache }}
       - uses: actions/setup-python@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -61,10 +61,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: google-github-actions/setup-gcloud@v0.3
+      - uses: google-github-actions/auth@v0
         with:
-          service_account_key: ${{ secrets.gcs_bazel_cache }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.gcs_bazel_cache }}
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9


### PR DESCRIPTION
## What do these changes do?
#691 seems to have broken CI for PRs from forks. This PR switches to the new `google-github-actions/auth` action since we don't need the `gcloud` command line utility on CI anyway.

## How Has This Been Tested?
CI and verified for PRs from forks in #697

## Related issue number

Build failure in #694