### PR TITLE
Simplify Python Linux wheel release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -232,7 +232,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     steps:
       - name: Configure Pagefile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -211,7 +211,7 @@ jobs:
           docker run -e PYTHON_VERSION=${{ matrix.python-version }} \
             -e LCE_RELEASE_VERSION=${{ github.event.inputs.version }} \
             -v ${PWD}:/compute-engine -w /compute-engine \
-            tensorflow/tensorflow:2.2.0-custom-op-ubuntu16 \
+            tensorflow/build:latest-python${{ matrix.python-version }} \
             .github/tools/release_linux.sh
 
           sudo apt-get -y -qq install patchelf --no-install-recommends

--- a/configure.py
+++ b/configure.py
@@ -411,26 +411,6 @@ def set_cc_opt_flags(environ_cp):
         write_to_bazelrc("build:opt --host_copt=%s" % opt)
 
 
-def maybe_set_manylinux_toolchain(environ_cp):
-    write_to_bazelrc(
-        "build:manylinux2010 --crosstool_top=@org_tensorflow//third_party/toolchains/preconfig/ubuntu16.04/gcc7_manylinux2010-nvcc-cuda11.2:toolchain"
-    )
-    if get_var(
-        environ_cp,
-        var_name="MANYLINUX2010",
-        query_item="manylinux2010-compatible pip package",
-        enabled_by_default=False,
-        question=(
-            "Are you trying to build a manylinux2010-compatible pip package "
-            "in the tensorflow:custom-op-ubuntu16 Docker container?"
-        ),
-        yes_reply="Building manylinux2010-compatible pip package.",
-        no_reply="Not building manylinux2010-compatible pip package.",
-    ):
-        write_to_bazelrc("build --config=manylinux2010")
-        write_to_bazelrc("test --config=manylinux2010")
-
-
 def set_windows_build_flags(environ_cp):
     """Set Windows specific build options."""
 
@@ -637,9 +617,6 @@ def main():
 
     if is_windows():
         set_windows_build_flags(environ_cp)
-
-    if is_linux():
-        maybe_set_manylinux_toolchain(environ_cp)
 
     if get_var(
         environ_cp,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") e
 setup(
     name="larq-compute-engine",
     version=get_version_number(default="0.6.2"),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     description="Highly optimized inference engine for binarized neural networks.",
     long_description=readme(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What do these changes do?
This simplifies the release scripts for the larq-compute-engine Python wheel converter for Linux. This is based on [the latest simplified method from tf-addons release system](https://github.com/tensorflow/addons/blob/master/tools/docker/build_wheel.Dockerfile) to build the larq-compute-engine wheel. The previous scripts resulted in issues, most likely due to running out of memory.

The implications are that this drops support for Python 3.6, since there is no corresponding Docker image available. It also relies on the 'latest' tag, which could result in things suddenly not working anymore as 'latest' changes due to a TensorFlow update. However, the advantage is that we always use the latest images.

This PR requires updating [the docs](https://github.com/larq/docs/blob/master/docs/compute-engine/build/docker.md) separately.

## How Has This Been Tested?
We'll need to do a test release on this branch before merging in. A test run is currently in progress here:
https://github.com/larq/compute-engine/actions/runs/1686835008
