### PR TITLE
Lce benchmark and interpreter flags

### DIFF
--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -29,9 +29,9 @@ tf_cc_binary(
         ],
     }),
     deps = [
+        "//larq_compute_engine/tflite/benchmark:lce_benchmark_tflite_model_lib",
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite/tools:logging",
-        "//larq_compute_engine/tflite/benchmark:lce_benchmark_tflite_model_lib",
     ],
 )
 
@@ -46,6 +46,6 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib"
+        "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib",
     ],
 )

--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -31,6 +31,21 @@ tf_cc_binary(
     deps = [
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite/tools:logging",
-        "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib",
+        "//larq_compute_engine/tflite/benchmark:lce_benchmark_tflite_model_lib",
+    ],
+)
+
+cc_library(
+    name = "lce_benchmark_tflite_model_lib",
+    srcs = ["lce_benchmark_tflite_model.cc"],
+    hdrs = ["lce_benchmark_tflite_model.h"],
+    copts = tflite_copts() + select({
+        "@org_tensorflow//tensorflow:ios": [
+            "-xobjective-c++",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@org_tensorflow//tensorflow/lite/tools/benchmark:benchmark_tflite_model_lib"
     ],
 )

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -27,7 +27,8 @@ bool use_indirect_bgemm = false;
 
 void ABSL_ATTRIBUTE_WEAK
 RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
-  compute_engine::tflite::RegisterLCECustomOps(resolver, use_reference_bconv, use_indirect_bgemm);
+  compute_engine::tflite::RegisterLCECustomOps(resolver, use_reference_bconv,
+  use_indirect_bgemm);
 }
 
 namespace tflite {

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -15,15 +15,19 @@ limitations under the License.
 ==============================================================================*/
 
 #include <iostream>
+#include <string>
 
 #include "absl/base/attributes.h"
 #include "larq_compute_engine/tflite/kernels/lce_ops_register.h"
-#include "tensorflow/lite/tools/benchmark/benchmark_tflite_model.h"
+#include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
 #include "tensorflow/lite/tools/logging.h"
+
+bool use_reference_bconv = false;
+bool use_indirect_bgemm = false;
 
 void ABSL_ATTRIBUTE_WEAK
 RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
-  compute_engine::tflite::RegisterLCECustomOps(resolver);
+  compute_engine::tflite::RegisterLCECustomOps(resolver, use_reference_bconv, use_indirect_bgemm);
 }
 
 namespace tflite {
@@ -31,7 +35,7 @@ namespace benchmark {
 
 int Main(int argc, char** argv) {
   TFLITE_LOG(INFO) << "STARTING!";
-  BenchmarkTfLiteModel benchmark;
+  LceBenchmarkTfLiteModel benchmark(LceBenchmarkTfLiteModel::DefaultParams(), use_reference_bconv, use_indirect_bgemm);
   if (benchmark.Run(argc, argv) != kTfLiteOk) {
     TFLITE_LOG(ERROR) << "Benchmarking failed.";
     return EXIT_FAILURE;

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -18,8 +18,8 @@ limitations under the License.
 #include <string>
 
 #include "absl/base/attributes.h"
-#include "larq_compute_engine/tflite/kernels/lce_ops_register.h"
 #include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
+#include "larq_compute_engine/tflite/kernels/lce_ops_register.h"
 #include "tensorflow/lite/tools/logging.h"
 
 bool use_reference_bconv = false;
@@ -28,7 +28,7 @@ bool use_indirect_bgemm = false;
 void ABSL_ATTRIBUTE_WEAK
 RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
   compute_engine::tflite::RegisterLCECustomOps(resolver, use_reference_bconv,
-  use_indirect_bgemm);
+                                               use_indirect_bgemm);
 }
 
 namespace tflite {
@@ -36,7 +36,8 @@ namespace benchmark {
 
 int Main(int argc, char** argv) {
   TFLITE_LOG(INFO) << "STARTING!";
-  LceBenchmarkTfLiteModel benchmark(LceBenchmarkTfLiteModel::DefaultParams(), use_reference_bconv, use_indirect_bgemm);
+  LceBenchmarkTfLiteModel benchmark(LceBenchmarkTfLiteModel::DefaultParams(),
+                                    use_reference_bconv, use_indirect_bgemm);
   if (benchmark.Run(argc, argv) != kTfLiteOk) {
     TFLITE_LOG(ERROR) << "Benchmarking failed.";
     return EXIT_FAILURE;

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -60,7 +60,7 @@ void LceBenchmarkTfLiteModel::LogParams() {
   LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm", "Use indirect BGEMM",
                       verbose);
 }
-  
+
 TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
   TF_LITE_ENSURE_STATUS(ParseFlags(argc, argv));
   use_reference_bconv = params_.Get<bool>("use_reference_bconv");

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -1,0 +1,69 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright (C) 2022 Larq Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
+
+#include "tensorflow/lite/tools/delegates/delegate_provider.h"
+
+
+namespace tflite {
+namespace benchmark {
+
+BenchmarkParams LceBenchmarkTfLiteModel::DefaultParams() {
+  BenchmarkParams default_params = BenchmarkTfLiteModel::DefaultParams();
+  default_params.AddParam("use_reference_bconv", BenchmarkParam::Create<bool>(false));
+  default_params.AddParam("use_indirect_bgemm", BenchmarkParam::Create<bool>(false));
+
+  return default_params;
+}
+
+LceBenchmarkTfLiteModel::LceBenchmarkTfLiteModel(BenchmarkParams params, bool &use_reference_bconv, bool &use_indirect_bgemm)
+    : BenchmarkTfLiteModel(std::move(params)), use_reference_bconv(use_reference_bconv), use_indirect_bgemm(use_indirect_bgemm) {
+}
+
+
+std::vector<Flag> LceBenchmarkTfLiteModel::GetFlags() {
+  std::vector<Flag> flags = BenchmarkTfLiteModel::GetFlags();
+  std::vector<Flag> lce_flags = {
+      CreateFlag<bool>("use_reference_bconv", &params_,
+                       "When true, uses the reference implementation of LceBconv2d."),
+      CreateFlag<bool>("use_indirect_bgemm", &params_,
+                       "When true, uses the optimized indirect BGEMM kernel of LceBconv2d.")};
+
+  flags.insert(flags.end(), lce_flags.begin(), lce_flags.end());
+
+  return flags;
+}
+
+void LceBenchmarkTfLiteModel::LogParams() {
+  BenchmarkTfLiteModel::LogParams();
+  const bool verbose = params_.Get<bool>("verbose");
+  LOG_BENCHMARK_PARAM(bool, "use_reference_bconv",
+                      "Use reference Bconv", verbose);
+  LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm",
+                      "Use indirect BGEMM", verbose);
+}
+    
+TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
+  TF_LITE_ENSURE_STATUS(ParseFlags(argc, argv));
+  use_reference_bconv = params_.Get<bool>("use_reference_bconv");
+  use_indirect_bgemm = params_.Get<bool>("use_indirect_bgemm");
+  return BenchmarkTfLiteModel::Run();
+}
+
+
+}  // namespace benchmark
+}  // namespace tflite

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -24,28 +24,31 @@ namespace benchmark {
 
 BenchmarkParams LceBenchmarkTfLiteModel::DefaultParams() {
   BenchmarkParams default_params = BenchmarkTfLiteModel::DefaultParams();
-  default_params.AddParam("use_reference_bconv", BenchmarkParam::Create<bool>(false));
-  default_params.AddParam("use_indirect_bgemm", BenchmarkParam::Create<bool>(false));
+  default_params.AddParam("use_reference_bconv",
+                          BenchmarkParam::Create<bool>(false));
+  default_params.AddParam("use_indirect_bgemm",
+                          BenchmarkParam::Create<bool>(false));
 
   return default_params;
 }
 
 LceBenchmarkTfLiteModel::LceBenchmarkTfLiteModel(BenchmarkParams params,
-                                                 bool &use_reference_bconv,
-                                                 bool &use_indirect_bgemm)
+                                                 bool& use_reference_bconv,
+                                                 bool& use_indirect_bgemm)
     : BenchmarkTfLiteModel(std::move(params)),
-    use_reference_bconv(use_reference_bconv),
-    use_indirect_bgemm(use_indirect_bgemm) {
-}
+      use_reference_bconv(use_reference_bconv),
+      use_indirect_bgemm(use_indirect_bgemm) {}
 
 
 std::vector<Flag> LceBenchmarkTfLiteModel::GetFlags() {
   std::vector<Flag> flags = BenchmarkTfLiteModel::GetFlags();
   std::vector<Flag> lce_flags = {
-      CreateFlag<bool>("use_reference_bconv", &params_,
-                       "When true, uses the reference implementation of LceBconv2d."),
+      CreateFlag<bool>(
+          "use_reference_bconv", &params_,
+          "When true, uses the reference implementation of LceBconv2d."),
       CreateFlag<bool>("use_indirect_bgemm", &params_,
-                       "When true, uses the optimized indirect BGEMM kernel of LceBconv2d.")};
+                       "When true, uses the optimized indirect BGEMM kernel of"
+                       "LceBconv2d.")};
 
   flags.insert(flags.end(), lce_flags.begin(), lce_flags.end());
 
@@ -55,16 +58,17 @@ std::vector<Flag> LceBenchmarkTfLiteModel::GetFlags() {
 void LceBenchmarkTfLiteModel::LogParams() {
   BenchmarkTfLiteModel::LogParams();
   const bool verbose = params_.Get<bool>("verbose");
-  LOG_BENCHMARK_PARAM(bool, "use_reference_bconv",
-                      "Use reference Bconv", verbose);
-  LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm",
-                      "Use indirect BGEMM", verbose);
+  LOG_BENCHMARK_PARAM(bool, "use_reference_bconv", "Use reference Bconv",
+                      verbose);
+  LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm", "Use indirect BGEMM",
+                      verbose);
 }
     
 TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
   TF_LITE_ENSURE_STATUS(ParseFlags(argc, argv));
   use_reference_bconv = params_.Get<bool>("use_reference_bconv");
   use_indirect_bgemm = params_.Get<bool>("use_indirect_bgemm");
+    
   return BenchmarkTfLiteModel::Run();
 }
 

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -30,8 +30,12 @@ BenchmarkParams LceBenchmarkTfLiteModel::DefaultParams() {
   return default_params;
 }
 
-LceBenchmarkTfLiteModel::LceBenchmarkTfLiteModel(BenchmarkParams params, bool &use_reference_bconv, bool &use_indirect_bgemm)
-    : BenchmarkTfLiteModel(std::move(params)), use_reference_bconv(use_reference_bconv), use_indirect_bgemm(use_indirect_bgemm) {
+LceBenchmarkTfLiteModel::LceBenchmarkTfLiteModel(BenchmarkParams params,
+                                                 bool &use_reference_bconv,
+                                                 bool &use_indirect_bgemm)
+    : BenchmarkTfLiteModel(std::move(params)),
+    use_reference_bconv(use_reference_bconv),
+    use_indirect_bgemm(use_indirect_bgemm) {
 }
 
 

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -15,9 +15,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
-
-#include "tensorflow/lite/tools/delegates/delegate_provider.h"
-
+#include "tensorflow/lite/tools/logging.h"
 
 namespace tflite {
 namespace benchmark {
@@ -38,7 +36,6 @@ LceBenchmarkTfLiteModel::LceBenchmarkTfLiteModel(BenchmarkParams params,
     : BenchmarkTfLiteModel(std::move(params)),
       use_reference_bconv(use_reference_bconv),
       use_indirect_bgemm(use_indirect_bgemm) {}
-
 
 std::vector<Flag> LceBenchmarkTfLiteModel::GetFlags() {
   std::vector<Flag> flags = BenchmarkTfLiteModel::GetFlags();
@@ -63,12 +60,12 @@ void LceBenchmarkTfLiteModel::LogParams() {
   LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm", "Use indirect BGEMM",
                       verbose);
 }
-    
+   
 TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
   TF_LITE_ENSURE_STATUS(ParseFlags(argc, argv));
   use_reference_bconv = params_.Get<bool>("use_reference_bconv");
   use_indirect_bgemm = params_.Get<bool>("use_indirect_bgemm");
-    
+
   return BenchmarkTfLiteModel::Run();
 }
 

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -60,7 +60,7 @@ void LceBenchmarkTfLiteModel::LogParams() {
   LOG_BENCHMARK_PARAM(bool, "use_indirect_bgemm", "Use indirect BGEMM",
                       verbose);
 }
-   
+  
 TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
   TF_LITE_ENSURE_STATUS(ParseFlags(argc, argv));
   use_reference_bconv = params_.Get<bool>("use_reference_bconv");
@@ -68,7 +68,6 @@ TfLiteStatus LceBenchmarkTfLiteModel::Run(int argc, char** argv) {
 
   return BenchmarkTfLiteModel::Run();
 }
-
 
 }  // namespace benchmark
 }  // namespace tflite

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc
@@ -15,6 +15,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
+
 #include "tensorflow/lite/tools/logging.h"
 
 namespace tflite {

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
@@ -25,8 +25,9 @@ namespace benchmark {
 // Benchmarks a TFLite model by running tflite interpreter.
 class LceBenchmarkTfLiteModel : public BenchmarkTfLiteModel {
  public:
-
-  explicit LceBenchmarkTfLiteModel(BenchmarkParams params, bool &use_reference_bconv, bool &use_indirect_bgemm);
+  explicit LceBenchmarkTfLiteModel(BenchmarkParams params,
+                                   bool &use_reference_bconv,
+                                   bool &use_indirect_bgemm);
 
   std::vector<Flag> GetFlags() override;
   void LogParams() override;

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
@@ -39,7 +39,6 @@ class LceBenchmarkTfLiteModel : public BenchmarkTfLiteModel {
  private:
   bool& use_reference_bconv;
   bool& use_indirect_bgemm;
-
 };
 
 }  // namespace benchmark

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
@@ -1,0 +1,48 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+Modifications copyright (C) 2022 Larq Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef COMPUTE_ENGINE_TFLITE_BENCHMARK_LCE_BENCHMARK_TFLITE_MODEL_H_
+#define COMPUTE_ENGINE_TFLITE_BENCHMARK_LCE_BENCHMARK_TFLITE_MODEL_H_
+
+#include "tensorflow/lite/tools/benchmark/benchmark_tflite_model.h"
+
+namespace tflite {
+namespace benchmark {
+
+// Benchmarks a TFLite model by running tflite interpreter.
+class LceBenchmarkTfLiteModel : public BenchmarkTfLiteModel {
+ public:
+
+  explicit LceBenchmarkTfLiteModel(BenchmarkParams params, bool &use_reference_bconv, bool &use_indirect_bgemm);
+  /*~BenchmarkTfLiteModel() override;*/
+
+  std::vector<Flag> GetFlags() override;
+  void LogParams() override;
+  static BenchmarkParams DefaultParams();
+    
+  using BenchmarkTfLiteModel::Run;
+  TfLiteStatus Run(int argc, char** argv);
+    
+ private:
+  bool &use_reference_bconv;
+  bool &use_indirect_bgemm;
+
+};
+
+}  // namespace benchmark
+}  // namespace tflite
+
+#endif  // COMPUTE_ENGINE_TFLITE_BENCHMARK_LCE_BENCHMARK_TFLITE_MODEL_H_

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
@@ -26,19 +26,19 @@ namespace benchmark {
 class LceBenchmarkTfLiteModel : public BenchmarkTfLiteModel {
  public:
   explicit LceBenchmarkTfLiteModel(BenchmarkParams params,
-                                   bool &use_reference_bconv,
-                                   bool &use_indirect_bgemm);
+                                   bool& use_reference_bconv,
+                                   bool& use_indirect_bgemm);
 
   std::vector<Flag> GetFlags() override;
   void LogParams() override;
   static BenchmarkParams DefaultParams();
-    
+
   using BenchmarkTfLiteModel::Run;
   TfLiteStatus Run(int argc, char** argv);
-    
+
  private:
-  bool &use_reference_bconv;
-  bool &use_indirect_bgemm;
+  bool& use_reference_bconv;
+  bool& use_indirect_bgemm;
 
 };
 

--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h
@@ -27,7 +27,6 @@ class LceBenchmarkTfLiteModel : public BenchmarkTfLiteModel {
  public:
 
   explicit LceBenchmarkTfLiteModel(BenchmarkParams params, bool &use_reference_bconv, bool &use_indirect_bgemm);
-  /*~BenchmarkTfLiteModel() override;*/
 
   std::vector<Flag> GetFlags() override;
   void LogParams() override;

--- a/larq_compute_engine/tflite/build_make/Makefile
+++ b/larq_compute_engine/tflite/build_make/Makefile
@@ -54,6 +54,7 @@ INCLUDES := \
 -I$(TF_MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(TF_MAKEFILE_DIR)/downloads/flatbuffers/include \
 -I$(TF_MAKEFILE_DIR)/downloads/fp16/include
+-Ilarq_compute_engine/tflite/benchmark/
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.
 INCLUDES += -I/usr/local/include

--- a/larq_compute_engine/tflite/build_make/Makefile
+++ b/larq_compute_engine/tflite/build_make/Makefile
@@ -53,8 +53,7 @@ INCLUDES := \
 -I$(TF_MAKEFILE_DIR)/downloads/neon_2_sse \
 -I$(TF_MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(TF_MAKEFILE_DIR)/downloads/flatbuffers/include \
--I$(TF_MAKEFILE_DIR)/downloads/fp16/include \
--Ilarq_compute_engine/tflite/benchmark
+-I$(TF_MAKEFILE_DIR)/downloads/fp16/include
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.
 INCLUDES += -I/usr/local/include

--- a/larq_compute_engine/tflite/build_make/Makefile
+++ b/larq_compute_engine/tflite/build_make/Makefile
@@ -54,7 +54,7 @@ INCLUDES := \
 -I$(TF_MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(TF_MAKEFILE_DIR)/downloads/flatbuffers/include \
 -I$(TF_MAKEFILE_DIR)/downloads/fp16/include \
--Ilarq_compute_engine/tflite/benchmark/
+-Ilarq_compute_engine/tflite/benchmark
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.
 INCLUDES += -I/usr/local/include
@@ -118,6 +118,7 @@ LCE_EXAMPLE_SRCS := \
 	examples/lce_minimal.cc
 
 LCE_BENCHMARK_SRCS := \
+    larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.cc \
 	larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
 
 # These target-specific makefiles should modify or replace options like

--- a/larq_compute_engine/tflite/build_make/Makefile
+++ b/larq_compute_engine/tflite/build_make/Makefile
@@ -53,7 +53,7 @@ INCLUDES := \
 -I$(TF_MAKEFILE_DIR)/downloads/neon_2_sse \
 -I$(TF_MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(TF_MAKEFILE_DIR)/downloads/flatbuffers/include \
--I$(TF_MAKEFILE_DIR)/downloads/fp16/include
+-I$(TF_MAKEFILE_DIR)/downloads/fp16/include \
 -Ilarq_compute_engine/tflite/benchmark/
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -44,7 +44,6 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
-        "@org_tensorflow//tensorflow/lite/tools/logging",
         "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
+        "@org_tensorflow//tensorflow/lite/tools/logging.h",
         "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -44,7 +44,6 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
-        "@org_tensorflow//tensorflow/lite/tools/logging.h",
         "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
+        "@org_tensorflow//tensorflow/lite/tools/logging",
         "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/BUILD
+++ b/larq_compute_engine/tflite/kernels/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:type_to_tflitetype",
         "@org_tensorflow//tensorflow/lite/kernels/internal:kernel_utils",
         "@org_tensorflow//tensorflow/lite/kernels/internal:tensor",
+        "@org_tensorflow//tensorflow/lite/tools:logging",
         "@ruy//ruy/profiler:instrumentation",
     ],
     alwayslink = 1,

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -2,13 +2,17 @@
 #define COMPUTE_ENGINE_TFLITE_KERNELS_LCE_OPS_REGISTER_H_
 
 #include "tensorflow/lite/context.h"
+//#include "tensorflow/lite/stderr_reporter.h"
 #include "tensorflow/lite/op_resolver.h"
+#include "tensorflow/lite/tools/logging.h"
 
 // This file contains forward declaration of all custom ops
 // implemented in LCE which can be used to link against LCE library.
 
 namespace compute_engine {
 namespace tflite {
+
+using namespace ::tflite;
 
 TfLiteRegistration* Register_QUANTIZE();
 TfLiteRegistration* Register_DEQUANTIZE();
@@ -22,6 +26,11 @@ TfLiteRegistration* Register_BMAXPOOL_2D();
 inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
                                  const bool use_reference_bconv = false,
                                  const bool use_indirect_bgemm = false) {
+  if (use_reference_bconv && use_indirect_bgemm) {
+    TFLITE_LOG(WARN) << "WARNING: 'use_reference_bconv' and `use_indirect_bgemm` "
+                         "are both set to true. use_indirect_bgemm==true "
+                         "will have no effect.";
+  }
   resolver->AddCustom("LceQuantize",
                       compute_engine::tflite::Register_QUANTIZE());
   resolver->AddCustom("LceDequantize",

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -38,7 +38,6 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
       resolver->AddCustom("LceBconv2d",
                           compute_engine::tflite::Register_BCONV_2D());
     }
-
   }
   resolver->AddCustom("LceBMaxPool2d",
                       compute_engine::tflite::Register_BMAXPOOL_2D());

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -2,7 +2,6 @@
 #define COMPUTE_ENGINE_TFLITE_KERNELS_LCE_OPS_REGISTER_H_
 
 #include "tensorflow/lite/context.h"
-//#include "tensorflow/lite/stderr_reporter.h"
 #include "tensorflow/lite/op_resolver.h"
 #include "tensorflow/lite/tools/logging.h"
 

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -27,9 +27,10 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
                                  const bool use_reference_bconv = false,
                                  const bool use_indirect_bgemm = false) {
   if (use_reference_bconv && use_indirect_bgemm) {
-    TFLITE_LOG(WARN) << "WARNING: 'use_reference_bconv' and `use_indirect_bgemm` "
-                         "are both set to true. use_indirect_bgemm==true "
-                         "will have no effect.";
+    TFLITE_LOG(WARN)
+        << "WARNING: 'use_reference_bconv' and `use_indirect_bgemm` "
+           "are both set to true. use_indirect_bgemm==true "
+           "will have no effect.";
   }
   resolver->AddCustom("LceQuantize",
                       compute_engine::tflite::Register_QUANTIZE());

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -14,12 +14,14 @@ TfLiteRegistration* Register_QUANTIZE();
 TfLiteRegistration* Register_DEQUANTIZE();
 TfLiteRegistration* Register_BCONV_2D();
 TfLiteRegistration* Register_BCONV_2D_REF();
+TfLiteRegistration* Register_BCONV_2D_OPT_INDIRECT_BGEMM();
 TfLiteRegistration* Register_BMAXPOOL_2D();
 
 // By calling this function on TF lite mutable op resolver, all LCE custom ops
 // will be registerd to the op resolver.
 inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
-                                 const bool use_reference_bconv = false) {
+                                 const bool use_reference_bconv = false,
+                                 const bool use_indirect_bgemm = false) {
   resolver->AddCustom("LceQuantize",
                       compute_engine::tflite::Register_QUANTIZE());
   resolver->AddCustom("LceDequantize",
@@ -28,8 +30,14 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
     resolver->AddCustom("LceBconv2d",
                         compute_engine::tflite::Register_BCONV_2D_REF());
   } else {
-    resolver->AddCustom("LceBconv2d",
+      if (use_indirect_bgemm) {
+          resolver->AddCustom("LceBconv2d",
+                        compute_engine::tflite::Register_BCONV_2D_OPT_INDIRECT_BGEMM());
+      } else {
+          resolver->AddCustom("LceBconv2d",
                         compute_engine::tflite::Register_BCONV_2D());
+      }
+    
   }
   resolver->AddCustom("LceBMaxPool2d",
                       compute_engine::tflite::Register_BMAXPOOL_2D());

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -38,7 +38,7 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
       resolver->AddCustom("LceBconv2d",
                           compute_engine::tflite::Register_BCONV_2D());
     }
-    
+
   }
   resolver->AddCustom("LceBMaxPool2d",
                       compute_engine::tflite::Register_BMAXPOOL_2D());

--- a/larq_compute_engine/tflite/kernels/lce_ops_register.h
+++ b/larq_compute_engine/tflite/kernels/lce_ops_register.h
@@ -30,13 +30,14 @@ inline void RegisterLCECustomOps(::tflite::MutableOpResolver* resolver,
     resolver->AddCustom("LceBconv2d",
                         compute_engine::tflite::Register_BCONV_2D_REF());
   } else {
-      if (use_indirect_bgemm) {
-          resolver->AddCustom("LceBconv2d",
-                        compute_engine::tflite::Register_BCONV_2D_OPT_INDIRECT_BGEMM());
-      } else {
-          resolver->AddCustom("LceBconv2d",
-                        compute_engine::tflite::Register_BCONV_2D());
-      }
+    if (use_indirect_bgemm) {
+      resolver->AddCustom(
+          "LceBconv2d",
+          compute_engine::tflite::Register_BCONV_2D_OPT_INDIRECT_BGEMM());
+    } else {
+      resolver->AddCustom("LceBconv2d",
+                          compute_engine::tflite::Register_BCONV_2D());
+    }
     
   }
   resolver->AddCustom("LceBMaxPool2d",

--- a/larq_compute_engine/tflite/python/BUILD
+++ b/larq_compute_engine/tflite/python/BUILD
@@ -25,6 +25,7 @@ pybind_extension(
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
+        "@org_tensorflow//tensorflow/lite/tools/logging.h",
         "@pybind11",
     ],
 )

--- a/larq_compute_engine/tflite/python/BUILD
+++ b/larq_compute_engine/tflite/python/BUILD
@@ -25,6 +25,7 @@ pybind_extension(
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
+        "@org_tensorflow//tensorflow/lite/tools/logging",
         "@pybind11",
     ],
 )

--- a/larq_compute_engine/tflite/python/BUILD
+++ b/larq_compute_engine/tflite/python/BUILD
@@ -25,7 +25,6 @@ pybind_extension(
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
-        "@org_tensorflow//tensorflow/lite/tools/logging",
         "@pybind11",
     ],
 )

--- a/larq_compute_engine/tflite/python/BUILD
+++ b/larq_compute_engine/tflite/python/BUILD
@@ -25,7 +25,6 @@ pybind_extension(
         "//larq_compute_engine/tflite/kernels:lce_op_kernels",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
-        "@org_tensorflow//tensorflow/lite/tools/logging.h",
         "@pybind11",
     ],
 )

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -24,6 +24,7 @@ class Interpreter(InterpreterBase):
         num_threads: The number of threads used by the interpreter.
         use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
         use_indirect_bgemm: When True, uses the optimized indirect BGEMM kernel of LceBconv2d.
+        use_xnnpack: When True, uses the XNNPack delegate of TFLite.
 
     # Attributes
         input_types: Returns a list of input types.
@@ -42,11 +43,13 @@ class Interpreter(InterpreterBase):
         num_threads: int = 1,
         use_reference_bconv: bool = False,
         use_indirect_bgemm: bool = False,
+        use_xnnpack: bool = False,
     ):
         from larq_compute_engine.tflite.python import interpreter_wrapper_lite
 
         super().__init__(
             interpreter_wrapper_lite.LiteInterpreter(
-                flatbuffer_model, num_threads, use_reference_bconv, use_indirect_bgemm
+                flatbuffer_model, num_threads, use_reference_bconv,
+                use_indirect_bgemm, use_xnnpack
             )
         )

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -49,7 +49,10 @@ class Interpreter(InterpreterBase):
 
         super().__init__(
             interpreter_wrapper_lite.LiteInterpreter(
-                flatbuffer_model, num_threads, use_reference_bconv,
-                use_indirect_bgemm, use_xnnpack
+                flatbuffer_model,
+                num_threads,
+                use_reference_bconv,
+                use_indirect_bgemm,
+                use_xnnpack,
             )
         )

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -23,6 +23,7 @@ class Interpreter(InterpreterBase):
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
         num_threads: The number of threads used by the interpreter.
         use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
+        use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
 
     # Attributes
         input_types: Returns a list of input types.
@@ -40,11 +41,12 @@ class Interpreter(InterpreterBase):
         flatbuffer_model: bytes,
         num_threads: int = 1,
         use_reference_bconv: bool = False,
+        use_indirect_bgemm: bool = False,
     ):
         from larq_compute_engine.tflite.python import interpreter_wrapper_lite
 
         super().__init__(
             interpreter_wrapper_lite.LiteInterpreter(
-                flatbuffer_model, num_threads, use_reference_bconv
+                flatbuffer_model, num_threads, use_reference_bconv, use_indirect_bgemm
             )
         )

--- a/larq_compute_engine/tflite/python/interpreter.py
+++ b/larq_compute_engine/tflite/python/interpreter.py
@@ -23,7 +23,7 @@ class Interpreter(InterpreterBase):
         flatbuffer_model: A serialized Larq Compute Engine model in the flatbuffer format.
         num_threads: The number of threads used by the interpreter.
         use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
-        use_reference_bconv: When True, uses the reference implementation of LceBconv2d.
+        use_indirect_bgemm: When True, uses the optimized indirect BGEMM kernel of LceBconv2d.
 
     # Attributes
         input_types: Returns a list of input types.

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -10,11 +10,11 @@
 class LiteInterpreterWrapper
     : public InterpreterWrapperBase<tflite::Interpreter> {
  public:
-  LiteInterpreterWrapper(const pybind11::bytes& flatbuffer,
-                         const int num_threads = 1,
-                         const bool use_reference_bconv = false
-                         const bool use_indirect_bgemm = false
-                         const bool use_xnnpack = false);
+  LiteInterpreterWrapper(
+      const pybind11::bytes& flatbuffer, const int num_threads = 1,
+      const bool use_reference_bconv = false,
+      const bool use_indirect_bgemm = false,
+      const bool use_xnnpack = false);
   ~LiteInterpreterWrapper(){};
 
  private:
@@ -27,7 +27,8 @@ class LiteInterpreterWrapper
 
 LiteInterpreterWrapper::LiteInterpreterWrapper(
     const pybind11::bytes& flatbuffer, const int num_threads,
-    const bool use_reference_bconv, const bool use_indirect_bgemm, const bool use_xnnpack) {
+    const bool use_reference_bconv, const bool use_indirect_bgemm,
+    const bool use_xnnpack) {
   // Make a copy of the flatbuffer because it can get deallocated after the
   // constructor is done
   flatbuffer_ = static_cast<std::string>(flatbuffer);
@@ -42,10 +43,11 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
   if (use_xnnpack) {
     resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
   } else {
-    resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates>();
+    resolver_ = std::make_unique<
+        tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates>();
   }
-  compute_engine::tflite::RegisterLCECustomOps(resolver_.get(),
-                                               use_reference_bconv, use_indirect_bgemm);
+  compute_engine::tflite::RegisterLCECustomOps(
+      resolver_.get(), use_reference_bconv, use_indirect_bgemm);
 
   tflite::InterpreterBuilder builder(*model_, *resolver_);
   builder(&interpreter_, num_threads);
@@ -57,8 +59,8 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
 
 PYBIND11_MODULE(interpreter_wrapper_lite, m) {
   pybind11::class_<LiteInterpreterWrapper>(m, "LiteInterpreter")
-      .def(pybind11::init<const pybind11::bytes&, const int, const bool,
-           const bool, const bool>())
+      .def(pybind11::init<const pybind11::bytes&, const int, const bool, 
+                          const bool, const bool>())
       .def_property("input_types", &LiteInterpreterWrapper::get_input_types,
                     nullptr)
       .def_property("output_types", &LiteInterpreterWrapper::get_output_types,

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -10,11 +10,11 @@
 class LiteInterpreterWrapper
     : public InterpreterWrapperBase<tflite::Interpreter> {
  public:
-  LiteInterpreterWrapper(
-      const pybind11::bytes& flatbuffer, const int num_threads = 1,
-      const bool use_reference_bconv = false,
-      const bool use_indirect_bgemm = false,
-      const bool use_xnnpack = false);
+  LiteInterpreterWrapper(const pybind11::bytes& flatbuffer,
+                         const int num_threads = 1,
+                         const bool use_reference_bconv = false,
+                         const bool use_indirect_bgemm = false,
+                         const bool use_xnnpack = false);
   ~LiteInterpreterWrapper(){};
 
  private:

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -25,7 +25,7 @@ class LiteInterpreterWrapper
 
 LiteInterpreterWrapper::LiteInterpreterWrapper(
     const pybind11::bytes& flatbuffer, const int num_threads,
-    const bool use_reference_bconv) {
+    const bool use_reference_bconv, const bool use_indirect_bgemm) {
   // Make a copy of the flatbuffer because it can get deallocated after the
   // constructor is done
   flatbuffer_ = static_cast<std::string>(flatbuffer);
@@ -39,7 +39,7 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
   // Build the interpreter
   resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
   compute_engine::tflite::RegisterLCECustomOps(resolver_.get(),
-                                               use_reference_bconv);
+                                               use_reference_bconv, use_indirect_bgemm);
 
   tflite::InterpreterBuilder builder(*model_, *resolver_);
   builder(&interpreter_, num_threads);

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -57,7 +57,8 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
 
 PYBIND11_MODULE(interpreter_wrapper_lite, m) {
   pybind11::class_<LiteInterpreterWrapper>(m, "LiteInterpreter")
-      .def(pybind11::init<const pybind11::bytes&, const int, const bool>())
+      .def(pybind11::init<const pybind11::bytes&, const int, const bool,
+           const bool, const bool>())
       .def_property("input_types", &LiteInterpreterWrapper::get_input_types,
                     nullptr)
       .def_property("output_types", &LiteInterpreterWrapper::get_output_types,

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -12,7 +12,9 @@ class LiteInterpreterWrapper
  public:
   LiteInterpreterWrapper(const pybind11::bytes& flatbuffer,
                          const int num_threads = 1,
-                         const bool use_reference_bconv = false);
+                         const bool use_reference_bconv = false
+                         const bool use_indirect_bgemm = false
+                         const bool use_xnnpack = false);
   ~LiteInterpreterWrapper(){};
 
  private:
@@ -38,9 +40,9 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
 
   // Build the interpreter
   if (use_xnnpack) {
-      resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
+    resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
   } else {
-      resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates>();
+    resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates>();
   }
   compute_engine::tflite::RegisterLCECustomOps(resolver_.get(),
                                                use_reference_bconv, use_indirect_bgemm);

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -25,7 +25,7 @@ class LiteInterpreterWrapper
 
 LiteInterpreterWrapper::LiteInterpreterWrapper(
     const pybind11::bytes& flatbuffer, const int num_threads,
-    const bool use_reference_bconv, const bool use_indirect_bgemm) {
+    const bool use_reference_bconv, const bool use_indirect_bgemm, const bool use_xnnpack) {
   // Make a copy of the flatbuffer because it can get deallocated after the
   // constructor is done
   flatbuffer_ = static_cast<std::string>(flatbuffer);
@@ -37,7 +37,11 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
   }
 
   // Build the interpreter
-  resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
+  if (use_xnnpack) {
+      resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolver>();
+  } else {
+      resolver_ = std::make_unique<tflite::ops::builtin::BuiltinOpResolverWithoutDefaultDelegates>();
+  }
   compute_engine::tflite::RegisterLCECustomOps(resolver_.get(),
                                                use_reference_bconv, use_indirect_bgemm);
 

--- a/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
+++ b/larq_compute_engine/tflite/python/interpreter_wrapper_lite.cc
@@ -59,7 +59,7 @@ LiteInterpreterWrapper::LiteInterpreterWrapper(
 
 PYBIND11_MODULE(interpreter_wrapper_lite, m) {
   pybind11::class_<LiteInterpreterWrapper>(m, "LiteInterpreter")
-      .def(pybind11::init<const pybind11::bytes&, const int, const bool, 
+      .def(pybind11::init<const pybind11::bytes&, const int, const bool,
                           const bool, const bool>())
       .def_property("input_types", &LiteInterpreterWrapper::get_input_types,
                     nullptr)


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->
In general, this PR allows registering of the different kernel implementations of LceBconv2D (`lce_register_ops.h`) by additional parameters in **LceInterpreter** and flags in **lce_benchmark_model** binary

## What do these changes do?
<!-- Please give a short brief about these changes. -->
### lce_benchmark_model
- added two cmdline flags `use_reference_bconv`/`use_indirect_bgemm` as global variables to register respective kernel implementations
- instead of manually parsing the flags in lce_benchmark_main.cc the builtin Flags of TF's **BenchmarkModel** are used. Thus by adding **LceBenchmarkTfLiteModel** as a child class of BenchmarkTfLiteModel the global variables are passed in as reference upon object instantiation and set after calling overidden Run() method
### LceInterpreter
- added parameter `use_indirect_bgemm` to register optimized indirect BGEMM kernel using `Register_BCONV_2D_OPT_INDIRECT_BGEMM()` in *lce_register_ops.h*
-  added parameter `use_xnnpack` in *interpreter_wrapper_lite.cc* to apply `BuiltinOpResolver` when true, otherwise `BuiltinOpResolverWithoutDefaultDelegates`

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
#711, #713 
