### PR TITLE
Update lint package versions

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-black==21.5b1
-pyflakes==2.3.1
-pytype==2021.5.25
+black==22.3.0
+pyflakes==2.4.0
+pytype==2022.3.29


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This PR updates all three linting packages (`black`, `pyflakes`, `pytype`) to their latest version.

In #720 CI failed because of an incompatibility between `black` and `click`, see https://github.com/larq/compute-engine/runs/5788623461?check_suite_focus=true . It seems `black` has a `click>=xxx` dependency and the newest click package is not compatible.
