### PR TITLE
Fix segfaults in benchmark binaries when setting num_threads > 1

### DIFF
--- a/larq_compute_engine/tflite/benchmark/BUILD
+++ b/larq_compute_engine/tflite/benchmark/BUILD
@@ -14,19 +14,13 @@ tf_cc_binary(
         "lce_benchmark_main.cc",
     ],
     copts = tflite_copts() + tflite_copts_warnings(),
-    features = select({
-        "@org_tensorflow//tensorflow:android": [],
-        "//conditions:default": ["fully_static_link"],
-    }),
     linkopts = tflite_linkopts() + select({
         "@org_tensorflow//tensorflow:android": [
             "-pie",  # Android 5.0 and later supports only PIE
             "-lm",  # some builtin ops, e.g., tanh, need -lm
+            "-Wl,--rpath=/data/local/tmp/",  # Hexagon delegate libraries should be in /data/local/tmp
         ],
-        "//conditions:default": [
-            "-lstdc++",
-            "-lm",
-        ],
+        "//conditions:default": [],
     }),
     deps = [
         "//larq_compute_engine/tflite/benchmark:lce_benchmark_tflite_model_lib",


### PR DESCRIPTION
## What do these changes do?
The LCE benchmark binaries would often (not always though) segfault when running with more than 1 thread. This was the case both on aarch64 and on x86, and both for BNNs and for regular INT8 networks. However, this issue was only present in the Bazel versions of the binaries and not with the (recently added) CMake versions. That suggested something was wrong in the build scripts and not in the code itself.

This PR changes the Bazel linking settings for the benchmark binaries such that they are in-line with what is done inside TensorFlow itself: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/tools/benchmark/BUILD#L33-L40. With these changes, I could no longer reproduce the segfaults.

## How Has This Been Tested?
By running the new benchmark binaries on both x86 and aarch64 a couple of times (with a large number of runs to be sure), with and without XNNPack, e.g.:
`bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model --graph=MobileNetV1_INT8.tflite --num_threads=4 --use_xnnpack=true --num_runs=5000`

## Benchmark Results
Unchanged.

## Related issue number
N/A.
