### PR TITLE
Add bazel cache for release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,12 +140,21 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: google-github-actions/auth@v0
+        continue-on-error: true
+        with:
+          credentials_json: ${{ secrets.gcs_bazel_cache }}
       - name: Build macOS wheels
         run: |
           python --version
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
           ./configure.py
+
+          if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
+            echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-macos' >> .bazelrc.user
+            echo -e 'build --google_default_credentials' >> .bazelrc.user
+          fi
 
           bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13 --linkopt=-dead_strip --distinct_host_configuration=false
           bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_13_x86_64
@@ -173,12 +182,21 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: google-github-actions/auth@v0
+        continue-on-error: true
+        with:
+          credentials_json: ${{ secrets.gcs_bazel_cache }}
       - name: Build macOS wheels
         run: |
           python --version
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
           ./configure.py
+
+          if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
+            echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-macos-arm' >> .bazelrc.user
+            echo -e 'build --google_default_credentials' >> .bazelrc.user
+          fi
 
           bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mmacosx-version-min=11.0 --linkopt=-mmacosx-version-min=11.0 --linkopt=-dead_strip --config=macos_arm64
           bazel-bin/build_pip_pkg artifacts --plat-name macosx_11_0_arm64
@@ -206,8 +224,17 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: google-github-actions/auth@v0
+        continue-on-error: true
+        with:
+          credentials_json: ${{ secrets.gcs_bazel_cache }}
       - name: Build manylinux2010 wheels
         run: |
+          if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
+            echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-manylinux' >> .bazelrc.user
+            echo -e 'build --google_default_credentials' >> .bazelrc.user
+          fi
+
           docker run -e LCE_RELEASE_VERSION=${{ github.event.inputs.version }} \
             -v ${PWD}:/compute-engine -w /compute-engine \
             tensorflow/build:2.8-python${{ matrix.python-version }} \
@@ -246,6 +273,10 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: google-github-actions/auth@v0
+        continue-on-error: true
+        with:
+          credentials_json: ${{ secrets.gcs_bazel_cache }}
       - name: Build Windows wheels
         run: |
           $Env:BAZEL_VC = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
@@ -258,6 +289,11 @@ jobs:
           python -m pip install wheel setuptools numpy six --no-cache-dir
 
           "" | python configure.py
+
+          if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
+            echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-windows' >> .bazelrc.user
+            echo -e 'build --google_default_credentials' >> .bazelrc.user
+          fi
 
           bazelisk --output_base=C:\build_output build :build_pip_pkg --enable_runfiles --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build --nouse_action_cache --local_ram_resources=4096
           bazel-bin/build_pip_pkg wheelhouse


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
This adds a bazel cache for release jobs:
- if they timeout we can simply restart them and they should finish within the time limit
- if they fail for any other reason we can try fixes without having to wait for 6 hours

## How Has This Been Tested?
It is running here: https://github.com/larq/compute-engine/actions/runs/2200323727