### PR TITLE
Deal with non-deterministic input order for interpreter test

### DIFF
--- a/larq_compute_engine/tflite/tests/interpreter_test.py
+++ b/larq_compute_engine/tflite/tests/interpreter_test.py
@@ -52,10 +52,14 @@ def test_interpreter_multi_input(use_iterator):
     assert interpreter.input_shapes == [(1, 24, 24, 1), (1, 24, 24, 2)]
     assert sorted(interpreter.output_shapes) == [(1, 24 * 24 * 1), (1, 24 * 24 * 2)]
 
+    # Input order is not deterministic, decide based on shape
+    if interpreter.input_shapes[0][-1] == 1:
+        x_np, y_np = y_np, x_np
+
     def input_fn():
         if use_iterator:
-            return ([y, x] for x, y in zip(x_np, y_np))
-        return [y_np, x_np]
+            return ([x, y] for x, y in zip(x_np, y_np))
+        return [x_np, y_np]
 
     output_x, output_y = interpreter.predict(input_fn())
     # Output order is not deterministic, decide based on shape

--- a/larq_compute_engine/tflite/tests/interpreter_test.py
+++ b/larq_compute_engine/tflite/tests/interpreter_test.py
@@ -49,7 +49,7 @@ def test_interpreter_multi_input(use_iterator):
     interpreter = Interpreter(converter.convert(), num_threads=2)
     assert interpreter.input_types == [np.float32, np.float32]
     assert interpreter.output_types == [np.float32, np.float32]
-    assert interpreter.input_shapes == [(1, 24, 24, 1), (1, 24, 24, 2)]
+    assert sorted(interpreter.input_shapes) == [(1, 24, 24, 1), (1, 24, 24, 2)]
     assert sorted(interpreter.output_shapes) == [(1, 24 * 24 * 1), (1, 24 * 24 * 2)]
 
     # Input order is not deterministic, decide based on shape


### PR DESCRIPTION
## What do these changes do?
In https://github.com/larq/compute-engine/pull/722 I reversed the input order, but it seems that when re-running the test more often that the input order is not deterministic. This fix decides the input order of the test based on the shape.

## How Has This Been Tested?
Running the test multiple times, e.g. `bazelisk test larq_compute_engine/tflite/tests:interpreter_test --test_output=all --runs_per_test=30`

## Benchmark Results
N/A

## Related issue number
N/A
