### PR TITLE
Fix build cache for windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,12 +292,7 @@ jobs:
 
           "" | python configure.py
 
-          if ($GOOGLE_APPLICATION_CREDENTIALS) {
-            echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-windows-python${{ matrix.python-version }}' >> .bazelrc.user
-            echo -e 'build --google_default_credentials' >> .bazelrc.user
-          }
-
-          bazelisk --output_base=C:\build_output build :build_pip_pkg --enable_runfiles --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build --nouse_action_cache --local_ram_resources=4096
+          bazelisk --output_base=C:\build_output build :build_pip_pkg --enable_runfiles --local_ram_resources=4096 --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-windows-python${{ matrix.python-version }} --google_default_credentials
           bazel-bin/build_pip_pkg wheelhouse
         env:
           LCE_RELEASE_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?

The `if ($GOOGLE_APPLICATION_CREDENTIALS)` in the windows release script was not working. Furthermore the windows build uses the flags `--discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build --nouse_action_cache` to speed up the build.
This PR removes those 'no cache' flags and enables the GCS cache.

## How Has This Been Tested?
First run: timeout after 6 hours as expected: https://github.com/larq/compute-engine/actions/runs/2207868415
Second run: finish after 1 hour: https://github.com/larq/compute-engine/actions/runs/2218470790
