### PR TITLE
Remove `weak` attribute for `RegisterSelectedOps`

### DIFF
--- a/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
+++ b/larq_compute_engine/tflite/benchmark/lce_benchmark_main.cc
@@ -17,7 +17,6 @@ limitations under the License.
 #include <iostream>
 #include <string>
 
-#include "absl/base/attributes.h"
 #include "larq_compute_engine/tflite/benchmark/lce_benchmark_tflite_model.h"
 #include "larq_compute_engine/tflite/kernels/lce_ops_register.h"
 #include "tensorflow/lite/tools/logging.h"
@@ -25,8 +24,7 @@ limitations under the License.
 bool use_reference_bconv = false;
 bool use_indirect_bgemm = false;
 
-void ABSL_ATTRIBUTE_WEAK
-RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
+void RegisterSelectedOps(::tflite::MutableOpResolver* resolver) {
   compute_engine::tflite::RegisterLCECustomOps(resolver, use_reference_bconv,
                                                use_indirect_bgemm);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution!
Please review https://github.com/larq/compute-engine/blob/main/CONTRIBUTING.md before opening a pull request. -->

## What do these changes do?
The bazel build of `lce_benchmark_model` works fine, but when using the cmake version, none of our ops are registered: `RegisterSelectedOps` is not called at all. This seems to be caused by the fact that the registration function is marked as 'weak', and then it depends on the order of linking which function wins.

There wasn't supposed to be a weak attribute here at all: the weak version of the symbol is in the TF library, meant to be overridden by binaries such as this one.

## How Has This Been Tested?
Both the cmake and bazel builds are now working as expected.
