### PR TITLE
Unpin flatbuffers

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -87,7 +87,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         shell: bash
       - name: Install pip dependencies
-        run: pip install tensorflow-cpu~=2.9.0 larq~=0.11 larq_zoo~=2.0 pytest tensorflow_datasets~=4.4 flatbuffers==1.12 tqdm --no-cache-dir
+        run: pip install tensorflow-cpu~=2.9.0 larq~=0.11 larq_zoo~=2.0 pytest tensorflow_datasets~=4.4 flatbuffers tqdm --no-cache-dir
       - name: Run Interpreter test
         run: bazelisk test larq_compute_engine/tflite/tests:interpreter_test --test_output=all
       - name: Run FileCheck tests
@@ -109,7 +109,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.11 larq_zoo~=2.0 tensorflow_datasets==1.3.2 packaging flatbuffers==1.12 --no-cache-dir
+        run: pip install tensorflow==${{matrix.tf-version}} larq~=0.11 larq_zoo~=2.0 tensorflow_datasets==1.3.2 packaging flatbuffers --no-cache-dir
       - name: Run Converter test
         run: PYTHONPATH=./ python larq_compute_engine/mlir/python/converter_test.py
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ext_modules=ext_modules,
     url="https://larq.dev/",
     install_requires=[
-        "flatbuffers>=1.12,<2.0",
+        "flatbuffers>=1.12",
         "packaging>=19",
         "tqdm>=4",
         "importlib-metadata ~= 2.0 ; python_version<'3.8'",


### PR DESCRIPTION
## What do these changes do?
This PR unpins flatbuffer in preparation for #749 since TF 2.9 and older depends on flatbuffers 1.12 and 2.10 started upgraded top flatbuffers 2.0

## How Has This Been Tested?
Let's see what CI thinks