### PR TITLE
Remove `--copt=-O2` from CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pip dependencies
         run: pip install numpy --no-cache-dir
       - name: Run C++ Unit Tests
-        run: bazelisk test larq_compute_engine/tests:cc_tests --copt=-O2 --distinct_host_configuration=false --test_output=all
+        run: bazelisk test larq_compute_engine/tests:cc_tests --distinct_host_configuration=false --test_output=all
       - name: Build TF Lite Static Library with CMake
         run: |
           mkdir build
@@ -76,7 +76,6 @@ jobs:
         run: |
           ./configure.py
           echo -e 'build --distinct_host_configuration=false' >> .bazelrc.user
-          echo -e 'build --copt=-O2' >> .bazelrc.user
           if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
             echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-ubuntu' >> .bazelrc.user
             echo -e 'build --google_default_credentials' >> .bazelrc.user


### PR DESCRIPTION
## What do these changes do?
This PR removes `--copt=-O2` from our unittesting on CI. I stumbled upon this while debugging build failures for #749.

We added this flag for #405 to resolve some build failures but it seems like this isn't necessary anymore.

## How Has This Been Tested?
CI and local build