### PR TITLE
Use Java 8 for building Android benchmark binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
+      - name: Set Java version
+        run: echo "JAVA_HOME=${JAVA_HOME_8_X64}" >> $GITHUB_ENV
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           asset_content_type: application/octet-stream
 
   android-aar:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -102,6 +102,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
+      - name: Set Java version
+        run: echo "JAVA_HOME=${JAVA_HOME_8_X64}" >> $GITHUB_ENV
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
@@ -216,7 +218,7 @@ jobs:
 
   manylinux-release-wheel:
     name: Build release wheels for manylinux2014
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -113,7 +113,7 @@ jobs:
         run: PYTHONPATH=./ python larq_compute_engine/mlir/python/converter_test.py
 
   Android_AAR:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
 
     steps:
@@ -130,6 +130,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/third_party/install_android.sh') }}
       - name: Install pip dependencies
         run: pip install numpy six --no-cache-dir
+      - name: Set Java version
+        run: echo "JAVA_HOME=${JAVA_HOME_8_X64}" >> $GITHUB_ENV
       - name: Download and install Android NDK/SDK
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh


### PR DESCRIPTION
## What do these changes do?
This PR sets the default version of JAVA to 8 in order to fix the [Android SDK install error we have seen in the last test release](https://github.com/larq/compute-engine/runs/6654428779?check_suite_focus=true).

## How Has This Been Tested?
I did a [test build](https://github.com/larq/compute-engine/actions/runs/2921184964) which passed.

This should enable us to make new 0.8 release.
