### PR TITLE
Increase minimal macOS version requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,8 +160,8 @@ jobs:
             echo -e 'build --google_default_credentials' >> .bazelrc.user
           fi
 
-          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.13 --linkopt=-mmacosx-version-min=10.13 --linkopt=-dead_strip --distinct_host_configuration=false
-          bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_13_x86_64
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.14 --linkopt=-mmacosx-version-min=10.14 --linkopt=-dead_strip --distinct_host_configuration=false
+          bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_14_x86_64
 
           for f in artifacts/*.whl; do
             delocate-wheel -w wheelhouse $f


### PR DESCRIPTION
This PR increases the minimal macOS version requirement to 10.14.
This should fix the following error that I am seeing in our test build:
```
error: aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on macOS 10.14 or newer
```

Judging from the pip wheel names TensorFlow is doing the same since 2.8.