### PR TITLE
Suppress C++ compiler warnings

### DIFF
--- a/.tensorflow.bazelrc
+++ b/.tensorflow.bazelrc
@@ -76,6 +76,15 @@ build:dynamic_kernels --copt=-DAUTOLOAD_DYNAMIC_KERNELS
 # Don't trigger --config=<host platform> when cross-compiling.
 build:android --noenable_platform_specific_config
 
+# Suppress C++ compiler warnings, otherwise build logs become 10s of MBs.
+build:android --copt=-w
+build:ios --copt=-w
+build:linux --copt=-w
+build:linux --host_copt=-w
+build:macos --copt=-w
+build:windows --copt=/W0
+build:windows --host_copt=/W0
+
 # Tensorflow uses M_* math constants that only get defined by MSVC headers if
 # _USE_MATH_DEFINES is defined.
 build:windows --copt=/D_USE_MATH_DEFINES


### PR DESCRIPTION
## What do these changes do?
This PR suppresses C++ warnings since our build since the CI build logs are getting really long. This is copied directly from the [TensorFlow bazel config](https://github.com/tensorflow/tensorflow/blob/e6177657b966d4a0d7c9dcff0e87789bfc968da8/.bazelrc#L295-L301). Not sure whether this ignores any important warnings, but to be honest the logs are so messy that it is almost impossible to see something in there anyway.

## How Has This Been Tested?
I tested this with a full converter build and it reduces the logged lines in GitHub actions from 19373 to 339.