### PR TITLE
Fix Windows pip build

### DIFF
--- a/.tensorflow.bazelrc
+++ b/.tensorflow.bazelrc
@@ -76,6 +76,11 @@ build:dynamic_kernels --copt=-DAUTOLOAD_DYNAMIC_KERNELS
 # Don't trigger --config=<host platform> when cross-compiling.
 build:android --noenable_platform_specific_config
 
+# On Windows, `__cplusplus` is wrongly defined without this switch
+# See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+build:windows --copt=/Zc:__cplusplus
+build:windows --host_copt=/Zc:__cplusplus
+
 # Tensorflow uses M_* math constants that only get defined by MSVC headers if
 # _USE_MATH_DEFINES is defined.
 build:windows --copt=/D_USE_MATH_DEFINES


### PR DESCRIPTION
## What do these changes do?
This PR adds some [missing bazel configs](https://github.com/tensorflow/tensorflow/blob/e6177657b966d4a0d7c9dcff0e87789bfc968da8/.bazelrc#L315-L318) which fix the following build errors on Windows:
```
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): error C2893: Failed to specialize function template 'unknown-type std::begin(_Container &)'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\xutility(1844): note: see declaration of 'std::begin'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): note: With the following template arguments:
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): note: '_Container=int'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): error C2784: 'const _Elem *std::begin(std::initializer_list<_Elem>) noexcept': could not deduce template argument for 'std::initializer_list<_Elem>' from 'int'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\initializer_list(55): note: see declaration of 'std::begin'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): error C2893: Failed to specialize function template 'unknown-type std::begin(_Container &)'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\xutility(1844): note: see declaration of 'std::begin'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): note: With the following template arguments:
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(56): note: '_Container=int'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1955): error C2955: 'std::iterator_traits': use of class template requires template argument list
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\xutility(1189): note: see declaration of 'std::iterator_traits'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1955): error C2039: 'reference': is not a member of 'std::iterator_traits<_Iter>'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1955): error C2061: syntax error: identifier 'reference'
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1972): error C3646: 'value': unknown override specifier
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1972): error C2059: syntax error: '('
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1972): error C2334: unexpected token(s) preceding '{'; skipping apparent function body
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(230): error C2039: 'value': is not a member of 'llvm::detail::result_pair<R>'
        with
        [
            R=int &
        ]
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1982): note: see declaration of 'llvm::detail::result_pair<R>'
        with
        [
            R=int &
        ]
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(230): error C2530: 'sharding_attr': references must be initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(236): error C3536: 'sharding_attr': cannot be used before it is initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(236): error C2059: syntax error: ')'
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(312): error C2672: 'mlir::Operation::getAttrOfType': no matching overloaded function found
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(313): error C2440: 'initializing': cannot convert from 'const absl::lts_20220623::string_view' to 'mlir::StringAttr'
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(313): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(311): error C2737: 'output_sharding_attrs': const object must be initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(314): error C3536: 'output_sharding_attrs': cannot be used before it is initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(323): error C2039: 'value': is not a member of 'llvm::detail::result_pair<R>'
        with
        [
            R=int &
        ]
external/llvm-project/llvm/include\llvm/ADT/STLExtras.h(1982): note: see declaration of 'llvm::detail::result_pair<R>'
        with
        [
            R=int &
        ]
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(323): error C2530: 'output_sharding': references must be initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(325): error C3536: 'output_sharding': cannot be used before it is initialized
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(325): error C2059: syntax error: ')'
external/org_tensorflow/tensorflow/compiler/mlir/tensorflow/utils/xla_sharding_util.cc(331): error C2059: syntax error: ')'
Target //:build_pip_pkg failed to build
```

## How Has This Been Tested?
Our internal converter build was built with this fix.