### PR TITLE
[CI] Use concurrency setting instead of cancel action

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   TFLite:
     runs-on: ubuntu-latest
@@ -60,10 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci-skip')"
     steps:
-      - name: Cancel Outdated Runs
-        uses: styfle/cancel-workflow-action@0.10.1
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v1
         continue-on-error: true


### PR DESCRIPTION
This PR switches to the [builtin concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) setting instead of using the third party `cancel-workflow-action` action.

Closes #758