### PR TITLE
:arrow_up: 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") e
 
 setup(
     name="larq-compute-engine",
-    version=get_version_number(default="0.8.0"),
+    version=get_version_number(default="0.11.0"),
     python_requires=">=3.7",
     description="Highly optimized inference engine for binarized neural networks.",
     long_description=readme(),


### PR DESCRIPTION
This prepares a new release.

Note that the previous release was 0.8.0, but this one will be named 0.11.0 instead of 0.9.0 to match the '11' in the TensorFlow version: 2.11. Future releases of the larq-compute-engine will also follow this scheme, such that it becomes easy to match a larq-compute-engine version with a TensorFlow version that it is based on.