### PR TITLE
Replace `-mmacosx-version-min` with `MACOSX_DEPLOYMENT_TARGET` env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,13 +154,14 @@ jobs:
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
           ./configure.py
+          export MACOSX_DEPLOYMENT_TARGET=10.14
 
           if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
             echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-macos-python${{ matrix.python-version }}' >> .bazelrc.user
             echo -e 'build --google_default_credentials' >> .bazelrc.user
           fi
 
-          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --copt=-mmacosx-version-min=10.14 --linkopt=-mmacosx-version-min=10.14 --linkopt=-dead_strip --distinct_host_configuration=false
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mavx --linkopt=-dead_strip --distinct_host_configuration=false
           bazel-bin/build_pip_pkg artifacts --plat-name macosx_10_14_x86_64
 
           for f in artifacts/*.whl; do
@@ -196,13 +197,14 @@ jobs:
           python -m pip install delocate wheel setuptools numpy six --no-cache-dir
 
           ./configure.py
+          export MACOSX_DEPLOYMENT_TARGET=11.0
 
           if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
             echo -e 'build --remote_http_cache=https://storage.googleapis.com/plumerai-bazel-cache/lce-release-macos-arm-python${{ matrix.python-version }}' >> .bazelrc.user
             echo -e 'build --google_default_credentials' >> .bazelrc.user
           fi
 
-          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --copt=-mmacosx-version-min=11.0 --linkopt=-mmacosx-version-min=11.0 --linkopt=-dead_strip --config=macos_arm64
+          bazelisk build :build_pip_pkg --copt=-fvisibility=hidden --linkopt=-dead_strip --config=macos_arm64
           bazel-bin/build_pip_pkg artifacts --plat-name macosx_11_0_arm64
 
           for f in artifacts/*.whl; do


### PR DESCRIPTION
## What do these changes do?
This PR fixed the macOS release build by replacing the `-mmacosx-version-min` option with a `MACOSX_DEPLOYMENT_TARGET` environment variable.

## How Has This Been Tested?
https://github.com/larq/compute-engine/actions/runs/3941200959
