### PR TITLE
Remove anonymous namespaces in MLIR transforms

### DIFF
--- a/larq_compute_engine/mlir/BUILD
+++ b/larq_compute_engine/mlir/BUILD
@@ -287,6 +287,7 @@ cc_library(
 cc_library(
     name = "larq_compute_engine_prepare",
     srcs = [
+        "transforms/common.h",
         "transforms/generated_prepare_target_arm.inc",
         "transforms/generated_prepare_target_other.inc",
         "transforms/prepare_tf.cc",
@@ -310,6 +311,7 @@ cc_library(
 cc_library(
     name = "larq_compute_engine_optimize",
     srcs = [
+        "transforms/common.h",
         "transforms/generated_bitpack_activations.inc",
         "transforms/generated_optimize_target_arm.inc",
         "transforms/generated_optimize_target_other.inc",

--- a/larq_compute_engine/mlir/transforms/bitpack_weights.cc
+++ b/larq_compute_engine/mlir/transforms/bitpack_weights.cc
@@ -10,8 +10,6 @@
 namespace mlir {
 namespace TFL {
 
-namespace {
-
 struct BitpackWeightsLCE
     : public PassWrapper<BitpackWeightsLCE, OperationPass<mlir::func::FuncOp>> {
   llvm::StringRef getArgument() const final {
@@ -30,17 +28,17 @@ bool IsConv2DFilter(TypedAttr filter) {
          filter_type.getShape().size() == 4;
 }
 
+namespace bitpackweights {
 #include "larq_compute_engine/mlir/transforms/generated_bitpack_weights.inc"
+}  // namespace bitpackweights
 
 void BitpackWeightsLCE::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   auto func = getOperation();
 
-  TFL::populateWithGenerated(patterns);
+  bitpackweights::populateWithGenerated(patterns);
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 }
-
-}  // namespace
 
 // Creates an instance of the TensorFlow dialect BitpackWeights pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>>

--- a/larq_compute_engine/mlir/transforms/common.h
+++ b/larq_compute_engine/mlir/transforms/common.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir {
+namespace TFL {
+
+inline bool IsConstantValue(Attribute values, float expected_value) {
+  if (!values.isa<DenseElementsAttr>()) return false;
+
+  for (auto value : values.cast<DenseElementsAttr>().getValues<float>()) {
+    if (value != expected_value) return false;
+  }
+  return true;
+}
+
+}  // namespace TFL
+}  // namespace mlir

--- a/larq_compute_engine/mlir/transforms/legalize_tflite.cc
+++ b/larq_compute_engine/mlir/transforms/legalize_tflite.cc
@@ -7,8 +7,6 @@
 namespace mlir {
 namespace TFL {
 
-namespace {
-
 struct LegalizeLCE
     : public PassWrapper<LegalizeLCE, OperationPass<mlir::func::FuncOp>> {
   llvm::StringRef getArgument() const final { return "tfl-legalize-lce"; }
@@ -54,8 +52,6 @@ void LegalizeLCE::runOnOperation() {
 
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 }
-
-}  // namespace
 
 // Creates an instance of the LegalizeLCE pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>> CreateLegalizeLCEPass() {

--- a/larq_compute_engine/mlir/transforms/op_removal.cc
+++ b/larq_compute_engine/mlir/transforms/op_removal.cc
@@ -8,8 +8,6 @@
 namespace mlir {
 namespace TFL {
 
-namespace {
-
 // Op removal of pass through ops to make following patterns easier and enable
 // early constant folding
 struct OpRemoval
@@ -21,17 +19,17 @@ struct OpRemoval
   void runOnOperation() override;
 };
 
+namespace op_removal {
 #include "larq_compute_engine/mlir/transforms/generated_op_removal.inc"
+}  // namespace op_removal
 
 void OpRemoval::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   auto func = getOperation();
 
-  TFL::populateWithGenerated(patterns);
+  op_removal::populateWithGenerated(patterns);
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 }
-
-}  // namespace
 
 // Creates an instance of the TensorFlow dialect OpRemoval pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>> CreateOpRemovalPass() {

--- a/larq_compute_engine/mlir/transforms/quantize.cc
+++ b/larq_compute_engine/mlir/transforms/quantize.cc
@@ -12,8 +12,6 @@ namespace TFL {
 //===----------------------------------------------------------------------===//
 // The actual Quantize Pass.
 //
-namespace {
-
 // Applies quantization on the model in TFL dialect.
 struct LCEQuantizePass
     : public PassWrapper<LCEQuantizePass, OperationPass<mlir::func::FuncOp>> {
@@ -24,15 +22,16 @@ struct LCEQuantizePass
   void runOnOperation() override;
 };
 
+namespace lce_quantize {
 #include "larq_compute_engine/mlir/transforms/generated_quantize.inc"
+}
 
 void LCEQuantizePass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   auto func = getOperation();
-  TFL::populateWithGenerated(patterns);
+  lce_quantize::populateWithGenerated(patterns);
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 }
-}  // namespace
 
 // Creates an instance of the TensorFlow Lite dialect QuantizeTFL pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>> CreateLCEQuantizePass() {

--- a/larq_compute_engine/mlir/transforms/set_batch_size.cc
+++ b/larq_compute_engine/mlir/transforms/set_batch_size.cc
@@ -6,8 +6,6 @@
 
 namespace mlir {
 
-namespace {
-
 mlir::Type SetBatchSize(mlir::Type type) {
   auto tensor_type = type.dyn_cast<mlir::TensorType>();
   if (tensor_type && tensor_type.hasRank()) {
@@ -58,8 +56,6 @@ struct SetBatchSizePass
     }
   }
 };
-
-}  // namespace
 
 // Creates an instance of the ZeroPointCompatibility pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>> CreateSetBatchSizePass() {

--- a/larq_compute_engine/mlir/transforms/translate_tflite.cc
+++ b/larq_compute_engine/mlir/transforms/translate_tflite.cc
@@ -22,8 +22,6 @@ static llvm::StringRef ConvertPaddingAttr(tflite::Padding padding_type) {
 namespace mlir {
 namespace TFL {
 
-namespace {
-
 struct TranslateToLCE
     : public PassWrapper<TranslateToLCE, OperationPass<mlir::func::FuncOp>> {
   llvm::StringRef getArgument() const final { return "lce-translate-tfl"; }
@@ -89,8 +87,6 @@ void TranslateToLCE::runOnOperation() {
   patterns.add<TranslateToLCEPattern>(ctx);
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 }
-
-}  // namespace
 
 // Creates an instance of the TranslateToLCE pass.
 std::unique_ptr<OperationPass<mlir::func::FuncOp>> CreateTranslateToLCEPass() {


### PR DESCRIPTION
## What do these changes do?
This fixes the following type of runtime errors when the converter is built with clang.
```
LLVM ERROR: TypeID::get<mlir::TFL::(anonymous namespace)::FusePadding>(): Using TypeID on a class with an anonymous namespace requires an explicit TypeID definition. The implicit fallback uses string name, which does not guarantee uniqueness in anonymous contexts. Define an explicit TypeID instantiation for this type using `MLIR_DECLARE_EXPLICIT_TYPE_ID`/`MLIR_DEFINE_EXPLICIT_TYPE_ID` or `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID`.
```
