### PR TITLE
Fix trailing slash in path in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ option(COMPILE_EXAMPLE "Enable compilation of the minimal example" ON)
 option(COMPILE_BENCHMARK "Enable compilation of the benchmarking utility" ON)
 
 # TensorFlow dependency, see https://www.tensorflow.org/lite/guide/build_cmake
-set(TENSORFLOW_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/third_party/tensorflow/")
+set(TENSORFLOW_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/third_party/tensorflow")
 set(TFLITE_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite")
 add_subdirectory("${TFLITE_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
## What do these changes do?
This fixes an issue raised in https://github.com/larq/compute-engine/discussions/779

## How Has This Been Tested?
On my system it already worked, and it still does.