### PR TITLE
:arrow_up: 0.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") e
 
 setup(
     name="larq-compute-engine",
-    version=get_version_number(default="0.11.1"),
+    version=get_version_number(default="0.13.0"),
     python_requires=">=3.9",
     description="Highly optimized inference engine for binarized neural networks.",
     long_description=readme(),


### PR DESCRIPTION
Bump to 0.13.0 (not 0.12.0 to reflect the fact that it is based on TF 2.13, not 2.12).

Changelog will be in the release notes.
