### PR TITLE
Upgrade Android NDK version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
       - name: Configure Bazel
-        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600" ./configure.py
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/21.4.7075529" ./configure.py
         shell: bash
       - run: mkdir benchmark-binaries
       - name: Build Benchmark utility for AArch64
@@ -108,7 +108,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
       - name: Configure Bazel
-        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600" ./configure.py
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/21.4.7075529" ./configure.py
         shell: bash
       - name: Build LCE AAR
         run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -150,7 +150,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./third_party/install_android.sh
       - name: Configure Bazel
-        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600" ./configure.py
+        run: LCE_SET_ANDROID_WORKSPACE=1 ANDROID_SDK_HOME="/tmp/lce_android" ANDROID_NDK_HOME="/tmp/lce_android/ndk/21.4.7075529" ./configure.py
         shell: bash
       - name: Build LCE AAR
         run: BUILDER=bazelisk ./larq_compute_engine/tflite/java/build_lce_aar.sh

--- a/configure.py
+++ b/configure.py
@@ -586,7 +586,7 @@ def get_ndk_api_level(environ_cp, android_ndk_home_path):
     android_ndk_api_level = prompt_loop_or_load_from_env(
         environ_cp,
         var_name="ANDROID_NDK_API_LEVEL",
-        var_default="21",  # 21 is required for ARM64 support.
+        var_default='26',  # 26 is required to support AHardwareBuffer.
         ask_for_var=(
             "Please specify the (min) Android NDK API level to use. "
             "[Available levels: %s]"

--- a/third_party/install_android.sh
+++ b/third_party/install_android.sh
@@ -9,7 +9,7 @@ export ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux
 export ANDROID_HOME="/tmp/lce_android"
 export ANDROID_VERSION=29
 export ANDROID_BUILD_TOOLS_VERSION=30.0.2
-export ANDROID_NDK_VERSION=19.2.5345600
+export ANDROID_NDK_VERSION=21.4.7075529
 
 # download android SDK
 mkdir -p $ANDROID_HOME; cd $ANDROID_HOME;


### PR DESCRIPTION
## What do these changes do?
This upgrades the Android NDK version and API level to fix the Android benchmarker build

## How Has This Been Tested?
A CI release build ran successfully [here](https://github.com/larq/compute-engine/actions/runs/5808095569)

## Related issue number
Fixes #788 
