### PR TITLE
Use command parameter files when compiling on Windows

### DIFF
--- a/.tensorflow.bazelrc
+++ b/.tensorflow.bazelrc
@@ -86,6 +86,10 @@ build:windows --host_copt=/Zc:__cplusplus
 build:windows --copt=/D_USE_MATH_DEFINES
 build:windows --host_copt=/D_USE_MATH_DEFINES
 
+# Windows has a relatively short command line limit, which TF has begun to hit.
+# See https://docs.bazel.build/versions/main/windows.html
+build:windows --features=compiler_param_file
+
 # By default, build LCE in C++ 17 mode.
 build:android --cxxopt=-std=c++17
 build:android --host_cxxopt=-std=c++17


### PR DESCRIPTION
Hopefully this fixed our Windows release builds. TensorFlow has the [same setting enabled](https://github.com/tensorflow/tensorflow/commit/2ff9f49e5a00af7d1afe05a3f7915e3d067b6126).

A test release is currently running [here](https://github.com/larq/compute-engine/actions/runs/5812935736).
