### PR TITLE
:arrow_up: 0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ ext_modules = [Extension("_foo", ["stub.cc"])] if platform.startswith("linux") e
 
 setup(
     name="larq-compute-engine",
-    version=get_version_number(default="0.13.0"),
+    version=get_version_number(default="0.16.0"),
     python_requires=">=3.10",
     description="Highly optimized inference engine for binarized neural networks.",
     long_description=readme(),


### PR DESCRIPTION
Bump to 0.16.0 (not 0.14.0 to reflect the fact that it is based on TF 2.16, not 2.14).