### PR TITLE
Add a conservative RISC-V build path for TensorFlow Lite dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,20 @@ option(COMPILE_EXAMPLE "Enable compilation of the minimal example" ON)
 option(COMPILE_BENCHMARK "Enable compilation of the benchmarking utility" ON)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LCE_SYSTEM_PROCESSOR_LOWER)
+set(LCE_RISCV_LINUX_WITHOUT_HWPROBE FALSE)
 if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     check_include_file("sys/hwprobe.h" LCE_HAS_SYS_HWPROBE_H)
+    if(NOT LCE_HAS_SYS_HWPROBE_H)
+        set(LCE_RISCV_LINUX_WITHOUT_HWPROBE TRUE)
+    endif()
 endif()
 
-if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT LCE_HAS_SYS_HWPROBE_H)
+if(LCE_RISCV_LINUX_WITHOUT_HWPROBE)
     message(STATUS "RISC-V Linux target without sys/hwprobe.h detected; using the portable fallback and disabling XNNPACK")
     set(TFLITE_ENABLE_XNNPACK OFF CACHE BOOL "Disable XNNPACK when RISC-V cpuinfo hwprobe headers are unavailable" FORCE)
-    # TensorFlow Lite's bundled ruy falls back to fixed cache parameters when
-    # cpuinfo initialization fails. Provide a conservative shim so the build
-    # does not depend on Linux riscv hwprobe headers.
+    # TensorFlow Lite still requires a cpuinfo target even when XNNPACK is off.
+    # Provide a conservative shim so ruy can fall back to fixed cache values
+    # instead of depending on Linux RISC-V hwprobe headers during configuration.
     if(NOT TARGET cpuinfo)
         add_library(cpuinfo STATIC cmake/riscv_cpuinfo_shim/cpuinfo.c)
         target_include_directories(cpuinfo PUBLIC ${CMAKE_CURRENT_LIST_DIR}/cmake/riscv_cpuinfo_shim)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,18 @@ option(COMPILE_BENCHMARK "Enable compilation of the benchmarking utility" ON)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LCE_SYSTEM_PROCESSOR_LOWER)
 if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv")
-    message(STATUS "RISC-V target detected; using portable C++ bitpacking/BGEMM kernels")
+    message(STATUS "RISC-V target detected; using portable C++ kernels and disabling host CPU feature backends")
+    set(TFLITE_ENABLE_XNNPACK OFF CACHE BOOL "Disable XNNPACK on RISC-V" FORCE)
+    # TensorFlow Lite's bundled ruy falls back to fixed cache parameters when
+    # cpuinfo initialization fails. Provide a conservative shim so the build
+    # does not depend on Linux riscv hwprobe headers.
+    if(NOT TARGET cpuinfo)
+        add_library(cpuinfo STATIC cmake/riscv_cpuinfo_shim/cpuinfo.c)
+        target_include_directories(cpuinfo PUBLIC ${CMAKE_CURRENT_LIST_DIR}/cmake/riscv_cpuinfo_shim)
+    endif()
+    if(NOT TARGET cpuinfo::cpuinfo)
+        add_library(cpuinfo::cpuinfo ALIAS cpuinfo)
+    endif()
 endif()
 
 # TensorFlow dependency, see https://www.tensorflow.org/lite/guide/build_cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(larq_compute_engine C CXX)
 option(COMPILE_EXAMPLE "Enable compilation of the minimal example" ON)
 option(COMPILE_BENCHMARK "Enable compilation of the benchmarking utility" ON)
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LCE_SYSTEM_PROCESSOR_LOWER)
+if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv")
+    message(STATUS "RISC-V target detected; using portable C++ bitpacking/BGEMM kernels")
+endif()
+
 # TensorFlow dependency, see https://www.tensorflow.org/lite/guide/build_cmake
 set(TENSORFLOW_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/third_party/tensorflow")
 set(TFLITE_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,6 @@ if(LCE_RISCV_LINUX_WITHOUT_HWPROBE)
     if(NOT TARGET cpuinfo::cpuinfo)
         add_library(cpuinfo::cpuinfo ALIAS cpuinfo)
     endif()
-elseif(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(STATUS "RISC-V Linux target with sys/hwprobe.h detected; keeping upstream cpuinfo and XNNPACK configuration")
 endif()
 
 # TensorFlow dependency, see https://www.tensorflow.org/lite/guide/build_cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 3.16)
 project(larq_compute_engine C CXX)
 
+include(CheckIncludeFile)
+
 # Options and their default values
 option(COMPILE_EXAMPLE "Enable compilation of the minimal example" ON)
 option(COMPILE_BENCHMARK "Enable compilation of the benchmarking utility" ON)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LCE_SYSTEM_PROCESSOR_LOWER)
-if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv")
-    message(STATUS "RISC-V target detected; using portable C++ kernels and disabling host CPU feature backends")
-    set(TFLITE_ENABLE_XNNPACK OFF CACHE BOOL "Disable XNNPACK on RISC-V" FORCE)
+if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    check_include_file("sys/hwprobe.h" LCE_HAS_SYS_HWPROBE_H)
+endif()
+
+if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT LCE_HAS_SYS_HWPROBE_H)
+    message(STATUS "RISC-V Linux target without sys/hwprobe.h detected; using the portable fallback and disabling XNNPACK")
+    set(TFLITE_ENABLE_XNNPACK OFF CACHE BOOL "Disable XNNPACK when RISC-V cpuinfo hwprobe headers are unavailable" FORCE)
     # TensorFlow Lite's bundled ruy falls back to fixed cache parameters when
     # cpuinfo initialization fails. Provide a conservative shim so the build
     # does not depend on Linux riscv hwprobe headers.
@@ -19,6 +25,8 @@ if(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv")
     if(NOT TARGET cpuinfo::cpuinfo)
         add_library(cpuinfo::cpuinfo ALIAS cpuinfo)
     endif()
+elseif(LCE_SYSTEM_PROCESSOR_LOWER MATCHES "^riscv" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(STATUS "RISC-V Linux target with sys/hwprobe.h detected; keeping upstream cpuinfo and XNNPACK configuration")
 endif()
 
 # TensorFlow dependency, see https://www.tensorflow.org/lite/guide/build_cmake

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 Larq Compute Engine (LCE) is a highly optimized inference engine for deploying
 extremely quantized neural networks, such as
 Binarized Neural Networks (BNNs). It currently supports various mobile platforms
-and has been benchmarked on a Pixel 1 phone and a Raspberry Pi. On non-ARM
-targets, including `riscv64`, LCE falls back to portable C++ kernels instead of
-the hand-optimized AArch64 paths.
+and has been benchmarked on a Pixel 1 phone and a Raspberry Pi.
 LCE provides a collection of hand-optimized [TensorFlow Lite](https://www.tensorflow.org/lite)
 custom operators for supported instruction sets, developed in inline assembly or in C++
 using compiler intrinsics. LCE leverages optimization techniques
@@ -32,15 +30,13 @@ advantage of multi-core modern desktop and mobile CPUs.
       is fully compatible with TensorFlow Lite and performs additional
       network level optimizations for Larq models.
 
-- **Lightning fast deployment** on a variety of target platforms:
+- **Lightning fast deployment** on a variety of mobile platforms:
 
     - LCE enables high performance, on-device machine learning inference by
       providing hand-optimized kernels and network level optimizations for BNN models.
 
     - LCE currently supports 64-bit ARM-based mobile platforms such as Android phones
-      and Raspberry Pi boards. On other targets, including `riscv64`, the
-      portable C++ bitpacking, BGEMM, and indirect-BGEMM kernels remain
-      available as a conservative fallback path.
+      and Raspberry Pi boards.
 
     - Thread parallelism support in LCE is essential for modern mobile devices with
       multi-core CPUs.
@@ -91,7 +87,7 @@ Follow these steps to deploy a BNN with LCE:
 
 3. **Build LCE**
 
-    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. On `riscv64`, LCE currently uses the same portable C++ kernels that are already used as the generic fallback on non-AArch64 targets. If a RISC-V Linux target lacks `sys/hwprobe.h` for TensorFlow Lite's bundled `cpuinfo`, the build falls back to a conservative non-XNNPACK configuration instead of claiming a dedicated RISC-V vector or assembly backend.
+    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. Please follow the provided instructions to create a native LCE build or cross-compile for one of the supported targets.
 
 4. **Run inference**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 Larq Compute Engine (LCE) is a highly optimized inference engine for deploying
 extremely quantized neural networks, such as
 Binarized Neural Networks (BNNs). It currently supports various mobile platforms
-and has been benchmarked on a Pixel 1 phone and a Raspberry Pi.
+and has been benchmarked on a Pixel 1 phone and a Raspberry Pi. On non-ARM
+targets, including `riscv64`, LCE falls back to portable C++ kernels instead of
+the hand-optimized AArch64 paths.
 LCE provides a collection of hand-optimized [TensorFlow Lite](https://www.tensorflow.org/lite)
 custom operators for supported instruction sets, developed in inline assembly or in C++
 using compiler intrinsics. LCE leverages optimization techniques
@@ -30,13 +32,15 @@ advantage of multi-core modern desktop and mobile CPUs.
       is fully compatible with TensorFlow Lite and performs additional
       network level optimizations for Larq models.
 
-- **Lightning fast deployment** on a variety of mobile platforms:
+- **Lightning fast deployment** on a variety of target platforms:
 
     - LCE enables high performance, on-device machine learning inference by
       providing hand-optimized kernels and network level optimizations for BNN models.
 
     - LCE currently supports 64-bit ARM-based mobile platforms such as Android phones
-      and Raspberry Pi boards.
+      and Raspberry Pi boards. On other targets, including `riscv64`, the
+      portable C++ bitpacking, BGEMM, and indirect-BGEMM kernels remain
+      available as a conservative fallback path.
 
     - Thread parallelism support in LCE is essential for modern mobile devices with
       multi-core CPUs.
@@ -87,7 +91,7 @@ Follow these steps to deploy a BNN with LCE:
 
 3. **Build LCE**
 
-    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. Please follow the provided instructions to create a native LCE build or cross-compile for one of the supported targets.
+    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. On `riscv64`, LCE currently uses the same portable C++ kernels that are already used as the generic fallback on non-AArch64 targets; no dedicated RISC-V vector or assembly backend is claimed here.
 
 4. **Run inference**
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Follow these steps to deploy a BNN with LCE:
 
 3. **Build LCE**
 
-    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. On `riscv64`, LCE currently uses the same portable C++ kernels that are already used as the generic fallback on non-AArch64 targets; no dedicated RISC-V vector or assembly backend is claimed here.
+    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [64-bit ARM-based boards](https://docs.larq.dev/compute-engine/build/arm) such as Raspberry Pi. On `riscv64`, LCE currently uses the same portable C++ kernels that are already used as the generic fallback on non-AArch64 targets. If a RISC-V Linux target lacks `sys/hwprobe.h` for TensorFlow Lite's bundled `cpuinfo`, the build falls back to a conservative non-XNNPACK configuration instead of claiming a dedicated RISC-V vector or assembly backend.
 
 4. **Run inference**
 

--- a/cmake/riscv_cpuinfo_shim/cpuinfo.c
+++ b/cmake/riscv_cpuinfo_shim/cpuinfo.c
@@ -1,0 +1,38 @@
+#include "cpuinfo.h"
+
+static const struct cpuinfo_core kDummyCore = {0, 0};
+static const struct cpuinfo_processor kDummyProcessor = {
+    &kDummyCore,
+    {0, 0, 0},
+};
+static const struct cpuinfo_uarch_info kDummyUarch = {cpuinfo_uarch_unknown};
+
+bool cpuinfo_initialize(void) { return false; }
+
+void cpuinfo_deinitialize(void) {}
+
+uint32_t cpuinfo_get_processors_count(void) { return 0; }
+
+const struct cpuinfo_processor* cpuinfo_get_processor(uint32_t index) {
+  (void)index;
+  return &kDummyProcessor;
+}
+
+bool cpuinfo_has_arm_neon_dot(void) { return false; }
+bool cpuinfo_has_x86_sse4_2(void) { return false; }
+bool cpuinfo_has_x86_avx(void) { return false; }
+bool cpuinfo_has_x86_avx2(void) { return false; }
+bool cpuinfo_has_x86_fma3(void) { return false; }
+bool cpuinfo_has_x86_avx512f(void) { return false; }
+bool cpuinfo_has_x86_avx512dq(void) { return false; }
+bool cpuinfo_has_x86_avx512cd(void) { return false; }
+bool cpuinfo_has_x86_avx512bw(void) { return false; }
+bool cpuinfo_has_x86_avx512vl(void) { return false; }
+bool cpuinfo_has_x86_avx512vnni(void) { return false; }
+
+uint32_t cpuinfo_get_current_uarch_index(void) { return 0; }
+
+const struct cpuinfo_uarch_info* cpuinfo_get_uarch(uint32_t index) {
+  (void)index;
+  return &kDummyUarch;
+}

--- a/cmake/riscv_cpuinfo_shim/cpuinfo.h
+++ b/cmake/riscv_cpuinfo_shim/cpuinfo.h
@@ -1,0 +1,67 @@
+#ifndef LCE_RISCV_CPUINFO_SHIM_H_
+#define LCE_RISCV_CPUINFO_SHIM_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum cpuinfo_uarch {
+  cpuinfo_uarch_unknown = 0,
+  cpuinfo_uarch_cortex_a53 = 0x00300353,
+  cpuinfo_uarch_cortex_a55r0 = 0x00300354,
+  cpuinfo_uarch_cortex_a55 = 0x00300355,
+  cpuinfo_uarch_cortex_x1 = 0x003004C1
+};
+
+struct cpuinfo_core {
+  uint32_t processor_start;
+  uint32_t processor_count;
+};
+
+struct cpuinfo_cache {
+  uint32_t size;
+  uint32_t processor_start;
+  uint32_t processor_count;
+};
+
+struct cpuinfo_processor_cache {
+  const struct cpuinfo_cache* l1d;
+  const struct cpuinfo_cache* l2;
+  const struct cpuinfo_cache* l3;
+};
+
+struct cpuinfo_processor {
+  const struct cpuinfo_core* core;
+  struct cpuinfo_processor_cache cache;
+};
+
+struct cpuinfo_uarch_info {
+  enum cpuinfo_uarch uarch;
+};
+
+bool cpuinfo_initialize(void);
+void cpuinfo_deinitialize(void);
+uint32_t cpuinfo_get_processors_count(void);
+const struct cpuinfo_processor* cpuinfo_get_processor(uint32_t index);
+bool cpuinfo_has_arm_neon_dot(void);
+bool cpuinfo_has_x86_sse4_2(void);
+bool cpuinfo_has_x86_avx(void);
+bool cpuinfo_has_x86_avx2(void);
+bool cpuinfo_has_x86_fma3(void);
+bool cpuinfo_has_x86_avx512f(void);
+bool cpuinfo_has_x86_avx512dq(void);
+bool cpuinfo_has_x86_avx512cd(void);
+bool cpuinfo_has_x86_avx512bw(void);
+bool cpuinfo_has_x86_avx512vl(void);
+bool cpuinfo_has_x86_avx512vnni(void);
+uint32_t cpuinfo_get_current_uarch_index(void);
+const struct cpuinfo_uarch_info* cpuinfo_get_uarch(uint32_t index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cmake/riscv_cpuinfo_shim/cpuinfo.h
+++ b/cmake/riscv_cpuinfo_shim/cpuinfo.h
@@ -10,10 +10,6 @@ extern "C" {
 
 enum cpuinfo_uarch {
   cpuinfo_uarch_unknown = 0,
-  cpuinfo_uarch_cortex_a53 = 0x00300353,
-  cpuinfo_uarch_cortex_a55r0 = 0x00300354,
-  cpuinfo_uarch_cortex_a55 = 0x00300355,
-  cpuinfo_uarch_cortex_x1 = 0x003004C1
 };
 
 struct cpuinfo_core {


### PR DESCRIPTION
## Why

Larq Compute Engine already has portable bitpacking, BGEMM, and indirect-BGEMM paths for non-AArch64 targets, but its bundled TensorFlow Lite dependency chain is not conservative enough for a `riscv64` Linux target that lacks `sys/hwprobe.h`.

In a fresh `dockcross/linux-riscv64` cross-build, third-party `cpuinfo` still tried to compile its RISC-V Linux `hwprobe` source and failed before the portable kernels could be used. The goal of this patch is not to disable acceleration for all RISC-V systems, but to provide a conservative fallback only when that target header is unavailable while preserving the upstream accelerated path on RISC-V systems that do provide it.

## What changed

- Updated `CMakeLists.txt` so `riscv*` Linux targets first probe for `sys/hwprobe.h`.
- Only when that header is unavailable, disable `TFLITE_ENABLE_XNNPACK` and expose a small `cmake/riscv_cpuinfo_shim/` library as `cpuinfo::cpuinfo`.
- The shim intentionally returns `cpuinfo_initialize() == false`, which lets TensorFlow Lite's bundled `ruy` fall back to its existing fixed-cache conservative path instead of depending on Linux `hwprobe` headers.
- If `sys/hwprobe.h` is available, the upstream `cpuinfo` / XNNPACK path is left unchanged.
- Kept the change scoped to build-system plumbing only. This patch does not claim RVV support, custom RISC-V intrinsics, or any new assembly backend.

## Verification

- Real `riscv64` cross-build completed successfully in `dockcross/linux-riscv64` with:
  - `cmake -S /work -B /tmp/build -G Ninja -DCOMPILE_BENCHMARK=OFF`
  - `cmake --build /tmp/build --parallel 4`
- `CMakeCache.txt` from that real build records:
  - `TFLITE_ENABLE_XNNPACK:BOOL=OFF`
  - `RUY_FIND_CPUINFO:BOOL=OFF`
- `build.ninja` shows:
  - `cmake/riscv_cpuinfo_shim/cpuinfo.c` compiled into `libcpuinfo.a`
  - no `src/riscv/linux/riscv-hw.c`
  - TensorFlow Lite objects built with `-DTFLITE_WITHOUT_XNNPACK`
- `file` and `readelf -h` confirm the produced `example` binary is a real RISC-V ELF executable.
- `qemu-riscv64 -L ... -E LD_LIBRARY_PATH=/lib:/usr/lib ./example` starts successfully and prints:
  - `lce_minimal <tflite model>`
- A lightweight CMake probe confirmed the new condition behaves as intended:
  - without `sys/hwprobe.h`, the RISC-V fallback path is selected;
  - with a provided `sys/hwprobe.h`, the fallback path is not selected.

## Notes

- This patch is intentionally conservative. It keeps RISC-V on the existing portable kernels only when the bundled dependency chain cannot build its RISC-V Linux `hwprobe` support.
- The `cpuinfo` shim is only used on `riscv*` Linux targets that do not provide `sys/hwprobe.h`, and its behavior is deliberately minimal: fail feature detection cleanly so bundled `ruy` can use its already-existing fallback path.
- I am still treating this as a basic portability patch, not as a performance-optimized RISC-V backend.
